### PR TITLE
Adding a path accessor function for the origin value

### DIFF
--- a/lib/utils/bgpstream_utils_as_path.c
+++ b/lib/utils/bgpstream_utils_as_path.c
@@ -429,6 +429,17 @@ bgpstream_as_path_get_origin_seg(bgpstream_as_path_t *path)
   return (bgpstream_as_path_seg_t*)(path->data+path->origin_offset);
 }
 
+int bgpstream_as_path_get_origin_val(bgpstream_as_path_t *path, uint32_t *asn)
+{
+  bgpstream_as_path_seg_t *origin_seg = bgpstream_as_path_get_origin_seg(path);
+  if (origin_seg == NULL || origin_seg->type != BGPSTREAM_AS_PATH_SEG_ASN) {
+     return -1;
+  } else {
+    *asn = ((bgpstream_as_path_seg_asn_t*)origin_seg)->asn;
+    return 0;
+  }
+}
+
 void bgpstream_as_path_iter_reset(bgpstream_as_path_iter_t *iter)
 {
   iter->cur_offset = 0;

--- a/lib/utils/bgpstream_utils_as_path.h
+++ b/lib/utils/bgpstream_utils_as_path.h
@@ -255,6 +255,15 @@ int bgpstream_as_path_copy(bgpstream_as_path_t *dst, bgpstream_as_path_t *src);
 bgpstream_as_path_seg_t *
 bgpstream_as_path_get_origin_seg(bgpstream_as_path_t *path);
 
+/** Get the origin ASN from the given path if possible
+ *
+ * @param path          pointer to the AS path to extract the origin AS for
+ * @param asn           pointer to the 32-bit field in which the asn will be stored
+ * @return 0 if the asn is valid, -1 otherwise
+ */
+int bgpstream_as_path_get_origin_val(bgpstream_as_path_t *path, uint32_t *asn);
+
+
 /** Reset the segment iterator for the given path
  *
  * @param iter          pointer to the AS path iterator to reset


### PR DESCRIPTION
A path accessor function that extracts the origin-asn value of a given as-path if possible and stores it in a given 32-bit field. If the field is valid, it returns 0, otherwise in case of a path-type unlike BGPSTREAM_AS_PATH_SEG_ASN it returns -1.