### PR TITLE
RTR support

### DIFF
--- a/lib/bgpstream.h
+++ b/lib/bgpstream.h
@@ -146,12 +146,34 @@ typedef struct struct_bgpstream_data_interface_option
 
 } bgpstream_data_interface_option_t;
 
+struct rtr_mgr_config* cfg_tr;
+
+struct rtr_server_configure {
+  char *host;
+  char *port;
+  bool active;
+} rtr_server_conf;
+
 /** @} */
 
 /**
  * @name Public API Functions
  *
  * @{ */
+
+/** Get the configuration of the RTR-Socket-Manager
+ *
+ * @return a pointer to the configuration of the rtr-socket-manager
+ */
+struct rtr_mgr_config *bgpstream_get_rtr_config();
+
+ /** Set the configuration of the RTR-Socket-Manager
+ *
+ * @param host    the host of the cache server
+ * @param port    the port of the cache server
+ * @param active  whether the rtr-validation is enabled
+ */
+int bgpstream_set_rtr_config(char *host, char *port, bool active);
 
 /** Create a new BGP Stream instance
  *

--- a/lib/bgpstream_elem.c
+++ b/lib/bgpstream_elem.c
@@ -320,9 +320,9 @@ char *bgpstream_elem_custom_snprintf(char *buf, size_t len,
       ADD_PIPE;
 
       /* ORIGIN AS */
-      if((seg = bgpstream_as_path_get_origin_seg(elem->aspath)) != NULL)
+      if(elem->origin_asnumber != 0)
         {
-          c = bgpstream_as_path_seg_snprintf(buf_p, B_REMAIN, seg);
+          c = snprintf(buf_p, B_REMAIN, "%"PRIu32, elem->origin_asnumber);
           written += c;
           buf_p += c;
         }

--- a/lib/bgpstream_elem.c
+++ b/lib/bgpstream_elem.c
@@ -320,9 +320,9 @@ char *bgpstream_elem_custom_snprintf(char *buf, size_t len,
       ADD_PIPE;
 
       /* ORIGIN AS */
-      if(elem->origin_asnumber != 0)
+      if(seg = bgpstream_as_path_get_origin_seg(elem->aspath)) != NULL)
         {
-          c = snprintf(buf_p, B_REMAIN, "%"PRIu32, elem->origin_asnumber);
+          c = bgpstream_as_path_seg_snprintf(buf_p, B_REMAIN, seg);
           written += c;
           buf_p += c;
         }

--- a/lib/bgpstream_elem.c
+++ b/lib/bgpstream_elem.c
@@ -320,9 +320,9 @@ char *bgpstream_elem_custom_snprintf(char *buf, size_t len,
       ADD_PIPE;
 
       /* ORIGIN AS */
-      if(seg = bgpstream_as_path_get_origin_seg(elem->aspath)) != NULL)
+      if(elem->origin_asnumber != 0)
         {
-          c = bgpstream_as_path_seg_snprintf(buf_p, B_REMAIN, seg);
+          c = snprintf(buf_p, B_REMAIN, "%"PRIu32, elem->origin_asnumber);
           written += c;
           buf_p += c;
         }

--- a/lib/bgpstream_elem.h
+++ b/lib/bgpstream_elem.h
@@ -128,6 +128,9 @@ typedef struct struct_bgpstream_elem_t {
   /** Peer AS number */
   uint32_t peer_asnumber;
 
+  /** Origin AS number */
+  uint32_t origin_asnumber;
+
   /* Type-dependent fields */
 
   /** IP prefix

--- a/lib/bgpstream_elem.h
+++ b/lib/bgpstream_elem.h
@@ -128,9 +128,6 @@ typedef struct struct_bgpstream_elem_t {
   /** Peer AS number */
   uint32_t peer_asnumber;
 
-  /** Origin AS number */
-  uint32_t origin_asnumber;
-
   /* Type-dependent fields */
 
   /** IP prefix
@@ -168,18 +165,6 @@ typedef struct struct_bgpstream_elem_t {
    * Available only for the Peer-state elem type
    */
   bgpstream_elem_peerstate_t new_state;
-
-  /** Validation status
-   *
-   * Validation_status for the given prefix
-   */
-  char *validation_status;
-
-  /** Valid ASNs
-   *
-   * Valid ASNs for the given prefix, max: 16 entries
-   */
-  uint32_t valid_asn[16];
 
 } bgpstream_elem_t;
 

--- a/lib/bgpstream_elem.h
+++ b/lib/bgpstream_elem.h
@@ -25,6 +25,7 @@
 #define __BGPSTREAM_ELEM_H
 
 #include "bgpstream_utils.h"
+#include "bgpstream_utils_rtr.h"
 
 /** @file
  *
@@ -164,6 +165,18 @@ typedef struct struct_bgpstream_elem_t {
    * Available only for the Peer-state elem type
    */
   bgpstream_elem_peerstate_t new_state;
+
+  /** Validation status
+   *
+   * Validation_status for the given prefix
+   */
+  char *validation_status;
+
+  /** Valid ASNs
+   *
+   * Valid ASNs for the given prefix, max: 16 entries
+   */
+  uint32_t valid_asn[16];
 
 } bgpstream_elem_t;
 

--- a/lib/bgpstream_elem_generator.c
+++ b/lib/bgpstream_elem_generator.c
@@ -221,8 +221,6 @@ static int table_line_mrtd_route(bgpstream_elem_generator_t *self,
      entry->attr->aspath)
     {
       bgpstream_as_path_populate(ri->aspath, entry->attr->aspath);
-      bgpstream_as_path_seg_t *seg = bgpstream_as_path_get_origin_seg(ri->aspath);
-      ri->origin_asnumber = ((bgpstream_as_path_seg_asn_t*)seg)->asn;
     }
 
   // communities
