### PR TITLE
Revise the document for element type section for PyBGPStream.

### DIFF
--- a/pybgpstream/docs/api__pybgpstream.rst
+++ b/pybgpstream/docs/api__pybgpstream.rst
@@ -233,7 +233,7 @@ BGPElem
    .. py:attribute:: type
 
       The type of the element, can be one of 'R' (rib), 'A' (announcement),
-      'W' (withdrawal), 'S' (peerstate), '\0' (unknown). *(basestring, readonly)*
+      'W' (withdrawal), 'S' (peerstate), '' (unknown). *(basestring, readonly)*
 
 
    .. py:attribute:: time

--- a/pybgpstream/docs/api__pybgpstream.rst
+++ b/pybgpstream/docs/api__pybgpstream.rst
@@ -232,8 +232,8 @@ BGPElem
 
    .. py:attribute:: type
 
-      The type of the element, can be one of 'rib', 'announcement',
-      'withdrawal', 'peerstate', 'unknown'. *(basestring, readonly)*
+      The type of the element, can be one of 'R' (rib), 'A' (announcement),
+      'W' (withdrawal), 'S' (peerstate), '\0' (unknown). *(basestring, readonly)*
 
 
    .. py:attribute:: time


### PR DESCRIPTION
Using the true return values here, i.e. R, A, W, \0. This can avoid some confusion when using the library. Users don't need to figure out what values they expect to see when doing `elem.type`.