### PR TITLE
Consolidate dict add call and remove possible memory leak

### DIFF
--- a/pybgpstream/src/_pybgpstream_bgpelem.c
+++ b/pybgpstream/src/_pybgpstream_bgpelem.c
@@ -75,8 +75,8 @@ get_communities_pylist(bgpstream_community_set_t *communities) {
       if((dict = PyDict_New()) == NULL)
         return NULL;
       /* add pair to dictionary */
-      if (!add_to_dict(dict, "asn", Py_BuildValue("k", c->asn)) ||
-          !add_to_dict(dict, "value", Py_BuildValue("k", c->value))) {
+      if (add_to_dict(dict, "asn", Py_BuildValue("k", c->asn)) ||
+          add_to_dict(dict, "value", Py_BuildValue("k", c->value))) {
         return NULL;
       }
 
@@ -156,23 +156,23 @@ BGPElem_get_fields(BGPElemObject *self, void *closure)
     {
     case BGPSTREAM_ELEM_TYPE_RIB:
     case BGPSTREAM_ELEM_TYPE_ANNOUNCEMENT:
-      if (!add_to_dict(dict, "next-hop", get_ip_pystr((bgpstream_ip_addr_t *)&self->elem->nexthop)) ||
-          !add_to_dict(dict, "as-path", get_aspath_pystr(self->elem->aspath)) ||
-          !add_to_dict(dict, "communities", get_communities_pylist(self->elem->communities))) {
+      if (add_to_dict(dict, "next-hop", get_ip_pystr((bgpstream_ip_addr_t *)&self->elem->nexthop)) ||
+          add_to_dict(dict, "as-path", get_aspath_pystr(self->elem->aspath)) ||
+          add_to_dict(dict, "communities", get_communities_pylist(self->elem->communities))) {
         return NULL;
       }
 
       /* FALLTHROUGH */
 
     case BGPSTREAM_ELEM_TYPE_WITHDRAWAL:
-      if (!add_to_dict(dict, "prefix", get_pfx_pystr((bgpstream_pfx_t *)&self->elem->prefix))) {
+      if (add_to_dict(dict, "prefix", get_pfx_pystr((bgpstream_pfx_t *)&self->elem->prefix))) {
         return NULL;
       }
       break;
 
     case BGPSTREAM_ELEM_TYPE_PEERSTATE:
-      if (!add_to_dict(dict, "old-state", get_peerstate_pystr(self->elem->old_state)) ||
-          !add_to_dict(dict, "new-state", get_peerstate_pystr(self->elem->new_state))) {
+      if (add_to_dict(dict, "old-state", get_peerstate_pystr(self->elem->old_state)) ||
+          add_to_dict(dict, "new-state", get_peerstate_pystr(self->elem->new_state))) {
         return NULL;
       }
       break;

--- a/pybgpstream/src/_pybgpstream_bgpelem.c
+++ b/pybgpstream/src/_pybgpstream_bgpelem.c
@@ -30,17 +30,6 @@
 
 #define BGPElemDocstring "BGPElem object"
 
-#define ADD_STR_TO_DICT(key_str, value_exp)             \
-  do {                                                  \
-    PyObject *key = PYSTR_FROMSTR(key_str);       \
-    PyObject *value = (value_exp);                      \
-    if(PyDict_SetItem(dict, key, value) == -1)          \
-      return NULL;                                      \
-    Py_DECREF(key);                                     \
-    Py_DECREF(value);                                   \
-  }                                                     \
-  while(0)
-
 static PyObject *
 get_ip_pystr(bgpstream_ip_addr_t *ip) {
   char ip_str[INET6_ADDRSTRLEN] = "";
@@ -86,8 +75,10 @@ get_communities_pylist(bgpstream_community_set_t *communities) {
       if((dict = PyDict_New()) == NULL)
         return NULL;
       /* add pair to dictionary */
-      ADD_STR_TO_DICT("asn", Py_BuildValue("k", c->asn));
-      ADD_STR_TO_DICT("value", Py_BuildValue("k", c->value));
+      if (!add_to_dict(dict, "asn", Py_BuildValue("k", c->asn)) ||
+          !add_to_dict(dict, "value", Py_BuildValue("k", c->value))) {
+        return NULL;
+      }
 
       /* add dictionary to list*/
       PyList_SetItem(list, (Py_ssize_t)i, dict);
@@ -165,30 +156,25 @@ BGPElem_get_fields(BGPElemObject *self, void *closure)
     {
     case BGPSTREAM_ELEM_TYPE_RIB:
     case BGPSTREAM_ELEM_TYPE_ANNOUNCEMENT:
-      /* next hop */
-      ADD_STR_TO_DICT("next-hop",
-                  get_ip_pystr((bgpstream_ip_addr_t *)&self->elem->nexthop));
-
-      /* as path */
-      ADD_STR_TO_DICT("as-path", get_aspath_pystr(self->elem->aspath));
-
-      /* communities */
-      ADD_STR_TO_DICT("communities", get_communities_pylist(self->elem->communities));
+      if (!add_to_dict(dict, "next-hop", get_ip_pystr((bgpstream_ip_addr_t *)&self->elem->nexthop)) ||
+          !add_to_dict(dict, "as-path", get_aspath_pystr(self->elem->aspath)) ||
+          !add_to_dict(dict, "communities", get_communities_pylist(self->elem->communities))) {
+        return NULL;
+      }
 
       /* FALLTHROUGH */
 
     case BGPSTREAM_ELEM_TYPE_WITHDRAWAL:
-      /* prefix */
-      ADD_STR_TO_DICT("prefix",
-                  get_pfx_pystr((bgpstream_pfx_t *)&self->elem->prefix));
+      if (!add_to_dict(dict, "prefix", get_pfx_pystr((bgpstream_pfx_t *)&self->elem->prefix))) {
+        return NULL;
+      }
       break;
 
     case BGPSTREAM_ELEM_TYPE_PEERSTATE:
-      /* old state */
-      ADD_STR_TO_DICT("old-state", get_peerstate_pystr(self->elem->old_state));
-
-      /* new state */
-      ADD_STR_TO_DICT("new-state", get_peerstate_pystr(self->elem->new_state));
+      if (!add_to_dict(dict, "old-state", get_peerstate_pystr(self->elem->old_state)) ||
+          !add_to_dict(dict, "new-state", get_peerstate_pystr(self->elem->new_state))) {
+        return NULL;
+      }
       break;
 
     case BGPSTREAM_ELEM_TYPE_UNKNOWN:

--- a/pybgpstream/src/_pybgpstream_bgpstream.c
+++ b/pybgpstream/src/_pybgpstream_bgpstream.c
@@ -186,12 +186,11 @@ BGPStream_get_data_interfaces(BGPStreamObject *self)
 
     /* add info to dict */
 
-    if (!add_to_dict(dict, "id", PYNUM_FROMLONG(ids[i])) ||
-        !add_to_dict(dict, "name", PYSTR_FROMSTR(info->name)) ||
-        !add_to_dict(dict, "description", PYSTR_FROMSTR(info->description))) {
+    if (add_to_dict(dict, "id", PYNUM_FROMLONG(ids[i])) ||
+        add_to_dict(dict, "name", PYSTR_FROMSTR(info->name)) ||
+        add_to_dict(dict, "description", PYSTR_FROMSTR(info->description))) {
         return NULL;
     }
-
 
     /* add dict to list */
     if(PyList_Append(list, dict) == -1)
@@ -253,8 +252,8 @@ BGPStream_get_data_interface_options(BGPStreamObject *self, PyObject *args)
     if((dict = PyDict_New()) == NULL)
       return NULL;
 
-    if (!add_to_dict(dict, "name", PYSTR_FROMSTR(options[i].name)) || 
-        !add_to_dict(dict, "description", PYSTR_FROMSTR(options[i].description))) {
+    if (add_to_dict(dict, "name", PYSTR_FROMSTR(options[i].name)) || 
+        add_to_dict(dict, "description", PYSTR_FROMSTR(options[i].description))) {
         return NULL;
     }
 

--- a/pybgpstream/src/_pybgpstream_bgpstream.c
+++ b/pybgpstream/src/_pybgpstream_bgpstream.c
@@ -155,17 +155,6 @@ BGPStream_add_interval_filter(BGPStreamObject *self, PyObject *args)
   Py_RETURN_NONE;
 }
 
-#define ADD_TO_DICT(key_str, value_exp)                 \
-  do {                                                  \
-    PyObject *key = PYSTR_FROMSTR(key_str);				\
-    PyObject *value = (value_exp);                      \
-    if(PyDict_SetItem(dict, key, value) == -1)          \
-      return NULL;                                      \
-    Py_DECREF(key);                                     \
-    Py_DECREF(value);                                   \
-  }                                                     \
-  while(0)
-
 /** Get information about available data interfaces */
 static PyObject *
 BGPStream_get_data_interfaces(BGPStreamObject *self)
@@ -197,18 +186,12 @@ BGPStream_get_data_interfaces(BGPStreamObject *self)
 
     /* add info to dict */
 
-    /* id */
-#if PY_MAJOR_VERSION > 2
-    ADD_TO_DICT("id", PyLong_FromLong(ids[i]));
-#else
-    ADD_TO_DICT("id", PyInt_FromLong(ids[i]));
-#endif
+    if (!add_to_dict(dict, "id", PYNUM_FROMLONG(ids[i])) ||
+        !add_to_dict(dict, "name", PYSTR_FROMSTR(info->name)) ||
+        !add_to_dict(dict, "description", PYSTR_FROMSTR(info->description))) {
+        return NULL;
+    }
 
-    /* name */
-    ADD_TO_DICT("name", PYSTR_FROMSTR(info->name));
-
-    /* description */
-    ADD_TO_DICT("description", PYSTR_FROMSTR(info->description));
 
     /* add dict to list */
     if(PyList_Append(list, dict) == -1)
@@ -270,11 +253,10 @@ BGPStream_get_data_interface_options(BGPStreamObject *self, PyObject *args)
     if((dict = PyDict_New()) == NULL)
       return NULL;
 
-    /* name */
-    ADD_TO_DICT("name", PYSTR_FROMSTR(options[i].name));
-
-    /* description */
-    ADD_TO_DICT("description", PYSTR_FROMSTR(options[i].description));
+    if (!add_to_dict(dict, "name", PYSTR_FROMSTR(options[i].name)) || 
+        !add_to_dict(dict, "description", PYSTR_FROMSTR(options[i].description))) {
+        return NULL;
+    }
 
     /* add dict to list */
     if(PyList_Append(list, dict) == -1)

--- a/pybgpstream/src/pyutils.h
+++ b/pybgpstream/src/pyutils.h
@@ -18,8 +18,23 @@
 
 #if PY_MAJOR_VERSION > 2
 #define PYSTR_FROMSTR(str) PyUnicode_FromString(str)
+#define PYNUM_FROMLONG(num) PyLong_FromLong(num)
 #else
 #define PYSTR_FROMSTR(str) PyString_FromString(str)
+#define PYNUM_FROMLONG(num) PyInt_FromLong(num)
 #endif
+
+#include <stdbool.h>
+
+static inline bool
+add_to_dict(PyObject* dict, const char* key_str, PyObject* value)
+{
+    PyObject *key = PYSTR_FROMSTR(key_str);
+    if(PyDict_SetItem(dict, key, value) == -1)
+      return false;
+    Py_DECREF(key);
+    Py_DECREF(value);
+    return true;
+}
 
 #endif

--- a/pybgpstream/src/pyutils.h
+++ b/pybgpstream/src/pyutils.h
@@ -30,11 +30,10 @@ static inline bool
 add_to_dict(PyObject* dict, const char* key_str, PyObject* value)
 {
     PyObject *key = PYSTR_FROMSTR(key_str);
-    if(PyDict_SetItem(dict, key, value) == -1)
-      return false;
+    int err = PyDict_SetItem(dict, key, value);
     Py_DECREF(key);
     Py_DECREF(value);
-    return true;
+    return err == 0;
 }
 
 #endif

--- a/pybgpstream/src/pyutils.h
+++ b/pybgpstream/src/pyutils.h
@@ -24,16 +24,14 @@
 #define PYNUM_FROMLONG(num) PyInt_FromLong(num)
 #endif
 
-#include <stdbool.h>
-
-static inline bool
+static inline int
 add_to_dict(PyObject* dict, const char* key_str, PyObject* value)
 {
     PyObject *key = PYSTR_FROMSTR(key_str);
     int err = PyDict_SetItem(dict, key, value);
     Py_DECREF(key);
     Py_DECREF(value);
-    return err == 0;
+    return err;
 }
 
 #endif


### PR DESCRIPTION
Enjoying toying around with this new library! 

Just a small change here in this pr to fix a possible leak.  Hiding a return inside of a do-while macro is a recipe for danger, as evidenced by the potential memory leak hidden in ADD_TO_DICT. Regardless of whether we fail to SetItem, we should be decrementing the key and values to avoid leaking them.