@@ -301,8 +299,6 @@ int table_line_dump_v2_prefix(bgpstream_elem_generator_t *self,
     // as path
     if (attr->aspath) {
       bgpstream_as_path_populate(ri->aspath, attr->aspath);
-      bgpstream_as_path_seg_t *seg = bgpstream_as_path_get_origin_seg(ri->aspath);
-      ri->origin_asnumber = ((bgpstream_as_path_seg_asn_t*)seg)->asn;
     }
     // communities
     if (attr->community) {
@@ -359,8 +355,6 @@ static int table_line_announce(bgpstream_elem_generator_t *self,
     if(entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_AS_PATH) &&
        entry->attr->aspath) {
       bgpstream_as_path_populate(ri->aspath, entry->attr->aspath);
-      bgpstream_as_path_seg_t *seg = bgpstream_as_path_get_origin_seg(ri->aspath);
-      ri->origin_asnumber = ((bgpstream_as_path_seg_asn_t*)seg)->asn;
     }
     // communities
     if(entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES) &&
@@ -407,8 +401,6 @@ static int table_line_announce_1(bgpstream_elem_generator_t *self,
     if(entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_AS_PATH) &&
        entry->attr->aspath) {
       bgpstream_as_path_populate(ri->aspath, entry->attr->aspath);
-      bgpstream_as_path_seg_t *seg = bgpstream_as_path_get_origin_seg(ri->aspath);
-      ri->origin_asnumber = ((bgpstream_as_path_seg_asn_t*)seg)->asn;
     }
     // communities
     if(entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES) &&
@@ -455,8 +447,6 @@ static int table_line_announce6(bgpstream_elem_generator_t *self,
     if(entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_AS_PATH) &&
        entry->attr->aspath) {
       bgpstream_as_path_populate(ri->aspath, entry->attr->aspath);
-      bgpstream_as_path_seg_t *seg = bgpstream_as_path_get_origin_seg(ri->aspath);
-      ri->origin_asnumber = ((bgpstream_as_path_seg_asn_t*)seg)->asn;
     }
     // communities
     if(entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES) &&

--- a/lib/bgpstream_elem_generator.c
+++ b/lib/bgpstream_elem_generator.c
@@ -221,6 +221,8 @@ static int table_line_mrtd_route(bgpstream_elem_generator_t *self,
      entry->attr->aspath)
     {
       bgpstream_as_path_populate(ri->aspath, entry->attr->aspath);
+      bgpstream_as_path_seg_t *seg = bgpstream_as_path_get_origin_seg(ri->aspath);
+      ri->origin_asnumber = ((bgpstream_as_path_seg_asn_t*)seg)->asn;
     }
 
   // communities
@@ -299,6 +301,8 @@ int table_line_dump_v2_prefix(bgpstream_elem_generator_t *self,
     // as path
     if (attr->aspath) {
       bgpstream_as_path_populate(ri->aspath, attr->aspath);
+      bgpstream_as_path_seg_t *seg = bgpstream_as_path_get_origin_seg(ri->aspath);
+      ri->origin_asnumber = ((bgpstream_as_path_seg_asn_t*)seg)->asn;
     }
     // communities
     if (attr->community) {
@@ -355,6 +359,8 @@ static int table_line_announce(bgpstream_elem_generator_t *self,
     if(entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_AS_PATH) &&
        entry->attr->aspath) {
       bgpstream_as_path_populate(ri->aspath, entry->attr->aspath);
+      bgpstream_as_path_seg_t *seg = bgpstream_as_path_get_origin_seg(ri->aspath);
+      ri->origin_asnumber = ((bgpstream_as_path_seg_asn_t*)seg)->asn;
     }
     // communities
     if(entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES) &&
@@ -401,6 +407,8 @@ static int table_line_announce_1(bgpstream_elem_generator_t *self,
     if(entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_AS_PATH) &&
        entry->attr->aspath) {
       bgpstream_as_path_populate(ri->aspath, entry->attr->aspath);
+      bgpstream_as_path_seg_t *seg = bgpstream_as_path_get_origin_seg(ri->aspath);
+      ri->origin_asnumber = ((bgpstream_as_path_seg_asn_t*)seg)->asn;
     }
     // communities
     if(entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES) &&
@@ -447,6 +455,8 @@ static int table_line_announce6(bgpstream_elem_generator_t *self,
     if(entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_AS_PATH) &&
        entry->attr->aspath) {
       bgpstream_as_path_populate(ri->aspath, entry->attr->aspath);
+      bgpstream_as_path_seg_t *seg = bgpstream_as_path_get_origin_seg(ri->aspath);
+      ri->origin_asnumber = ((bgpstream_as_path_seg_asn_t*)seg)->asn;
     }
     // communities
     if(entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES) &&

--- a/lib/utils/Makefile.am
+++ b/lib/utils/Makefile.am
@@ -73,7 +73,9 @@ libbgpstream_utils_la_SOURCES =             \
 	bgpstream_utils_str_set.c  	    \
 	bgpstream_utils_str_set.h	    \
 	bgpstream_utils_ip_counter.c	    \
-	bgpstream_utils_ip_counter.h      
+	bgpstream_utils_ip_counter.h    \
+	bgpstream_utils_rtr.c    \
+	bgpstream_utils_rtr.h
 
 
 libbgpstream_utils_la_LIBADD = $(CONDITIONAL_LIBS)

--- a/lib/utils/Makefile.am
+++ b/lib/utils/Makefile.am
@@ -74,7 +74,9 @@ libbgpstream_utils_la_SOURCES =             \
 	bgpstream_utils_ip_counter.c	    \
 	bgpstream_utils_ip_counter.h	    \
 	bgpstream_utils_patricia.c	    \
-	bgpstream_utils_patricia.h
+	bgpstream_utils_patricia.h  \
+	bgpstream_utils_rtr.c	    \
+	bgpstream_utils_rtr.h
 
 
 libbgpstream_utils_la_LIBADD = $(CONDITIONAL_LIBS)

--- a/lib/utils/Makefile.am
+++ b/lib/utils/Makefile.am
@@ -37,15 +37,12 @@ include_HEADERS= bgpstream_utils.h 		     \
 		 bgpstream_utils_addr_set.h	     \
 		 bgpstream_utils_as_path.h	     \
 		 bgpstream_utils_as_path_store.h     \
-		 bgpstream_utils_community.h	     \
 		 bgpstream_utils_id_set.h     	     \
 		 bgpstream_utils_peer_sig_map.h      \
 		 bgpstream_utils_pfx.h		     \
 		 bgpstream_utils_pfx_set.h	     \
 		 bgpstream_utils_str_set.h	     \
-		 bgpstream_utils_ip_counter.h	     \
-	         bgpstream_utils_patricia.h
-
+		 bgpstream_utils_ip_counter.h
 
 libbgpstream_utils_la_SOURCES =             \
 	bgpstream_utils.h                   \
@@ -58,9 +55,6 @@ libbgpstream_utils_la_SOURCES =             \
 	bgpstream_utils_as_path_store.c	    \
 	bgpstream_utils_as_path_store.h	    \
 	bgpstream_utils_as_path_int.h	    \
-	bgpstream_utils_community.h	    \
-	bgpstream_utils_community.c	    \
-	bgpstream_utils_community_int.h	    \
 	bgpstream_utils_id_set.c     	    \
 	bgpstream_utils_id_set.h     	    \
 	bgpstream_utils_peer_sig_map.c      \
@@ -72,10 +66,9 @@ libbgpstream_utils_la_SOURCES =             \
 	bgpstream_utils_str_set.c  	    \
 	bgpstream_utils_str_set.h	    \
 	bgpstream_utils_ip_counter.c	    \
-	bgpstream_utils_ip_counter.h	    \
-	bgpstream_utils_patricia.c	    \
-	bgpstream_utils_patricia.h  \
+	bgpstream_utils_ip_counter.h      \
 	bgpstream_utils_rtr.c	    \
+	bgpstream_utils_rtr_test.c	    \
 	bgpstream_utils_rtr.h
 
 

--- a/lib/utils/Makefile.am
+++ b/lib/utils/Makefile.am
@@ -37,12 +37,14 @@ include_HEADERS= bgpstream_utils.h 		     \
 		 bgpstream_utils_addr_set.h	     \
 		 bgpstream_utils_as_path.h	     \
 		 bgpstream_utils_as_path_store.h     \
+		 bgpstream_utils_community.h	     \
 		 bgpstream_utils_id_set.h     	     \
+		 bgpstream_utils_ip_counter.h	     \
 		 bgpstream_utils_peer_sig_map.h      \
 		 bgpstream_utils_pfx.h		     \
 		 bgpstream_utils_pfx_set.h	     \
 		 bgpstream_utils_str_set.h	     \
-		 bgpstream_utils_ip_counter.h
+		 bgpstream_utils_patricia.h
 
 libbgpstream_utils_la_SOURCES =             \
 	bgpstream_utils.h                   \
@@ -55,8 +57,13 @@ libbgpstream_utils_la_SOURCES =             \
 	bgpstream_utils_as_path_store.c	    \
 	bgpstream_utils_as_path_store.h	    \
 	bgpstream_utils_as_path_int.h	    \
+	bgpstream_utils_community.h	    \
+	bgpstream_utils_community.c	    \
+	bgpstream_utils_community_int.h	    \
 	bgpstream_utils_id_set.c     	    \
 	bgpstream_utils_id_set.h     	    \
+	bgpstream_utils_patricia.h  \
+	bgpstream_utils_patricia.c	    \
 	bgpstream_utils_peer_sig_map.c      \
 	bgpstream_utils_peer_sig_map.h      \
 	bgpstream_utils_pfx.c		    \
@@ -66,10 +73,7 @@ libbgpstream_utils_la_SOURCES =             \
 	bgpstream_utils_str_set.c  	    \
 	bgpstream_utils_str_set.h	    \
 	bgpstream_utils_ip_counter.c	    \
-	bgpstream_utils_ip_counter.h      \
-	bgpstream_utils_rtr.c	    \
-	bgpstream_utils_rtr_test.c	    \
-	bgpstream_utils_rtr.h
+	bgpstream_utils_ip_counter.h      
 
 
 libbgpstream_utils_la_LIBADD = $(CONDITIONAL_LIBS)

--- a/lib/utils/bgpstream_utils.h
+++ b/lib/utils/bgpstream_utils.h
@@ -56,6 +56,7 @@
 #include "bgpstream_utils_pfx_set.h"       /*< Prefix Set utilities */
 #include "bgpstream_utils_str_set.h"       /*< String Set utilities */
 #include "bgpstream_utils_patricia.h"      /*< Patricia Tree utilities */
+#include "bgpstream_utils_rtr.h"           /*< RTR utilities */
 
 #endif /* __BGPSTREAM_UTILS_H */
 

--- a/lib/utils/bgpstream_utils_rtr.c
+++ b/lib/utils/bgpstream_utils_rtr.c
@@ -29,17 +29,12 @@
 
 struct rtr_mgr_config* bgpstream_rtr_start_connection(char * host, char * port, uint32_t * polling_period, uint32_t * cache_timeout, char * ssh_user, char * ssh_hostkey, char * ssh_privkey){
 
-	char p[5]="8282\0";
-	if(port == NULL){
-		port = p;
-	}
-
-	uint32_t pp=240;
+	uint32_t pp = 240;
   if(polling_period == NULL){
     polling_period = &pp;
   }
 
-	uint32_t ct=520;
+	uint32_t ct = 520;
   if(cache_timeout == NULL){
     cache_timeout = &ct;
   }
@@ -93,7 +88,7 @@ enum pfxv_state bgpstream_rtr_validate (struct rtr_mgr_config* mgr_cfg, uint32_t
   return result;
 }
 
-struct reasoned_result bgpstream_rtr_validate_reason(struct rtr_mgr_config* mgr_cfg, uint32_t asn, char prefix[], uint32_t mask_len){	
+struct reasoned_result bgpstream_rtr_validate_reason(struct rtr_mgr_config* mgr_cfg, uint32_t asn, char prefix[], uint32_t mask_len){
   struct lrtr_ip_addr pref;
   lrtr_ip_str_to_addr(prefix, &pref);
   enum pfxv_state result;
@@ -104,6 +99,7 @@ struct reasoned_result bgpstream_rtr_validate_reason(struct rtr_mgr_config* mgr_
 
 	struct reasoned_result reasoned_res;
 	reasoned_res.reason = reason;
+	reasoned_res.reason_len = reason_len;
 	reasoned_res.result = result; 
 
 	return(reasoned_res);

--- a/lib/utils/bgpstream_utils_rtr.c
+++ b/lib/utils/bgpstream_utils_rtr.c
@@ -1,0 +1,131 @@
+/*
+ * This file is part of bgpstream
+ *
+ * CAIDA, UC San Diego
+ * bgpstream-info@caida.org
+ *
+ * Copyright (C) 2012 The Regents of the University of California.
+ * Authors: Alistair King, Chiara Orsini
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <time.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <stdbool.h>
+#include <string.h>
+#include "rtrlib/rtrlib.h"
+#include "rtrlib/rtr_mgr.h"
+#include "rtrlib/transport/ssh/ssh_transport.h"
+#include "rtrlib/rtr_mgr.h"
+#include "bgpstream.h"
+
+#include "bgpstream_utils_rtr.h"
+
+int main()
+{
+
+  struct conf_tr cfg_tr = bgpstream_rtr_start_connection("rpki-validator.realmv6.org", "8282", NULL, NULL ,NULL);
+  char * result = bgpstream_rtr_validate(cfg_tr, 12345, "10.10.0.0", 24);
+  bgpstream_rtr_close_connection(cfg_tr.tr);
+
+  return 0;
+}
+/* PUBLIC FUNCTIONS */
+
+struct conf_tr bgpstream_rtr_start_connection(char * host, char * port, char * ssh_user, char * ssh_hostkey, char * ssh_privkey)
+{
+  struct tr_socket tr;
+  if (host != NULL && port != NULL && ssh_user != NULL && ssh_hostkey != NULL && ssh_privkey != NULL)
+  {
+    int port = atoi(port);
+    struct tr_ssh_config config = {
+        host,
+        port,
+        NULL,
+        ssh_user,
+        ssh_hostkey,
+        ssh_privkey,
+    };
+    tr_ssh_init(&config, &tr);
+  }
+
+  else if (host != NULL && port != NULL)
+  {
+    struct tr_tcp_config config = {
+      host,
+      port,
+      NULL
+    };
+    tr_tcp_init(&config, &tr);
+  }
+
+  struct rtr_socket rtr;
+  rtr.tr_socket = &tr;
+
+  struct rtr_mgr_group groups[1];
+  groups[0].sockets = malloc(sizeof(struct rtr_socket*));
+  groups[0].sockets_len = 1;
+  groups[0].sockets[0] = &rtr;
+  groups[0].preference = 1;
+
+  struct conf_tr cfmgr_tr;
+  struct rtr_mgr_config *conf = rtr_mgr_init(groups, 1, 240, 520, NULL, NULL, NULL, NULL);
+  rtr_mgr_start(conf);
+
+  while(!rtr_mgr_conf_in_sync(conf))
+      sleep(1);
+
+  cfmgr_tr.conf = conf;
+  cfmgr_tr.tr = tr;
+
+  return cfmgr_tr;
+}
+
+char *
+bgpstream_rtr_validate (struct conf_tr cfg_tr, uint32_t asn,
+                        char * prefix, uint32_t mask_len)
+{
+  struct ip_addr *pref;
+  lrtr_ip_str_to_addr(prefix, &pref);
+  enum pfxv_state result;
+  rtr_mgr_validate(cfg_tr.conf, asn, &pref, mask_len, &result);
+
+  char * validity_code;
+  if (result == BGP_PFXV_STATE_VALID) 
+  {
+      validity_code = "valid";
+  } else if (result == BGP_PFXV_STATE_NOT_FOUND) 
+  {
+      validity_code = "State not found";
+  } else if (result == BGP_PFXV_STATE_INVALID) 
+  {
+      validity_code = "State invalid";
+  }
+
+  return validity_code;
+}
+
+void bgpstream_rtr_close_connection(struct tr_socket *tr)
+{
+  tr_close(tr);
+  //tr_free(&tr);
+}
+

--- a/lib/utils/bgpstream_utils_rtr.c
+++ b/lib/utils/bgpstream_utils_rtr.c
@@ -123,11 +123,11 @@ void bgpstream_rtr_close_connection(struct rtr_mgr_config *mgr_cfg){
 char* pfxv2str(enum pfxv_state result){
   char* validity_code;
   if (result == BGP_PFXV_STATE_VALID){
-      validity_code = "valid";
+      validity_code = "valid\0";
   } else if (result == BGP_PFXV_STATE_NOT_FOUND){
-      validity_code = "State not found";
+      validity_code = "State not found\0";
   } else if (result == BGP_PFXV_STATE_INVALID){
-      validity_code = "State invalid";
+      validity_code = "State invalid\0";
   }
   return validity_code;
 }

--- a/lib/utils/bgpstream_utils_rtr.c
+++ b/lib/utils/bgpstream_utils_rtr.c
@@ -39,15 +39,16 @@
 
 #include "bgpstream_utils_rtr.h"
 
-int main()
+void main()
 {
+  char ip[] = "10.10.0.0";
+  struct conf_tr cfg_tr = bgpstream_rtr_start_connection("rpki-validator.realmv6.org", "8282", NULL, NULL ,NULL);  
+  char * result = bgpstream_rtr_validate(cfg_tr, 12345, ip, 24);
+  bgpstream_rtr_close_connection(cfg_tr);
 
-  struct conf_tr cfg_tr = bgpstream_rtr_start_connection("rpki-validator.realmv6.org", "8282", NULL, NULL ,NULL);
-  char * result = bgpstream_rtr_validate(cfg_tr, 12345, "10.10.0.0", 24);
-  bgpstream_rtr_close_connection(cfg_tr.tr);
-
-  return 0;
+  printf("\nState for IP-Address: %s is %s \n\n",ip, result);
 }
+
 /* PUBLIC FUNCTIONS */
 
 struct conf_tr bgpstream_rtr_start_connection(char * host, char * port, char * ssh_user, char * ssh_hostkey, char * ssh_privkey)
@@ -123,9 +124,9 @@ bgpstream_rtr_validate (struct conf_tr cfg_tr, uint32_t asn,
   return validity_code;
 }
 
-void bgpstream_rtr_close_connection(struct tr_socket *tr)
+void bgpstream_rtr_close_connection(struct conf_tr cfg_tr)
 {
-  tr_close(tr);
-  //tr_free(&tr);
+  tr_close(&cfg_tr.tr);
+  tr_free(&cfg_tr.tr);
 }
 

--- a/lib/utils/bgpstream_utils_rtr.c
+++ b/lib/utils/bgpstream_utils_rtr.c
@@ -21,24 +21,31 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <stdio.h>
+#include <stdlib.h>
 #include "rtrlib/rtrlib.h"
 #include "bgpstream_utils_rtr.h"
 
 /* PUBLIC FUNCTIONS */
 
-struct rtr_mgr_config* bgpstream_rtr_start_connection(char * host, char port[], uint32_t polling_period, uint32_t cache_timeout,
-                                                      char * ssh_user, char * ssh_hostkey, char * ssh_privkey){
-  if(polling_period == 0){
-    polling_period = 240;
+struct rtr_mgr_config* bgpstream_rtr_start_connection(char * host, char * port, uint32_t * polling_period, uint32_t * cache_timeout, char * ssh_user, char * ssh_hostkey, char * ssh_privkey){
+
+	char p[5]="8282\0";
+	if(port == NULL){
+		port = p;
+	}
+
+	uint32_t pp=240;
+  if(polling_period == NULL){
+    polling_period = &pp;
   }
 
-  if(cache_timeout == 0){
-    cache_timeout = 520;
+	uint32_t ct=520;
+  if(cache_timeout == NULL){
+    cache_timeout = &ct;
   }
 
   struct tr_socket *tr = malloc(sizeof(struct tr_socket));
-  if (host != NULL && port != NULL && ssh_user != NULL && ssh_hostkey != NULL && ssh_privkey != NULL){
+  if (host != NULL && ssh_user != NULL && ssh_hostkey != NULL && ssh_privkey != NULL){
     int port = port;
     struct tr_ssh_config config = {
         host,
@@ -51,7 +58,7 @@ struct rtr_mgr_config* bgpstream_rtr_start_connection(char * host, char port[], 
     tr_ssh_init(&config, tr);
   }
 
-  else if (host != NULL && port != NULL){
+  else if (host != NULL){
     struct tr_tcp_config config = {
       host,
       port,
@@ -69,7 +76,7 @@ struct rtr_mgr_config* bgpstream_rtr_start_connection(char * host, char port[], 
   groups[0].sockets[0] = rtr;
   groups[0].preference = 1;
 
-  struct rtr_mgr_config *conf = rtr_mgr_init(groups, 1, polling_period, cache_timeout, NULL, NULL, NULL, NULL);
+  struct rtr_mgr_config *conf = rtr_mgr_init(groups, 1, *polling_period, *cache_timeout, NULL, NULL, NULL, NULL);
   rtr_mgr_start(conf);
 
   while(!rtr_mgr_conf_in_sync(conf))

--- a/lib/utils/bgpstream_utils_rtr.h
+++ b/lib/utils/bgpstream_utils_rtr.h
@@ -39,8 +39,9 @@
 /** @} */
 
 struct reasoned_result {
-	struct pfx_record* reason;
+	struct pfx_record *reason;
 	enum pfxv_state result;
+    unsigned int reason_len;
 };
 
 /**
@@ -64,10 +65,10 @@ struct rtr_mgr_config* bgpstream_rtr_start_connection(char * host, char * port, 
 /**
  * @brief Validates the origin of a BGP-Route.
  * @param mgr_cfg Manager-Configuration
- * @param asn Autonomous system number of the Origin-AS of the prefix.
+ * @param asn Autonomous system number of the Origin-AS of the prefix
  * @param prefix Announced network prefix
  * @param mask_len Length of the network mask of the announced prefix
- * @param[out] result Outcome of the validation.
+ * @param[out] result Outcome of the validation
  * @return the validation of the ip: BGP_PFXV_STATE_VALID, BGP_PFXV_STATE_NOT_FOUND or BGP_PFXV_STATE_INVALID.
  */
 enum pfxv_state bgpstream_rtr_validate(struct rtr_mgr_config* mgr_cfg, uint32_t asn, char * prefix, uint32_t mask_len);
@@ -75,10 +76,10 @@ enum pfxv_state bgpstream_rtr_validate(struct rtr_mgr_config* mgr_cfg, uint32_t 
 /**
  * @brief Validates the origin of a BGP-Route and returns the reason for the state.
  * @param mgr_cfg Manager-Configuration
- * @param asn Autonomous system number of the Origin-AS of the prefix.
+ * @param asn Autonomous system number of the Origin-AS of the prefix
  * @param prefix Announced network prefix
  * @param mask_len Length of the network mask of the announced prefix
- * @param[out] result Outcome of the validation and the reason for the state.
+ * @param[out] result Outcome of the validation and the reason for the state
  * @return the validation of the ip: BGP_PFXV_STATE_VALID, BGP_PFXV_STATE_NOT_FOUND or BGP_PFXV_STATE_INVALID.
  */
 struct reasoned_result bgpstream_rtr_validate_reason(struct rtr_mgr_config* mgr_cfg, uint32_t asn, char prefix[], uint32_t mask_len);

--- a/lib/utils/bgpstream_utils_rtr.h
+++ b/lib/utils/bgpstream_utils_rtr.h
@@ -50,11 +50,9 @@
 
 /** @} */
 
-struct conf_tr
-{
-  struct rtr_mgr_config *conf;
-  struct tr_socket tr;
-
+struct reasoned_result {
+	struct pfx_record* reason;
+	enum pfxv_state result;
 };
 
 /**
@@ -71,24 +69,43 @@ struct conf_tr
  * @param ssh_privkey     if ssh should be used, the private key to be used
  * @return a struct consisting of the configuration and the address of the transport-socket
  */
-struct conf_tr bgpstream_rtr_start_connection(char * host, char * port, char * ssh_user, char * ssh_hostkey, char * ssh_privkey);
+struct rtr_mgr_config* bgpstream_rtr_start_connection(char * host, char * port, uint32_t polling_period, uint32_t cache_timeout,
+                                                      char * ssh_user, char * ssh_hostkey, char * ssh_privkey);
 
 /**
  * @brief Validates the origin of a BGP-Route.
- * @param conf_tr Configuration and socket
+ * @param mgr_cfg Manager-Configuration
  * @param asn Autonomous system number of the Origin-AS of the prefix.
  * @param prefix Announced network prefix
  * @param mask_len Length of the network mask of the announced prefix
  * @param[out] result Outcome of the validation.
  * @return the validation of the ip: BGP_PFXV_STATE_VALID, BGP_PFXV_STATE_NOT_FOUND or BGP_PFXV_STATE_INVALID.
  */
-char *bgpstream_rtr_validate(struct conf_tr, uint32_t asn, char * prefix, uint32_t mask_len);
+enum pfxv_state bgpstream_rtr_validate(struct rtr_mgr_config* mgr_cfg, uint32_t asn, char * prefix, uint32_t mask_len);
+
+/**
+ * @brief Validates the origin of a BGP-Route and returns the reason for the state.
+ * @param mgr_cfg Manager-Configuration
+ * @param asn Autonomous system number of the Origin-AS of the prefix.
+ * @param prefix Announced network prefix
+ * @param mask_len Length of the network mask of the announced prefix
+ * @param[out] result Outcome of the validation and the reason for the state.
+ * @return the validation of the ip: BGP_PFXV_STATE_VALID, BGP_PFXV_STATE_NOT_FOUND or BGP_PFXV_STATE_INVALID.
+ */
+struct reasoned_result bgpstream_rtr_validate_reason(struct rtr_mgr_config* mgr_cfg, uint32_t asn, char prefix[], uint32_t mask_len);
+  
 
 /** Stop a connection to a desired RTR-Server over SSH or TCP
  *
- * @param conf_tr Configuration and socket
+ * @param mgr_cfg Configuration and socket
  */
-void bgpstream_rtr_close_connection(struct conf_tr cfg_tr);
+void bgpstream_rtr_close_connection(struct rtr_mgr_config* mgr_cfg);
+
+/** Converts PFVX_STATE to string
+ *
+ * @param result Outcome of the validation
+ */
+char* pfxv2str(enum pfxv_state result);
 
 
 /** @} */

--- a/lib/utils/bgpstream_utils_rtr.h
+++ b/lib/utils/bgpstream_utils_rtr.h
@@ -1,0 +1,99 @@
+/*
+ * This file is part of bgpstream
+ *
+ * CAIDA, UC San Diego
+ * bgpstream-info@caida.org
+ *
+ * Copyright (C) 2012 The Regents of the University of California.
+ * Authors: Alistair King, Chiara Orsini
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <time.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <stdbool.h>
+#include <string.h>
+#include "rtrlib/rtrlib.h"
+#include "rtrlib/transport/ssh/ssh_transport.h"
+#include "rtrlib/rtr_mgr.h"
+#include "bgpstream.h"
+
+#ifndef __BGPSTREAM_UTILS_RTR_H
+#define __BGPSTREAM_UTILS_RTR_H
+
+/** @file
+ *
+ * @brief Header file that exposes the public interface of the BGP Stream String
+ * Set.
+ *
+ * @author Chiara Orsini
+ *
+ */
+
+/** @} */
+
+struct conf_tr
+{
+  struct rtr_mgr_config *conf;
+  struct tr_socket tr;
+
+};
+
+/**
+ * @name Public API Functions
+ *
+ * @{ */
+
+/** Start a connection to a desired RTR-Server over SSH or TCP
+ *
+ * @param host         string of the host-address
+ * @param port         string of the port-number
+ * @param ssh_user     if ssh should be used, the username to be used
+ * @param ssh_hostkey     if ssh should be used, the hostkey to be used
+ * @param ssh_privkey     if ssh should be used, the private key to be used
+ * @return a struct consisting of the configuration and the address of the transport-socket
+ */
+struct conf_tr bgpstream_rtr_start_connection(char * host, char * port, char * ssh_user, char * ssh_hostkey, char * ssh_privkey);
+
+/**
+ * @brief Validates the origin of a BGP-Route.
+ * @param[in] conf_tr Configuration and socket
+ * @param[in] asn Autonomous system number of the Origin-AS of the prefix.
+ * @param[in] prefix Announced network prefix
+ * @param[in] mask_len Length of the network mask of the announced prefix
+ * @param[out] result Outcome of the validation.
+ * @return PFX_SUCCESS On success.
+ * @return PFX_ERROR If an error occurred.
+ */
+char *bgpstream_rtr_validate(struct conf_tr, uint32_t asn, char * prefix, uint32_t mask_len);
+
+/** Remove a string from the set
+ *
+ * @param set           pointer to the string set
+ * @param val           pointer to the string to remove
+ * @return 1 if the string was removed, 0 if the string was not in the set
+ */
+void bgpstream_rtr_close_connection();
+
+
+/** @} */
+
+#endif /*__BGPSTREAM_UTILS_RTR_H*/

--- a/lib/utils/bgpstream_utils_rtr.h
+++ b/lib/utils/bgpstream_utils_rtr.h
@@ -41,7 +41,7 @@
 
 /** @file
  *
- * @brief Header file that exposes the public interface of the BGP Stream String
+ * @brief Header file that exposes the public interface of the RTR-Validation for a BGP-Records
  * Set.
  *
  * @author Chiara Orsini
@@ -75,23 +75,20 @@ struct conf_tr bgpstream_rtr_start_connection(char * host, char * port, char * s
 
 /**
  * @brief Validates the origin of a BGP-Route.
- * @param[in] conf_tr Configuration and socket
- * @param[in] asn Autonomous system number of the Origin-AS of the prefix.
- * @param[in] prefix Announced network prefix
- * @param[in] mask_len Length of the network mask of the announced prefix
+ * @param conf_tr Configuration and socket
+ * @param asn Autonomous system number of the Origin-AS of the prefix.
+ * @param prefix Announced network prefix
+ * @param mask_len Length of the network mask of the announced prefix
  * @param[out] result Outcome of the validation.
- * @return PFX_SUCCESS On success.
- * @return PFX_ERROR If an error occurred.
+ * @return the validation of the ip: BGP_PFXV_STATE_VALID, BGP_PFXV_STATE_NOT_FOUND or BGP_PFXV_STATE_INVALID.
  */
 char *bgpstream_rtr_validate(struct conf_tr, uint32_t asn, char * prefix, uint32_t mask_len);
 
-/** Remove a string from the set
+/** Stop a connection to a desired RTR-Server over SSH or TCP
  *
- * @param set           pointer to the string set
- * @param val           pointer to the string to remove
- * @return 1 if the string was removed, 0 if the string was not in the set
+ * @param conf_tr Configuration and socket
  */
-void bgpstream_rtr_close_connection();
+void bgpstream_rtr_close_connection(struct conf_tr cfg_tr);
 
 
 /** @} */

--- a/lib/utils/bgpstream_utils_rtr.h
+++ b/lib/utils/bgpstream_utils_rtr.h
@@ -21,30 +21,18 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <stdio.h>
-#include <time.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <stdlib.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <arpa/inet.h>
-#include <stdbool.h>
-#include <string.h>
-#include "rtrlib/rtrlib.h"
-#include "rtrlib/transport/ssh/ssh_transport.h"
-#include "rtrlib/rtr_mgr.h"
-#include "bgpstream.h"
-
 #ifndef __BGPSTREAM_UTILS_RTR_H
 #define __BGPSTREAM_UTILS_RTR_H
 
+#include "rtrlib/rtrlib.h"
+
+
 /** @file
  *
- * @brief Header file that exposes the public interface of the RTR-Validation for a BGP-Records
- * Set.
+ * @brief Header file that exposes the public interface of the RTR-Validation for 
+ * a BGP-Record Set.
  *
- * @author Chiara Orsini
+ * @author Samir Al-Sheikh, Fabrice J. Ryba
  *
  */
 
@@ -62,15 +50,16 @@ struct reasoned_result {
 
 /** Start a connection to a desired RTR-Server over SSH or TCP
  *
- * @param host         string of the host-address
- * @param port         string of the port-number
- * @param ssh_user     if ssh should be used, the username to be used
+ * @param host         		string of the host-address
+ * @param port         		if specific port should be used, string of the port-number
+ * @param polling_period 	if specific polling period should be used, uint32_t number (seconds)
+ * @param cache_timeout		if specific cache_timeout should be used, uint32_t nuber (seconds)
+ * @param ssh_user    		if ssh should be used, the username to be used
  * @param ssh_hostkey     if ssh should be used, the hostkey to be used
  * @param ssh_privkey     if ssh should be used, the private key to be used
  * @return a struct consisting of the configuration and the address of the transport-socket
  */
-struct rtr_mgr_config* bgpstream_rtr_start_connection(char * host, char * port, uint32_t polling_period, uint32_t cache_timeout,
-                                                      char * ssh_user, char * ssh_hostkey, char * ssh_privkey);
+struct rtr_mgr_config* bgpstream_rtr_start_connection(char * host, char * port, uint32_t * polling_period, uint32_t * cache_timeout, char * ssh_user, char * ssh_hostkey, char * ssh_privkey);
 
 /**
  * @brief Validates the origin of a BGP-Route.

--- a/lib/utils/bgpstream_utils_rtr_test.c
+++ b/lib/utils/bgpstream_utils_rtr_test.c
@@ -1,0 +1,55 @@
+/*
+ * This file is part of bgpstream
+ *
+ * CAIDA, UC San Diego
+ * bgpstream-info@caida.org
+ *
+ * Copyright (C) 2012 The Regents of the University of California.
+ * Authors: Alistair King, Chiara Orsini
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include "rtrlib/rtrlib.h"
+#include "bgpstream_utils_rtr.h"
+#include "bgpstream_utils_rtr.c"
+
+void main()
+{
+  char ip[] = "10.11.10.0";
+  uint32_t asn = 12345;
+  uint32_t mask_len = 24;
+
+  /* TCP Example - without Reason */
+  struct rtr_mgr_config* cfg_tr = bgpstream_rtr_start_connection("rpki-validator.realmv6.org", "8282", 0, 0, NULL, NULL ,NULL);  
+  enum pfxv_state result = bgpstream_rtr_validate(cfg_tr, asn, ip, mask_len);
+  bgpstream_rtr_close_connection(cfg_tr);
+  printf("\nTCP - State for IP-Address: %s is %s \n\n",ip, pfxv2str(result));
+
+  /* TCP Example - Reason*/
+  cfg_tr = bgpstream_rtr_start_connection("rpki-validator.realmv6.org", "8282", 0, 0, NULL, NULL ,NULL);  
+  struct reasoned_result res_reasoned = bgpstream_rtr_validate_reason(cfg_tr, asn, ip, mask_len);
+  bgpstream_rtr_close_connection(cfg_tr);
+  printf("\nTCP - State for IP-Address: %s is %s \n\n",ip, pfxv2str(res_reasoned.result));
+  struct pfx_record* reason = res_reasoned.reason;
+  //printf("TCP - Reason for IP-Address: %s is %s \n\n", ip, reason.xxx);
+
+  /*SSH Example - without Reason*/
+  /*cfg_tr = bgpstream_rtr_start_connection("rpki-validator.realmv6.org", "22", 0, 0, "rtr-ssh", "~/.ssh/id_rsa" ,"~/.ssh/known_hosts");  
+  result = bgpstream_rtr_validate(cfg_tr, asn, ip, mask_len);
+  bgpstream_rtr_close_connection(cfg_tr);
+  printf("\nSSH - State for IP-Address: %s is %s \n\n",ip, pfxv2str(result));*/
+
+}

--- a/lib/utils/bgpstream_utils_rtr_test.c
+++ b/lib/utils/bgpstream_utils_rtr_test.c
@@ -28,9 +28,9 @@
 
 int main()
 {
-  char ip[] = "10.11.10.0";
-  uint32_t asn = 12345;
-  uint32_t mask_len = 24;
+  char ip[] = "2001:678:3::";
+  uint32_t asn = 42;
+  uint32_t mask_len = 48;
 
   /* TCP Example - without Reason */
   struct rtr_mgr_config* cfg_tr = bgpstream_rtr_start_connection("rpki-validator.realmv6.org", NULL, NULL, NULL, NULL, NULL ,NULL);  
@@ -45,12 +45,14 @@ int main()
   printf("\nTCP - State for IP-Address: %s is %s \n",ip, pfxv2str(res_reasoned.result) );
   if(res_reasoned.reason){
 		struct pfx_record *reason = res_reasoned.reason;
-		char ip_prefix[INET6_ADDRSTRLEN];
+		char ip_prefix[INET6_ADDRSTRLEN+1];
 		lrtr_ip_addr_to_str(&(reason->prefix), ip_prefix, sizeof(ip_prefix));
+		int len_of_prefix = sizeof(ip_prefix);
   	printf(
-			"TCP - Reason for IP-Address %s is: ASN(%10u) Prefix(%-18s) minimal length(%3u) maximal length(%3u) \n\n",
+			"TCP - Reason for IP-Address %s is: ASN(%"PRIu32") Prefix(%.*s) minimal length(%"PRIu8") maximal length(%"PRIu8") \n\n",
 			ip, 
 			reason->asn, 
+			len_of_prefix,
 			ip_prefix,
 			reason->min_len,
 			reason->max_len);

--- a/lib/utils/bgpstream_utils_rtr_test.c
+++ b/lib/utils/bgpstream_utils_rtr_test.c
@@ -24,7 +24,6 @@
 #include <stdio.h>
 #include "rtrlib/rtrlib.h"
 #include "bgpstream_utils_rtr.h"
-#include "bgpstream_utils_rtr.c"
 
 void main()
 {
@@ -33,16 +32,16 @@ void main()
   uint32_t mask_len = 24;
 
   /* TCP Example - without Reason */
-  struct rtr_mgr_config* cfg_tr = bgpstream_rtr_start_connection("rpki-validator.realmv6.org", "8282", 0, 0, NULL, NULL ,NULL);  
+  struct rtr_mgr_config* cfg_tr = bgpstream_rtr_start_connection("rpki-validator.realmv6.org", NULL, NULL, NULL, NULL, NULL ,NULL);  
   enum pfxv_state result = bgpstream_rtr_validate(cfg_tr, asn, ip, mask_len);
   bgpstream_rtr_close_connection(cfg_tr);
   printf("\nTCP - State for IP-Address: %s is %s \n\n",ip, pfxv2str(result));
 
   /* TCP Example - Reason*/
-  cfg_tr = bgpstream_rtr_start_connection("rpki-validator.realmv6.org", "8282", 0, 0, NULL, NULL ,NULL);  
+  cfg_tr = bgpstream_rtr_start_connection("rpki-validator.realmv6.org", NULL, NULL, NULL, NULL, NULL ,NULL);  
   struct reasoned_result res_reasoned = bgpstream_rtr_validate_reason(cfg_tr, asn, ip, mask_len);
   bgpstream_rtr_close_connection(cfg_tr);
-  printf("\nTCP - State for IP-Address: %s is %s \n\n",ip, pfxv2str(res_reasoned.result));
+  printf("\nTCP - State for IP-Address: %s is %s \n\n",ip, pfxv2str(res_reasoned.result), );
   struct pfx_record* reason = res_reasoned.reason;
   //printf("TCP - Reason for IP-Address: %s is %s \n\n", ip, reason.xxx);
 


### PR DESCRIPTION
Hello,
we want to extend BGPStream with the RTRlib functionalities. The functionalities mainly cover the connection to an RTR cache server, checking for the validity of prefixes for ASes and close the connection. We provide these functions and examples how they can be used. To make the RTRib an option to be used within BGPStream we would like to know the best way to integrate it into your project.

More information about the RTRlib can be found on: http://rtrlib.realmv6.org/ and https://github.com/rtrlib/rtrlib

Best regards,
Fabrice J. Ryba