### PR TITLE
Make code style consistent

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,98 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Linux
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories:
+  - Regex:           '^".+_int'
+    Priority:        1
+  - Regex:           '^"(bgpstream|bgpdump|bgpcorsaro)'
+    Priority:        2
+  - Regex:           '^"config'
+    Priority:        3
+  - Regex:           '^(<|")(utils|wandio_util|khash)'
+    Priority:        4
+  - Regex:           '^"'
+    Priority:        5
+  - Regex:           '^<'
+    Priority:        6
+IndentCaseLabels: false
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never
+JavaScriptQuotes: Leave
+...

--- a/Makefile.am
+++ b/Makefile.am
@@ -43,3 +43,9 @@ include_HEADERS =
 ACLOCAL_AMFLAGS = -I m4
 
 CLEANFILES = *~
+
+format:
+	find . -type f -name "*.[ch]" -not -path "./common/*" -exec \
+		clang-format -style=file -i {} \;
+
+.PHONY: format

--- a/bgpcorsaro/lib/bgpcorsaro.c
+++ b/bgpcorsaro/lib/bgpcorsaro.c
@@ -20,8 +20,8 @@
  * You should have received a copy of the GNU General Public License along with
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "config.h"
 #include "bgpcorsaro_int.h"
+#include "config.h"
 
 #include <assert.h>
 #include <inttypes.h>
@@ -46,13 +46,11 @@ static bgpcorsaro_record_t *bgpcorsaro_record_alloc(bgpcorsaro_t *bgpcorsaro)
 {
   bgpcorsaro_record_t *rec;
 
-  if((rec = malloc_zero(sizeof(bgpcorsaro_record_t))) == NULL)
-    {
-      bgpcorsaro_log(__func__, bgpcorsaro,
-		     "could not malloc bgpcorsaro_record");
-      return NULL;
-    }
-  
+  if ((rec = malloc_zero(sizeof(bgpcorsaro_record_t))) == NULL) {
+    bgpcorsaro_log(__func__, bgpcorsaro, "could not malloc bgpcorsaro_record");
+    return NULL;
+  }
+
   /* this bgpcorsaro record still needs a bgpstream record to be loaded... */
   return rec;
 }
@@ -75,10 +73,9 @@ static inline void bgpcorsaro_record_state_reset(bgpcorsaro_record_t *record)
 static void bgpcorsaro_record_free(bgpcorsaro_record_t *record)
 {
   /* we will assume that somebody else is taking care of the bgpstream record */
-  if(record != NULL)
-    {
-      free(record);
-    }
+  if (record != NULL) {
+    free(record);
+  }
 }
 
 /** Cleanup and free the given bgpcorsaro instance */
@@ -86,42 +83,37 @@ static void bgpcorsaro_free(bgpcorsaro_t *bgpcorsaro)
 {
   bgpcorsaro_plugin_t *p = NULL;
 
-  if(bgpcorsaro == NULL)
-    {
-      /* nothing to be done... */
-      return;
-    }
+  if (bgpcorsaro == NULL) {
+    /* nothing to be done... */
+    return;
+  }
 
   /* free up the plugins first, they may try and use some of our info before
      closing */
-  if(bgpcorsaro->plugin_manager != NULL)
-    {
-      while((p = bgpcorsaro_plugin_next(bgpcorsaro->plugin_manager, p)) != NULL)
-	{
-	  p->close_output(bgpcorsaro);
-	}
-
-      bgpcorsaro_plugin_manager_free(bgpcorsaro->plugin_manager);
-      bgpcorsaro->plugin_manager = NULL;
+  if (bgpcorsaro->plugin_manager != NULL) {
+    while ((p = bgpcorsaro_plugin_next(bgpcorsaro->plugin_manager, p)) !=
+           NULL) {
+      p->close_output(bgpcorsaro);
     }
 
-  if(bgpcorsaro->monitorname != NULL)
-    {
-      free(bgpcorsaro->monitorname);
-      bgpcorsaro->monitorname = NULL;
-    }
+    bgpcorsaro_plugin_manager_free(bgpcorsaro->plugin_manager);
+    bgpcorsaro->plugin_manager = NULL;
+  }
 
-  if(bgpcorsaro->template != NULL)
-    {
-      free(bgpcorsaro->template);
-      bgpcorsaro->template = NULL;
-    }
+  if (bgpcorsaro->monitorname != NULL) {
+    free(bgpcorsaro->monitorname);
+    bgpcorsaro->monitorname = NULL;
+  }
 
-  if(bgpcorsaro->record != NULL)
-    {
-      bgpcorsaro_record_free(bgpcorsaro->record);
-      bgpcorsaro->record = NULL;
-    }
+  if (bgpcorsaro->template != NULL) {
+    free(bgpcorsaro->template);
+    bgpcorsaro->template = NULL;
+  }
+
+  if (bgpcorsaro->record != NULL) {
+    bgpcorsaro_record_free(bgpcorsaro->record);
+    bgpcorsaro->record = NULL;
+  }
 
   /* close this as late as possible */
   bgpcorsaro_log_close(bgpcorsaro);
@@ -133,8 +125,7 @@ static void bgpcorsaro_free(bgpcorsaro_t *bgpcorsaro)
 
 /** Fill the given interval object with the default values */
 static inline void populate_interval(bgpcorsaro_interval_t *interval,
-				     uint32_t number,
-				     uint32_t time)
+                                     uint32_t number, uint32_t time)
 {
   interval->number = number;
   interval->time = time;
@@ -145,20 +136,16 @@ static int is_meta_rotate_interval(bgpcorsaro_t *bgpcorsaro)
 {
   assert(bgpcorsaro != NULL);
 
-  if(bgpcorsaro->meta_output_rotate < 0)
-    {
-      return bgpcorsaro_is_rotate_interval(bgpcorsaro);
-    }
-  else if(bgpcorsaro->meta_output_rotate > 0 &&
-	  (bgpcorsaro->interval_start.number+1) %
-	  bgpcorsaro->meta_output_rotate == 0)
-    {
-      return 1;
-    }
-  else
-    {
-      return 0;
-    }
+  if (bgpcorsaro->meta_output_rotate < 0) {
+    return bgpcorsaro_is_rotate_interval(bgpcorsaro);
+  } else if (bgpcorsaro->meta_output_rotate > 0 &&
+             (bgpcorsaro->interval_start.number + 1) %
+                 bgpcorsaro->meta_output_rotate ==
+               0) {
+    return 1;
+  } else {
+    return 0;
+  }
 }
 
 /** Initialize a new bgpcorsaro object */
@@ -166,11 +153,10 @@ static bgpcorsaro_t *bgpcorsaro_init(char *template)
 {
   bgpcorsaro_t *e;
 
-  if((e = malloc_zero(sizeof(bgpcorsaro_t))) == NULL)
-    {
-      bgpcorsaro_log(__func__, NULL, "could not malloc bgpcorsaro_t");
-      return NULL;
-    }
+  if ((e = malloc_zero(sizeof(bgpcorsaro_t))) == NULL) {
+    bgpcorsaro_log(__func__, NULL, "could not malloc bgpcorsaro_t");
+    return NULL;
+  }
 
   /* what time is it? */
   gettimeofday_wrap(&e->init_time);
@@ -181,17 +167,14 @@ static bgpcorsaro_t *bgpcorsaro_init(char *template)
 
   /* template does, however */
   /* check that it is valid */
-  if(bgpcorsaro_io_validate_template(e, template) == 0)
-    {
-      bgpcorsaro_log(__func__, e, "invalid template %s", template);
-      goto err;
-    }
-  if((e->template = strdup(template)) == NULL)
-    {
-      bgpcorsaro_log(__func__, e,
-		"could not duplicate template string");
-      goto err;
-    }
+  if (bgpcorsaro_io_validate_template(e, template) == 0) {
+    bgpcorsaro_log(__func__, e, "invalid template %s", template);
+    goto err;
+  }
+  if ((e->template = strdup(template)) == NULL) {
+    bgpcorsaro_log(__func__, e, "could not duplicate template string");
+    goto err;
+  }
 
   /* check if compression should be used based on the file name */
   e->compress = wandio_detect_compression_type(e->template);
@@ -200,21 +183,20 @@ static bgpcorsaro_t *bgpcorsaro_init(char *template)
   e->compress_level = 6;
 
   /* lets get us a wrapper record ready */
-  if((e->record = bgpcorsaro_record_alloc(e)) == NULL)
-    {
-      bgpcorsaro_log(__func__, e, "could not create bgpcorsaro record");
-      goto err;
-    }
+  if ((e->record = bgpcorsaro_record_alloc(e)) == NULL) {
+    bgpcorsaro_log(__func__, e, "could not create bgpcorsaro record");
+    goto err;
+  }
 
   /* ask the plugin manager to get us some plugins */
   /* this will init all compiled plugins but not start them, this gives
      us a chance to wait for the user to choose a subset to enable
      with bgpcorsaro_enable_plugin and then we'll re-init */
-  if((e->plugin_manager = bgpcorsaro_plugin_manager_init(e->logfile)) == NULL)
-    {
-      bgpcorsaro_log(__func__, e, "could not initialize plugin manager");
-      goto err;
-    }
+  if ((e->plugin_manager = bgpcorsaro_plugin_manager_init(e->logfile)) ==
+      NULL) {
+    bgpcorsaro_log(__func__, e, "could not initialize plugin manager");
+    goto err;
+  }
 
   /* set the default interval alignment value */
   e->interval_align = BGPCORSARO_INTERVAL_ALIGN_DEFAULT;
@@ -234,7 +216,7 @@ static bgpcorsaro_t *bgpcorsaro_init(char *template)
 
   return e;
 
- err:
+err:
   /* 02/26/13 - ak comments because it is up to the user to call
      bgpcorsaro_finalize_output to free the memory */
   /*bgpcorsaro_free(e);*/
@@ -252,49 +234,43 @@ static int start_interval(bgpcorsaro_t *bgpcorsaro, long int_start)
 
   /* the following is to support file rotation */
   /* initialize the log file */
-  if(bgpcorsaro->logfile_disabled == 0 && bgpcorsaro->logfile == NULL)
-    {
-      /* if this is the first interval, let them know we are switching to
-	 logging to a file */
-      if(bgpcorsaro->interval_start.number == 0)
-	{
-	  /* there is a replica of this message in the other place that
-	   * bgpcorsaro_log_init is called */
-	  bgpcorsaro_log(
-		      __func__, bgpcorsaro, "now logging to file"
+  if (bgpcorsaro->logfile_disabled == 0 && bgpcorsaro->logfile == NULL) {
+    /* if this is the first interval, let them know we are switching to
+       logging to a file */
+    if (bgpcorsaro->interval_start.number == 0) {
+      /* there is a replica of this message in the other place that
+       * bgpcorsaro_log_init is called */
+      bgpcorsaro_log(__func__, bgpcorsaro, "now logging to file"
 #ifdef DEBUG
-		      " (and stderr)"
+                                           " (and stderr)"
 #endif
-		      );
-	}
-
-      if(bgpcorsaro_log_init(bgpcorsaro) != 0)
-	{
-	  bgpcorsaro_log(__func__, bgpcorsaro, "could not initialize log file");
-	  bgpcorsaro_free(bgpcorsaro);
-	  return -1;
-	}
+                     );
     }
+
+    if (bgpcorsaro_log_init(bgpcorsaro) != 0) {
+      bgpcorsaro_log(__func__, bgpcorsaro, "could not initialize log file");
+      bgpcorsaro_free(bgpcorsaro);
+      return -1;
+    }
+  }
 
   /* ask each plugin to start a new interval */
   /* plugins should rotate their files now too */
-  while((tmp = bgpcorsaro_plugin_next(bgpcorsaro->plugin_manager, tmp)) != NULL)
-    {
+  while ((tmp = bgpcorsaro_plugin_next(bgpcorsaro->plugin_manager, tmp)) !=
+         NULL) {
 #ifdef WITH_PLUGIN_TIMING
-      TIMER_START(start_interval);
+    TIMER_START(start_interval);
 #endif
-      if(tmp->start_interval(bgpcorsaro, &bgpcorsaro->interval_start) != 0)
-	{
-	  bgpcorsaro_log(__func__, bgpcorsaro,
-			 "%s failed to start interval at %ld",
-			 tmp->name, int_start);
-	  return -1;
-	}
-#ifdef WITH_PLUGIN_TIMING
-      TIMER_END(start_interval);
-      tmp->start_interval_usec += TIMER_VAL(start_interval);
-#endif
+    if (tmp->start_interval(bgpcorsaro, &bgpcorsaro->interval_start) != 0) {
+      bgpcorsaro_log(__func__, bgpcorsaro, "%s failed to start interval at %ld",
+                     tmp->name, int_start);
+      return -1;
     }
+#ifdef WITH_PLUGIN_TIMING
+    TIMER_END(start_interval);
+    tmp->start_interval_usec += TIMER_VAL(start_interval);
+#endif
+  }
   return 0;
 }
 
@@ -308,34 +284,31 @@ static int end_interval(bgpcorsaro_t *bgpcorsaro, long int_end)
   populate_interval(&interval_end, bgpcorsaro->interval_start.number, int_end);
 
   /* ask each plugin to end the current interval */
-  while((tmp = bgpcorsaro_plugin_next(bgpcorsaro->plugin_manager, tmp)) != NULL)
-    {
+  while ((tmp = bgpcorsaro_plugin_next(bgpcorsaro->plugin_manager, tmp)) !=
+         NULL) {
 #ifdef WITH_PLUGIN_TIMING
-      TIMER_START(end_interval);
+    TIMER_START(end_interval);
 #endif
-      if(tmp->end_interval(bgpcorsaro, &interval_end) != 0)
-	{
-	  bgpcorsaro_log(__func__, bgpcorsaro, "%s failed to end interval at %ld",
-		    tmp->name, int_end);
-	  return -1;
-	}
-#ifdef WITH_PLUGIN_TIMING
-      TIMER_END(end_interval);
-      tmp->end_interval_usec += TIMER_VAL(end_interval);
-#endif
+    if (tmp->end_interval(bgpcorsaro, &interval_end) != 0) {
+      bgpcorsaro_log(__func__, bgpcorsaro, "%s failed to end interval at %ld",
+                     tmp->name, int_end);
+      return -1;
     }
+#ifdef WITH_PLUGIN_TIMING
+    TIMER_END(end_interval);
+    tmp->end_interval_usec += TIMER_VAL(end_interval);
+#endif
+  }
 
   /* if we are rotating, now is the time to close our output files */
-  if(is_meta_rotate_interval(bgpcorsaro))
-    {
-      /* this MUST be the last thing closed in case any of the other things want
-	 to log their end-of-interval activities (e.g. the pkt cnt from writing
-	 the trailers */
-      if(bgpcorsaro->logfile != NULL)
-	{
-	  bgpcorsaro_log_close(bgpcorsaro);
-	}
+  if (is_meta_rotate_interval(bgpcorsaro)) {
+    /* this MUST be the last thing closed in case any of the other things want
+       to log their end-of-interval activities (e.g. the pkt cnt from writing
+       the trailers */
+    if (bgpcorsaro->logfile != NULL) {
+      bgpcorsaro_log_close(bgpcorsaro);
     }
+  }
 
   bgpcorsaro->interval_end_needed = 0;
   return 0;
@@ -343,25 +316,24 @@ static int end_interval(bgpcorsaro_t *bgpcorsaro, long int_end)
 
 /** Process the given bgpcorsaro record */
 static inline int process_record(bgpcorsaro_t *bgpcorsaro,
-				 bgpcorsaro_record_t *record)
+                                 bgpcorsaro_record_t *record)
 {
   bgpcorsaro_plugin_t *tmp = NULL;
-  while((tmp = bgpcorsaro_plugin_next(bgpcorsaro->plugin_manager, tmp)) != NULL)
-    {
+  while ((tmp = bgpcorsaro_plugin_next(bgpcorsaro->plugin_manager, tmp)) !=
+         NULL) {
 #ifdef WITH_PLUGIN_TIMING
-      TIMER_START(process_record);
+    TIMER_START(process_record);
 #endif
-      if(tmp->process_record(bgpcorsaro, record) < 0)
-	{
-	  bgpcorsaro_log(__func__, bgpcorsaro, "%s failed to process record",
-		    tmp->name);
-	  return -1;
-	}
-#ifdef WITH_PLUGIN_TIMING
-      TIMER_END(process_record);
-      tmp->process_record_usec += TIMER_VAL(process_record);
-#endif
+    if (tmp->process_record(bgpcorsaro, record) < 0) {
+      bgpcorsaro_log(__func__, bgpcorsaro, "%s failed to process record",
+                     tmp->name);
+      return -1;
     }
+#ifdef WITH_PLUGIN_TIMING
+    TIMER_END(process_record);
+    tmp->process_record_usec += TIMER_VAL(process_record);
+#endif
+  }
   return 0;
 }
 
@@ -372,18 +344,16 @@ bgpcorsaro_t *bgpcorsaro_alloc_output(char *template)
   bgpcorsaro_t *bgpcorsaro;
 
   /* quick sanity check that folks aren't trying to write to stdout */
-  if(template == NULL || strcmp(template, "-") == 0)
-    {
-      bgpcorsaro_log(__func__, NULL, "writing to stdout not supported");
-      return NULL;
-    }
+  if (template == NULL || strcmp(template, "-") == 0) {
+    bgpcorsaro_log(__func__, NULL, "writing to stdout not supported");
+    return NULL;
+  }
 
   /* initialize the bgpcorsaro object */
-  if((bgpcorsaro = bgpcorsaro_init(template)) == NULL)
-    {
-      bgpcorsaro_log(__func__, NULL, "could not initialize bgpcorsaro object");
-      return NULL;
-    }
+  if ((bgpcorsaro = bgpcorsaro_init(template)) == NULL) {
+    bgpcorsaro_log(__func__, NULL, "could not initialize bgpcorsaro object");
+    return NULL;
+  }
 
   /* 10/17/13 AK moves logging init to bgpcorsaro_start_output so that the user
      may call bgpcorsaro_disable_logfile after alloc */
@@ -403,46 +373,41 @@ int bgpcorsaro_start_output(bgpcorsaro_t *bgpcorsaro)
      messages will not be logged to a file. In fact nothing will be logged until
      the first record is received. */
   assert(bgpcorsaro->logfile == NULL);
-  if(bgpcorsaro->logfile_disabled == 0 &&
-     bgpcorsaro_io_template_has_timestamp(bgpcorsaro) == 0)
-    {
-      bgpcorsaro_log( __func__, bgpcorsaro, "now logging to file"
+  if (bgpcorsaro->logfile_disabled == 0 &&
+      bgpcorsaro_io_template_has_timestamp(bgpcorsaro) == 0) {
+    bgpcorsaro_log(__func__, bgpcorsaro, "now logging to file"
 #ifdef DEBUG
-		      " (and stderr)"
+                                         " (and stderr)"
 #endif
-		      );
+                   );
 
-      if(bgpcorsaro_log_init(bgpcorsaro) != 0)
-	{
-	  return -1;
-	}
+    if (bgpcorsaro_log_init(bgpcorsaro) != 0) {
+      return -1;
     }
+  }
 
   /* ask the plugin manager to start up */
   /* this allows it to remove disabled plugins */
-  if(bgpcorsaro_plugin_manager_start(bgpcorsaro->plugin_manager) != 0)
-    {
-      bgpcorsaro_log(__func__, bgpcorsaro, "could not start plugin manager");
-      return -1;
-    }
+  if (bgpcorsaro_plugin_manager_start(bgpcorsaro->plugin_manager) != 0) {
+    bgpcorsaro_log(__func__, bgpcorsaro, "could not start plugin manager");
+    return -1;
+  }
 
   /* now, ask each plugin to open its output file */
   /* we need to do this here so that the bgpcorsaro object is fully set up
      that is, the traceuri etc is set */
-  while((p = bgpcorsaro_plugin_next(bgpcorsaro->plugin_manager, p)) != NULL)
-    {
+  while ((p = bgpcorsaro_plugin_next(bgpcorsaro->plugin_manager, p)) != NULL) {
 #ifdef WITH_PLUGIN_TIMING
-      TIMER_START(init_output);
+    TIMER_START(init_output);
 #endif
-      if(p->init_output(bgpcorsaro) != 0)
-	{
-	  return -1;
-	}
-#ifdef WITH_PLUGIN_TIMING
-      TIMER_END(init_output);
-      p->init_output_usec += TIMER_VAL(init_output);
-#endif
+    if (p->init_output(bgpcorsaro) != 0) {
+      return -1;
     }
+#ifdef WITH_PLUGIN_TIMING
+    TIMER_END(init_output);
+    p->init_output_usec += TIMER_VAL(init_output);
+#endif
+  }
 
   bgpcorsaro->started = 1;
 
@@ -450,14 +415,14 @@ int bgpcorsaro_start_output(bgpcorsaro_t *bgpcorsaro)
 }
 
 void bgpcorsaro_set_interval_alignment(bgpcorsaro_t *bgpcorsaro,
-				       bgpcorsaro_interval_align_t align)
+                                       bgpcorsaro_interval_align_t align)
 {
   assert(bgpcorsaro != NULL);
   /* you cant set interval alignment once bgpcorsaro has started */
   assert(bgpcorsaro->started == 0);
 
   bgpcorsaro_log(__func__, bgpcorsaro, "setting interval alignment to %d",
-	      align);
+                 align);
 
   bgpcorsaro->interval_align = align;
 }
@@ -468,49 +433,45 @@ void bgpcorsaro_set_interval(bgpcorsaro_t *bgpcorsaro, unsigned int i)
   /* you can't set the interval once bgpcorsaro has been started */
   assert(bgpcorsaro->started == 0);
 
-  bgpcorsaro_log(__func__, bgpcorsaro, "setting interval length to %d",
-	      i);
+  bgpcorsaro_log(__func__, bgpcorsaro, "setting interval length to %d", i);
 
   bgpcorsaro->interval = i;
 }
 
-void bgpcorsaro_set_output_rotation(bgpcorsaro_t *bgpcorsaro,
-				    int intervals)
+void bgpcorsaro_set_output_rotation(bgpcorsaro_t *bgpcorsaro, int intervals)
 {
   assert(bgpcorsaro != NULL);
   /* you can't enable rotation once bgpcorsaro has been started */
   assert(bgpcorsaro->started == 0);
 
   bgpcorsaro_log(__func__, bgpcorsaro,
-	      "setting output rotation after %d interval(s)",
-	      intervals);
+                 "setting output rotation after %d interval(s)", intervals);
 
   /* if they have asked to rotate, but did not put a timestamp in the template,
    * we will end up clobbering files. warn them. */
-  if(bgpcorsaro_io_template_has_timestamp(bgpcorsaro) == 0)
-    {
-      /* we skip the log and write directly out so that it is clear even if they
-       * have debugging turned off */
-      fprintf(stderr, "WARNING: using output rotation without any timestamp "
-	      "specifiers in the template.\n");
-      fprintf(stderr,
-	      "WARNING: output files will be overwritten upon rotation\n");
-      /* @todo consider making this a fatal error */
-    }
+  if (bgpcorsaro_io_template_has_timestamp(bgpcorsaro) == 0) {
+    /* we skip the log and write directly out so that it is clear even if they
+     * have debugging turned off */
+    fprintf(stderr, "WARNING: using output rotation without any timestamp "
+                    "specifiers in the template.\n");
+    fprintf(stderr,
+            "WARNING: output files will be overwritten upon rotation\n");
+    /* @todo consider making this a fatal error */
+  }
 
   bgpcorsaro->output_rotate = intervals;
 }
 
 void bgpcorsaro_set_meta_output_rotation(bgpcorsaro_t *bgpcorsaro,
-					 int intervals)
+                                         int intervals)
 {
   assert(bgpcorsaro != NULL);
   /* you can't enable rotation once bgpcorsaro has been started */
   assert(bgpcorsaro->started == 0);
 
   bgpcorsaro_log(__func__, bgpcorsaro,
-	      "setting meta output rotation after %d intervals(s)",
-	      intervals);
+                 "setting meta output rotation after %d intervals(s)",
+                 intervals);
 
   bgpcorsaro->meta_output_rotate = intervals;
 }
@@ -519,18 +480,15 @@ int bgpcorsaro_is_rotate_interval(bgpcorsaro_t *bgpcorsaro)
 {
   assert(bgpcorsaro != NULL);
 
-  if(bgpcorsaro->output_rotate == 0)
-    {
-      return 0;
-    }
-  else if((bgpcorsaro->interval_start.number+1) % bgpcorsaro->output_rotate == 0)
-    {
-      return 1;
-    }
-  else
-    {
-      return 0;
-    }
+  if (bgpcorsaro->output_rotate == 0) {
+    return 0;
+  } else if ((bgpcorsaro->interval_start.number + 1) %
+               bgpcorsaro->output_rotate ==
+             0) {
+    return 1;
+  } else {
+    return 0;
+  }
 }
 
 int bgpcorsaro_set_stream(bgpcorsaro_t *bgpcorsaro, bgpstream_t *stream)
@@ -538,14 +496,11 @@ int bgpcorsaro_set_stream(bgpcorsaro_t *bgpcorsaro, bgpstream_t *stream)
   assert(bgpcorsaro != NULL);
 
   /* this function can actually be called once bgpcorsaro is started */
-  if(bgpcorsaro->stream != NULL)
-    {
-      bgpcorsaro_log(__func__, bgpcorsaro, "updating stream pointer");
-    }
-  else
-    {
-      bgpcorsaro_log(__func__, bgpcorsaro, "setting stream pointer");
-    }
+  if (bgpcorsaro->stream != NULL) {
+    bgpcorsaro_log(__func__, bgpcorsaro, "updating stream pointer");
+  } else {
+    bgpcorsaro_log(__func__, bgpcorsaro, "setting stream pointer");
+  }
 
   bgpcorsaro->stream = stream;
   return 0;
@@ -558,13 +513,13 @@ void bgpcorsaro_disable_logfile(bgpcorsaro_t *bgpcorsaro)
 }
 
 int bgpcorsaro_enable_plugin(bgpcorsaro_t *bgpcorsaro, const char *plugin_name,
-			  const char *plugin_args)
+                             const char *plugin_args)
 {
   assert(bgpcorsaro != NULL);
   assert(bgpcorsaro->plugin_manager != NULL);
 
   return bgpcorsaro_plugin_enable_plugin(bgpcorsaro->plugin_manager,
-					 plugin_name, plugin_args);
+                                         plugin_name, plugin_args);
 }
 
 int bgpcorsaro_get_plugin_names(char ***plugin_names)
@@ -579,22 +534,19 @@ int bgpcorsaro_get_plugin_names(char ***plugin_names)
   char **names = NULL;
   bgpcorsaro_plugin_t *tmp = NULL;
   bgpcorsaro_plugin_manager_t *tmp_manager = NULL;
-  if((tmp_manager = bgpcorsaro_plugin_manager_init(NULL)) == NULL)
-    {
-      return -1;
-    }
+  if ((tmp_manager = bgpcorsaro_plugin_manager_init(NULL)) == NULL) {
+    return -1;
+  }
 
   /* initialize the array of char pointers */
-  if((names = malloc(sizeof(char *) * tmp_manager->plugins_cnt)) == NULL)
-    {
-      return -1;
-    }
+  if ((names = malloc(sizeof(char *) * tmp_manager->plugins_cnt)) == NULL) {
+    return -1;
+  }
 
-  while((tmp = bgpcorsaro_plugin_next(tmp_manager, tmp)) != NULL)
-    {
-      names[i] = strdup(tmp->name);
-      i++;
-    }
+  while ((tmp = bgpcorsaro_plugin_next(tmp_manager, tmp)) != NULL) {
+    names[i] = strdup(tmp->name);
+    i++;
+  }
 
   bgpcorsaro_plugin_manager_free(tmp_manager);
 
@@ -605,18 +557,15 @@ int bgpcorsaro_get_plugin_names(char ***plugin_names)
 void bgpcorsaro_free_plugin_names(char **plugin_names, int plugin_cnt)
 {
   int i;
-  if(plugin_names == NULL)
-    {
-      return;
+  if (plugin_names == NULL) {
+    return;
+  }
+  for (i = 0; i < plugin_cnt; i++) {
+    if (plugin_names[i] != NULL) {
+      free(plugin_names[i]);
     }
-  for(i = 0; i < plugin_cnt; i++)
-    {
-      if(plugin_names[i] != NULL)
-	{
-	  free(plugin_names[i]);
-	}
-      plugin_names[i] = NULL;
-    }
+    plugin_names[i] = NULL;
+  }
   free(plugin_names);
 }
 
@@ -624,32 +573,24 @@ int bgpcorsaro_set_monitorname(bgpcorsaro_t *bgpcorsaro, char *name)
 {
   assert(bgpcorsaro != NULL);
 
-  if(bgpcorsaro->started != 0)
-    {
-      bgpcorsaro_log(__func__, bgpcorsaro,
-		     "monitor name can only be set before "
-		     "bgpcorsaro_start_output is called");
-      return -1;
-    }
+  if (bgpcorsaro->started != 0) {
+    bgpcorsaro_log(__func__, bgpcorsaro, "monitor name can only be set before "
+                                         "bgpcorsaro_start_output is called");
+    return -1;
+  }
 
-  if(bgpcorsaro->monitorname != NULL)
-    {
-      bgpcorsaro_log(__func__, bgpcorsaro,
-		     "updating monitor name from %s to %s",
-		     bgpcorsaro->monitorname, name);
-    }
-  else
-    {
-      bgpcorsaro_log(__func__, bgpcorsaro, "setting monitor name to %s",
-		     name);
-    }
+  if (bgpcorsaro->monitorname != NULL) {
+    bgpcorsaro_log(__func__, bgpcorsaro, "updating monitor name from %s to %s",
+                   bgpcorsaro->monitorname, name);
+  } else {
+    bgpcorsaro_log(__func__, bgpcorsaro, "setting monitor name to %s", name);
+  }
 
-  if((bgpcorsaro->monitorname = strdup(name)) == NULL)
-    {
-      bgpcorsaro_log(__func__, bgpcorsaro,
-		     "could not duplicate monitor name string");
-      return -1;
-    }
+  if ((bgpcorsaro->monitorname = strdup(name)) == NULL) {
+    bgpcorsaro_log(__func__, bgpcorsaro,
+                   "could not duplicate monitor name string");
+    return -1;
+  }
   bgpcorsaro_log(__func__, bgpcorsaro, "%s", bgpcorsaro->monitorname);
   return 0;
 }
@@ -660,15 +601,15 @@ const char *bgpcorsaro_get_monitorname(bgpcorsaro_t *bgpcorsaro)
 }
 
 int bgpcorsaro_per_record(bgpcorsaro_t *bgpcorsaro,
-			  bgpstream_record_t *bsrecord)
+                          bgpstream_record_t *bsrecord)
 {
   long ts;
   long report;
 
   assert(bgpcorsaro != NULL);
   assert(bgpcorsaro->started == 1 &&
-	 "bgpcorsaro_start_output must be called before records can be "
-	 "processed");
+         "bgpcorsaro_start_output must be called before records can be "
+         "processed");
 
   /* poke this bsrecord into our bgpcorsaro record */
   bgpcorsaro->record->bsrecord = bsrecord;
@@ -686,57 +627,50 @@ int bgpcorsaro_per_record(bgpcorsaro_t *bgpcorsaro,
   bgpcorsaro->interval_end_needed = 1;
 
   /* if this is the first record we record, keep the timestamp */
-  if(bgpcorsaro->record_cnt == 0)
-    {
-      bgpcorsaro->first_ts = ts;
-      if(start_interval(bgpcorsaro, ts) != 0)
-	{
-	  bgpcorsaro_log(__func__, bgpcorsaro,
-			 "could not start interval at %ld", ts);
-	  return -1;
-	}
-
-      bgpcorsaro->next_report = ts + bgpcorsaro->interval;
-
-      /* if we are aligning our intervals, truncate the end down */
-      if(bgpcorsaro->interval_align == BGPCORSARO_INTERVAL_ALIGN_YES)
-	{
-	  bgpcorsaro->next_report =
-	    (bgpcorsaro->next_report/bgpcorsaro->interval)*bgpcorsaro->interval;
-	}
+  if (bgpcorsaro->record_cnt == 0) {
+    bgpcorsaro->first_ts = ts;
+    if (start_interval(bgpcorsaro, ts) != 0) {
+      bgpcorsaro_log(__func__, bgpcorsaro, "could not start interval at %ld",
+                     ts);
+      return -1;
     }
+
+    bgpcorsaro->next_report = ts + bgpcorsaro->interval;
+
+    /* if we are aligning our intervals, truncate the end down */
+    if (bgpcorsaro->interval_align == BGPCORSARO_INTERVAL_ALIGN_YES) {
+      bgpcorsaro->next_report =
+        (bgpcorsaro->next_report / bgpcorsaro->interval) * bgpcorsaro->interval;
+    }
+  }
 
   /* using an interval value of less than zero disables intervals
      such that only one distribution will be generated upon completion */
-  while(bgpcorsaro->interval >= 0 && ts >= bgpcorsaro->next_report)
-    {
-      /* we want to mark the end of the interval such that all pkt times are <=
-	 the time of the end of the interval.
-	 because we deal in second granularity, we simply subtract one from the
-	 time */
-      report = bgpcorsaro->next_report-1;
+  while (bgpcorsaro->interval >= 0 && ts >= bgpcorsaro->next_report) {
+    /* we want to mark the end of the interval such that all pkt times are <=
+       the time of the end of the interval.
+       because we deal in second granularity, we simply subtract one from the
+       time */
+    report = bgpcorsaro->next_report - 1;
 
-      if(end_interval(bgpcorsaro, report) != 0)
-	{
-	  bgpcorsaro_log(__func__, bgpcorsaro,
-			 "could not end interval at %ld", ts);
-	  /* we don't free in case the client wants to try to carry on */
-	  return -1;
-	}
-
-      bgpcorsaro->interval_start.number++;
-
-      /* we now add the second back on to the time to get the start time */
-      report = bgpcorsaro->next_report;
-      if(start_interval(bgpcorsaro, report) != 0)
-	{
-	  bgpcorsaro_log(__func__, bgpcorsaro, "could not start interval at %ld",
-			 ts);
-	  /* we don't free in case the client wants to try to carry on */
-	  return -1;
-	}
-      bgpcorsaro->next_report += bgpcorsaro->interval;
+    if (end_interval(bgpcorsaro, report) != 0) {
+      bgpcorsaro_log(__func__, bgpcorsaro, "could not end interval at %ld", ts);
+      /* we don't free in case the client wants to try to carry on */
+      return -1;
     }
+
+    bgpcorsaro->interval_start.number++;
+
+    /* we now add the second back on to the time to get the start time */
+    report = bgpcorsaro->next_report;
+    if (start_interval(bgpcorsaro, report) != 0) {
+      bgpcorsaro_log(__func__, bgpcorsaro, "could not start interval at %ld",
+                     ts);
+      /* we don't free in case the client wants to try to carry on */
+      return -1;
+    }
+    bgpcorsaro->next_report += bgpcorsaro->interval;
+  }
 
   /* count this record for our overall record count */
   bgpcorsaro->record_cnt++;
@@ -752,53 +686,49 @@ int bgpcorsaro_finalize_output(bgpcorsaro_t *bgpcorsaro)
   struct timeval total_end, total_diff;
   gettimeofday_wrap(&total_end);
   timeval_subtract(&total_diff, &total_end, &bgpcorsaro->init_time);
-  uint64_t total_time_usec = ((total_diff.tv_sec*1000000) + total_diff.tv_usec);
+  uint64_t total_time_usec =
+    ((total_diff.tv_sec * 1000000) + total_diff.tv_usec);
 #endif
 
-  if(bgpcorsaro == NULL)
-    {
-      return 0;
+  if (bgpcorsaro == NULL) {
+    return 0;
+  }
+  if (bgpcorsaro->started != 0) {
+    if (bgpcorsaro->interval_end_needed != 0 &&
+        end_interval(bgpcorsaro, bgpcorsaro->last_ts) != 0) {
+      bgpcorsaro_log(__func__, bgpcorsaro, "could not end interval at %ld",
+                     bgpcorsaro->last_ts);
+      bgpcorsaro_free(bgpcorsaro);
+      return -1;
     }
-  if(bgpcorsaro->started != 0)
-    {
-      if(bgpcorsaro->interval_end_needed != 0 &&
-	 end_interval(bgpcorsaro, bgpcorsaro->last_ts) != 0)
-	{
-	  bgpcorsaro_log(__func__, bgpcorsaro, "could not end interval at %ld",
-		      bgpcorsaro->last_ts);
-	  bgpcorsaro_free(bgpcorsaro);
-	  return -1;
-	}
-    }
+  }
 
 #ifdef WITH_PLUGIN_TIMING
   fprintf(stderr, "========================================\n");
   fprintf(stderr, "Plugin Timing\n");
-  while((p = bgpcorsaro_plugin_next(bgpcorsaro->plugin_manager, p)) != NULL)
-    {
-      fprintf(stderr, "----------------------------------------\n");
-      fprintf(stderr, "%s\n", p->name);
-      fprintf(stderr, "\tinit_output    %"PRIu64" (%0.2f%%)\n",
-	      p->init_output_usec,
-	      p->init_output_usec*100.0/total_time_usec);
-      fprintf(stderr, "\tprocess_record %"PRIu64" (%0.2f%%)\n",
-	      p->process_record_usec,
-	      p->process_record_usec*100.0/total_time_usec);
-      fprintf(stderr, "\tstart_interval %"PRIu64" (%0.2f%%)\n",
-	      p->start_interval_usec,
-	      p->start_interval_usec*100.0/total_time_usec);
-      fprintf(stderr, "\tend_interval   %"PRIu64" (%0.2f%%)\n",
-	      p->end_interval_usec,
-	      p->end_interval_usec*100.0/total_time_usec);
-      fprintf(stderr, "\ttotal   %"PRIu64" (%0.2f%%)\n",
-	      p->init_output_usec + p->process_record_usec +
-	      p->start_interval_usec + p->end_interval_usec,
-	      (p->init_output_usec + p->process_record_usec +
-	       p->start_interval_usec + p->end_interval_usec)*
-	      100.0/total_time_usec);
-    }
+  while ((p = bgpcorsaro_plugin_next(bgpcorsaro->plugin_manager, p)) != NULL) {
+    fprintf(stderr, "----------------------------------------\n");
+    fprintf(stderr, "%s\n", p->name);
+    fprintf(stderr, "\tinit_output    %" PRIu64 " (%0.2f%%)\n",
+            p->init_output_usec, p->init_output_usec * 100.0 / total_time_usec);
+    fprintf(stderr, "\tprocess_record %" PRIu64 " (%0.2f%%)\n",
+            p->process_record_usec,
+            p->process_record_usec * 100.0 / total_time_usec);
+    fprintf(stderr, "\tstart_interval %" PRIu64 " (%0.2f%%)\n",
+            p->start_interval_usec,
+            p->start_interval_usec * 100.0 / total_time_usec);
+    fprintf(stderr, "\tend_interval   %" PRIu64 " (%0.2f%%)\n",
+            p->end_interval_usec,
+            p->end_interval_usec * 100.0 / total_time_usec);
+    fprintf(stderr, "\ttotal   %" PRIu64 " (%0.2f%%)\n",
+            p->init_output_usec + p->process_record_usec +
+              p->start_interval_usec + p->end_interval_usec,
+            (p->init_output_usec + p->process_record_usec +
+             p->start_interval_usec + p->end_interval_usec) *
+              100.0 / total_time_usec);
+  }
   fprintf(stderr, "========================================\n");
-  fprintf(stderr, "Total Time (usec): %"PRIu64"\n", total_time_usec);
+  fprintf(stderr, "Total Time (usec): %" PRIu64 "\n", total_time_usec);
 #endif
 
   bgpcorsaro_free(bgpcorsaro);

--- a/bgpcorsaro/lib/bgpcorsaro.h
+++ b/bgpcorsaro/lib/bgpcorsaro.h
@@ -57,12 +57,11 @@ typedef struct bgpcorsaro_interval bgpcorsaro_interval_t;
  * @{ */
 
 /** Settings for interval alignment */
-typedef enum bgpcorsaro_interval_align
-  {
-    BGPCORSARO_INTERVAL_ALIGN_NO      = 0,
-    BGPCORSARO_INTERVAL_ALIGN_YES     = 1,
-    BGPCORSARO_INTERVAL_ALIGN_DEFAULT = BGPCORSARO_INTERVAL_ALIGN_NO,
-  } bgpcorsaro_interval_align_t;
+typedef enum bgpcorsaro_interval_align {
+  BGPCORSARO_INTERVAL_ALIGN_NO = 0,
+  BGPCORSARO_INTERVAL_ALIGN_YES = 1,
+  BGPCORSARO_INTERVAL_ALIGN_DEFAULT = BGPCORSARO_INTERVAL_ALIGN_NO,
+} bgpcorsaro_interval_align_t;
 
 /** @} */
 
@@ -75,7 +74,8 @@ typedef enum bgpcorsaro_interval_align
  * The basic process for using bgpcorsaro to generate output is:
  * -# init bgpcorsaro using bgpcorsaro_alloc_output
  * -# optionally call bgpcorsaro_set_interval to set the interval time
- * -# call bgpcorsaro_start_output to initialize the plugins (and create the files)
+ * -# call bgpcorsaro_start_output to initialize the plugins (and create the
+ * files)
  * -# call bgpcorsaro_per_record with each record to be processed
  * -# call bgpcorsaro_finalize when all records have been processed
  *
@@ -127,8 +127,8 @@ int bgpcorsaro_start_output(bgpcorsaro_t *bgpcorsaro);
  * sense when the interval length is evenly divisible into 1 hour.
  * The default is no interval alignment.
  */
-void bgpcorsaro_set_interval_alignment(bgpcorsaro_t *bgpcorsaro,
-				    bgpcorsaro_interval_align_t interval_align);
+void bgpcorsaro_set_interval_alignment(
+  bgpcorsaro_t *bgpcorsaro, bgpcorsaro_interval_align_t interval_align);
 
 /** Accessor function to set the interval length
  *
@@ -149,8 +149,7 @@ void bgpcorsaro_set_interval(bgpcorsaro_t *bgpcorsaro, unsigned int interval);
  * If this is set to > 0, all output files will be rotated at the end of
  * n intervals. The default is 0 (no rotation).
  */
-void bgpcorsaro_set_output_rotation(bgpcorsaro_t *bgpcorsaro,
-				    int intervals);
+void bgpcorsaro_set_output_rotation(bgpcorsaro_t *bgpcorsaro, int intervals);
 
 /** Accessor function to set the rotation frequency of meta output files
  *
@@ -163,7 +162,7 @@ void bgpcorsaro_set_output_rotation(bgpcorsaro_t *bgpcorsaro,
  * rotation interval specified by bgpcorsaro_set_output_rotation.
  */
 void bgpcorsaro_set_meta_output_rotation(bgpcorsaro_t *bgpcorsaro,
-					 int intervals);
+                                         int intervals);
 
 /** Convenience function to determine if the output files should be rotated
  *
@@ -204,7 +203,7 @@ void bgpcorsaro_disable_logfile(bgpcorsaro_t *bgpcorsaro);
  * enabled using this function will be used
  */
 int bgpcorsaro_enable_plugin(bgpcorsaro_t *bgpcorsaro, const char *plugin_name,
-			     const char *plugin_args);
+                             const char *plugin_args);
 
 /** Return an array of the names of plugins which are compiled into bgpcorsaro
  *

--- a/bgpcorsaro/lib/bgpcorsaro_int.h
+++ b/bgpcorsaro/lib/bgpcorsaro_int.h
@@ -43,39 +43,39 @@
 /** @todo either make use of those that libtrace defines, or copy the way that
     libtrace does this*/
 #if __GNUC__ >= 3
-#  ifndef DEPRECATED
-#    define DEPRECATED __attribute__((deprecated))
-#  endif
-#  ifndef SIMPLE_FUNCTION
-#    define SIMPLE_FUNCTION __attribute__((pure))
-#  endif
-#  ifndef UNUSED
-#    define UNUSED __attribute__((unused))
-#  endif
-#  ifndef PACKED
-#    define PACKED __attribute__((packed))
-#  endif
-#  ifndef PRINTF
-#    define PRINTF(formatpos,argpos) __attribute__((format(printf,formatpos,argpos)))
-#  endif
-#else
-#  ifndef DEPRECATED
-#    define DEPRECATED
-#  endif
-#  ifndef SIMPLE_FUNCTION
-#    define SIMPLE_FUNCTION
-#  endif
-#  ifndef UNUSED
-#    define UNUSED
-#  endif
-#  ifndef PACKED
-#    define PACKED
-#  endif
-#  ifndef PRINTF
-#    define PRINTF(formatpos,argpos)
-#  endif
+#ifndef DEPRECATED
+#define DEPRECATED __attribute__((deprecated))
 #endif
-
+#ifndef SIMPLE_FUNCTION
+#define SIMPLE_FUNCTION __attribute__((pure))
+#endif
+#ifndef UNUSED
+#define UNUSED __attribute__((unused))
+#endif
+#ifndef PACKED
+#define PACKED __attribute__((packed))
+#endif
+#ifndef PRINTF
+#define PRINTF(formatpos, argpos)                                              \
+  __attribute__((format(printf, formatpos, argpos)))
+#endif
+#else
+#ifndef DEPRECATED
+#define DEPRECATED
+#endif
+#ifndef SIMPLE_FUNCTION
+#define SIMPLE_FUNCTION
+#endif
+#ifndef UNUSED
+#define UNUSED
+#endif
+#ifndef PACKED
+#define PACKED
+#endif
+#ifndef PRINTF
+#define PRINTF(formatpos, argpos)
+#endif
+#endif
 
 /**
  * @name Bgpcorsaro data structures
@@ -103,12 +103,11 @@
  *
  * Values are all in HOST byte order
  */
-struct bgpcorsaro_interval
-{
+struct bgpcorsaro_interval {
   /** The interval number (starts at 0) */
-  uint16_t         number;
+  uint16_t number;
   /** The time this interval started/ended */
-  uint32_t         time;
+  uint32_t time;
 };
 
 /** @} */
@@ -121,37 +120,32 @@ struct bgpcorsaro_interval
  * This is passed, along with the record, to each plugin.
  * Plugins can add data to it, or check for data from earlier plugins.
  */
-struct bgpcorsaro_record_state
-{
+struct bgpcorsaro_record_state {
   /** Features of the record that have been identified by earlier plugins */
   uint8_t flags;
 };
 
 /** The possible record state flags */
-enum
-  {
-    /** The record should be ignored by filter-aware plugins */
-    BGPCORSARO_RECORD_STATE_FLAG_IGNORE         = 0x01,
-  };
+enum {
+  /** The record should be ignored by filter-aware plugins */
+  BGPCORSARO_RECORD_STATE_FLAG_IGNORE = 0x01,
+};
 
 /** A lightweight wrapper around a bgpstream record */
-struct bgpcorsaro_record
-{
+struct bgpcorsaro_record {
   /** The bgpcorsaro state associated with this record */
-  bgpcorsaro_record_state_t  state;
+  bgpcorsaro_record_state_t state;
 
   /** A pointer to the underlying bgpstream record */
-  bgpstream_record_t    *bsrecord;
-
+  bgpstream_record_t *bsrecord;
 };
 
 /** Convenience macro to get to the bgpstream recprd inside a bgpcorsaro
     record */
-#define BS_REC(bgpcorsaro_record)   (bgpcorsaro_record->bsrecord)
+#define BS_REC(bgpcorsaro_record) (bgpcorsaro_record->bsrecord)
 
 /** Bgpcorsaro output state */
-struct bgpcorsaro
-{
+struct bgpcorsaro {
   /** The local wall time that bgpcorsaro was started at */
   struct timeval init_time;
 
@@ -219,28 +213,26 @@ struct bgpcorsaro
 
   /** Has this bgpcorsaro object been started yet? */
   int started;
-
 };
 
 #ifdef WITH_PLUGIN_TIMING
 /* Helper macros for doing timing */
 
 /** Start a timer with the given name */
-#define TIMER_START(timer)			\
-  struct timeval timer_start;			\
-  do {						\
-  gettimeofday_wrap(&timer_start);		\
-  } while(0)
+#define TIMER_START(timer)                                                     \
+  struct timeval timer_start;                                                  \
+  do {                                                                         \
+    gettimeofday_wrap(&timer_start);                                           \
+  } while (0)
 
-#define TIMER_END(timer)					\
-  struct timeval timer_end, timer_diff;				\
-  do {								\
-    gettimeofday_wrap(&timer_end);				\
-    timeval_subtract(&timer_diff, &timer_end, &timer_start);	\
-  } while(0)
+#define TIMER_END(timer)                                                       \
+  struct timeval timer_end, timer_diff;                                        \
+  do {                                                                         \
+    gettimeofday_wrap(&timer_end);                                             \
+    timeval_subtract(&timer_diff, &timer_end, &timer_start);                   \
+  } while (0)
 
-#define TIMER_VAL(timer)			\
-  ((timer_diff.tv_sec*1000000) + timer_diff.tv_usec)
+#define TIMER_VAL(timer) ((timer_diff.tv_sec * 1000000) + timer_diff.tv_usec)
 #endif
 
 #endif /* __BGPCORSARO_INT_H */

--- a/bgpcorsaro/lib/bgpcorsaro_io.c
+++ b/bgpcorsaro/lib/bgpcorsaro_io.c
@@ -20,17 +20,17 @@
  * You should have received a copy of the GNU General Public License along with
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "config.h"
 #include "bgpcorsaro_int.h"
+#include "config.h"
 
 #include <assert.h>
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
@@ -49,16 +49,15 @@
 
 static char *stradd(const char *str, char *bufp, char *buflim)
 {
-  while(bufp < buflim && (*bufp = *str++) != '\0')
-    {
-      ++bufp;
-    }
+  while (bufp < buflim && (*bufp = *str++) != '\0') {
+    ++bufp;
+  }
   return bufp;
 }
 
 static char *generate_file_name(bgpcorsaro_t *bgpcorsaro, const char *plugin,
-				bgpcorsaro_interval_t *interval,
-				int compress_type)
+                                bgpcorsaro_interval_t *interval,
+                                int compress_type)
 {
   /* some of the structure of this code is borrowed from the
      FreeBSD implementation of strftime */
@@ -69,71 +68,63 @@ static char *generate_file_name(bgpcorsaro_t *bgpcorsaro, const char *plugin,
   char buf[1024];
   char tbuf[1024];
   char *bufp = buf;
-  char *buflim = buf+sizeof(buf);
+  char *buflim = buf + sizeof(buf);
 
   char *tmpl = bgpcorsaro->template;
   char secs[11]; /* length of UINT32_MAX +1 */
   struct timeval tv;
 
-  for(; *tmpl; ++tmpl)
-    {
-      if(*tmpl == '.' && compress_type == WANDIO_COMPRESS_NONE)
-	{
-	  if(strncmp(tmpl, BGPCORSARO_IO_ZLIB_SUFFIX,
-		     strlen(BGPCORSARO_IO_ZLIB_SUFFIX)) == 0 ||
-	     strncmp(tmpl, BGPCORSARO_IO_BZ2_SUFFIX,
-		     strlen(BGPCORSARO_IO_BZ2_SUFFIX)) == 0)
-	    {
-	      break;
-	    }
-	}
-      else if(*tmpl == '%')
-	{
-	  switch(*++tmpl)
-	    {
-	    case '\0':
-	      --tmpl;
-	      break;
+  for (; *tmpl; ++tmpl) {
+    if (*tmpl == '.' && compress_type == WANDIO_COMPRESS_NONE) {
+      if (strncmp(tmpl, BGPCORSARO_IO_ZLIB_SUFFIX,
+                  strlen(BGPCORSARO_IO_ZLIB_SUFFIX)) == 0 ||
+          strncmp(tmpl, BGPCORSARO_IO_BZ2_SUFFIX,
+                  strlen(BGPCORSARO_IO_BZ2_SUFFIX)) == 0) {
+        break;
+      }
+    } else if (*tmpl == '%') {
+      switch (*++tmpl) {
+      case '\0':
+        --tmpl;
+        break;
 
-	      /* BEWARE: if you add a new pattern here, you must also add it to
-	       * bgpcorsaro_io_template_has_timestamp */
+      /* BEWARE: if you add a new pattern here, you must also add it to
+       * bgpcorsaro_io_template_has_timestamp */
 
-	    case BGPCORSARO_IO_MONITOR_PATTERN:
-	      bufp = stradd(bgpcorsaro->monitorname, bufp, buflim);
-	      continue;
+      case BGPCORSARO_IO_MONITOR_PATTERN:
+        bufp = stradd(bgpcorsaro->monitorname, bufp, buflim);
+        continue;
 
-	    case BGPCORSARO_IO_PLUGIN_PATTERN:
-	      bufp = stradd(plugin, bufp, buflim);
-	      continue;
+      case BGPCORSARO_IO_PLUGIN_PATTERN:
+        bufp = stradd(plugin, bufp, buflim);
+        continue;
 
-	    case 's':
-	      if(interval != NULL)
-		{
-		  snprintf(secs, sizeof(secs), "%"PRIu32, interval->time);
-		  bufp = stradd(secs, bufp, buflim);
-		  continue;
-		}
-	      /* fall through */
-	    default:
-	      /* we want to be generous and leave non-recognized formats
-		 intact - especially for strftime to use */
-	      --tmpl;
-	    }
-	}
-      if (bufp == buflim)
-	break;
-      *bufp++ = *tmpl;
+      case 's':
+        if (interval != NULL) {
+          snprintf(secs, sizeof(secs), "%" PRIu32, interval->time);
+          bufp = stradd(secs, bufp, buflim);
+          continue;
+        }
+      /* fall through */
+      default:
+        /* we want to be generous and leave non-recognized formats
+           intact - especially for strftime to use */
+        --tmpl;
+      }
     }
+    if (bufp == buflim)
+      break;
+    *bufp++ = *tmpl;
+  }
 
   *bufp = '\0';
 
   /* now let strftime have a go */
-  if(interval != NULL)
-    {
-      tv.tv_sec = interval->time;
-      strftime(tbuf, sizeof(tbuf), buf, gmtime(&tv.tv_sec));
-      return strdup(tbuf);
-    }
+  if (interval != NULL) {
+    tv.tv_sec = interval->time;
+    strftime(tbuf, sizeof(tbuf), buf, gmtime(&tv.tv_sec));
+    return strdup(tbuf);
+  }
 
   return strdup(buf);
 }
@@ -141,44 +132,37 @@ static char *generate_file_name(bgpcorsaro_t *bgpcorsaro, const char *plugin,
 /* == EXPORTED FUNCTIONS BELOW THIS POINT == */
 
 iow_t *bgpcorsaro_io_prepare_file(bgpcorsaro_t *bgpcorsaro,
-				  const char *plugin_name,
-				  bgpcorsaro_interval_t *interval)
+                                  const char *plugin_name,
+                                  bgpcorsaro_interval_t *interval)
 {
-  return bgpcorsaro_io_prepare_file_full(bgpcorsaro,
-					 plugin_name,
-					 interval,
-					 bgpcorsaro->compress,
-					 bgpcorsaro->compress_level,
-					 O_CREAT);
+  return bgpcorsaro_io_prepare_file_full(bgpcorsaro, plugin_name, interval,
+                                         bgpcorsaro->compress,
+                                         bgpcorsaro->compress_level, O_CREAT);
 }
 
 iow_t *bgpcorsaro_io_prepare_file_full(bgpcorsaro_t *bgpcorsaro,
-				       const char *plugin_name,
-				       bgpcorsaro_interval_t *interval,
-				       int compress_type,
-				       int compress_level,
-				       int flags)
+                                       const char *plugin_name,
+                                       bgpcorsaro_interval_t *interval,
+                                       int compress_type, int compress_level,
+                                       int flags)
 {
   iow_t *f = NULL;
   char *outfileuri;
 
   /* generate a file name based on the plugin name */
-  if((outfileuri = generate_file_name(bgpcorsaro, plugin_name,
-				      interval, compress_type)) == NULL)
-    {
-      bgpcorsaro_log(__func__, bgpcorsaro, "could not generate file name for %s",
-		  plugin_name);
-      return NULL;
-    }
+  if ((outfileuri = generate_file_name(bgpcorsaro, plugin_name, interval,
+                                       compress_type)) == NULL) {
+    bgpcorsaro_log(__func__, bgpcorsaro, "could not generate file name for %s",
+                   plugin_name);
+    return NULL;
+  }
 
-  if((f = wandio_wcreate(outfileuri,
-			 compress_type, compress_level,
-			 flags)) == NULL)
-    {
-      bgpcorsaro_log(__func__, bgpcorsaro, "could not open %s for writing",
-		  outfileuri);
-      return NULL;
-    }
+  if ((f = wandio_wcreate(outfileuri, compress_type, compress_level, flags)) ==
+      NULL) {
+    bgpcorsaro_log(__func__, bgpcorsaro, "could not open %s for writing",
+                   outfileuri);
+    return NULL;
+  }
 
   free(outfileuri);
   return f;
@@ -189,19 +173,17 @@ int bgpcorsaro_io_validate_template(bgpcorsaro_t *bgpcorsaro, char *template)
   /* be careful using bgpcorsaro here, it is likely not initialized fully */
 
   /* check for length first */
-  if(template == NULL)
-    {
-      bgpcorsaro_log(__func__, bgpcorsaro, "output template must be set");
-      return 0;
-    }
+  if (template == NULL) {
+    bgpcorsaro_log(__func__, bgpcorsaro, "output template must be set");
+    return 0;
+  }
 
   /* check that the plugin pattern is in the template */
-  if(strstr(template, BGPCORSARO_IO_PLUGIN_PATTERN_STR) == NULL)
-    {
-      bgpcorsaro_log(__func__, bgpcorsaro, "template string must contain %s",
-		  BGPCORSARO_IO_PLUGIN_PATTERN_STR);
-      return 0;
-    }
+  if (strstr(template, BGPCORSARO_IO_PLUGIN_PATTERN_STR) == NULL) {
+    bgpcorsaro_log(__func__, bgpcorsaro, "template string must contain %s",
+                   BGPCORSARO_IO_PLUGIN_PATTERN_STR);
+    return 0;
+  }
 
   /* we're good! */
   return 1;
@@ -216,62 +198,56 @@ int bgpcorsaro_io_template_has_timestamp(bgpcorsaro_t *bgpcorsaro)
   /* the easiest (but not easiest to maintain) way to do this is to step through
    * each '%' character in the string and check what is after it. if it is
    * anything other than P (for plugin) or N (for monitor name), then it is a
-   * timestamp. HOWEVER. If new bgpcorsaro-specific patterns are added, they must
+   * timestamp. HOWEVER. If new bgpcorsaro-specific patterns are added, they
+   * must
    * also be added here. gross */
 
-  for(; *p; ++p)
-    {
-      if(*p == '%')
-	{
-	  /* BEWARE: if you add a new pattern here, you must also add it to
-	   * generate_file_name */
-	  if(*(p+1) != BGPCORSARO_IO_MONITOR_PATTERN &&
-	     *(p+1) != BGPCORSARO_IO_PLUGIN_PATTERN)
-	    {
-	      return 1;
-	    }
-	}
+  for (; *p; ++p) {
+    if (*p == '%') {
+      /* BEWARE: if you add a new pattern here, you must also add it to
+       * generate_file_name */
+      if (*(p + 1) != BGPCORSARO_IO_MONITOR_PATTERN &&
+          *(p + 1) != BGPCORSARO_IO_PLUGIN_PATTERN) {
+        return 1;
+      }
     }
+  }
   return 0;
-
 }
 
 off_t bgpcorsaro_io_write_interval_start(bgpcorsaro_t *bgpcorsaro, iow_t *file,
-					 bgpcorsaro_interval_t *int_start)
+                                         bgpcorsaro_interval_t *int_start)
 {
   return wandio_printf(file, "# BGPCORSARO_INTERVAL_START %d %ld\n",
-		       int_start->number, int_start->time);
+                       int_start->number, int_start->time);
 }
 
 void bgpcorsaro_io_print_interval_start(bgpcorsaro_interval_t *int_start)
 {
-  fprintf(stdout,
-	  "# BGPCORSARO_INTERVAL_START %d %"PRIu32"\n",
-	  int_start->number, int_start->time);
+  fprintf(stdout, "# BGPCORSARO_INTERVAL_START %d %" PRIu32 "\n",
+          int_start->number, int_start->time);
 }
 
 off_t bgpcorsaro_io_write_interval_end(bgpcorsaro_t *bgpcorsaro, iow_t *file,
-				       bgpcorsaro_interval_t *int_end)
+                                       bgpcorsaro_interval_t *int_end)
 {
   return wandio_printf(file, "# BGPCORSARO_INTERVAL_END %d %ld\n",
-		       int_end->number, int_end->time);
+                       int_end->number, int_end->time);
 }
 
 void bgpcorsaro_io_print_interval_end(bgpcorsaro_interval_t *int_end)
 {
-  fprintf(stdout,
-	  "# BGPCORSARO_INTERVAL_END %d %"PRIu32"\n",
-	  int_end->number,
-	  int_end->time);
+  fprintf(stdout, "# BGPCORSARO_INTERVAL_END %d %" PRIu32 "\n", int_end->number,
+          int_end->time);
 }
 
 off_t bgpcorsaro_io_write_plugin_start(bgpcorsaro_t *bgpcorsaro, iow_t *file,
-				       bgpcorsaro_plugin_t *plugin)
+                                       bgpcorsaro_plugin_t *plugin)
 {
   assert(plugin != NULL);
 
   return wandio_printf(file, "# BGPCORSARO_PLUGIN_DATA_START %s\n",
-		       plugin->name);
+                       plugin->name);
 }
 
 void bgpcorsaro_io_print_plugin_start(bgpcorsaro_plugin_t *plugin)
@@ -280,7 +256,7 @@ void bgpcorsaro_io_print_plugin_start(bgpcorsaro_plugin_t *plugin)
 }
 
 off_t bgpcorsaro_io_write_plugin_end(bgpcorsaro_t *bgpcorsaro, iow_t *file,
-				     bgpcorsaro_plugin_t *plugin)
+                                     bgpcorsaro_plugin_t *plugin)
 {
   assert(plugin != NULL);
 

--- a/bgpcorsaro/lib/bgpcorsaro_io.h
+++ b/bgpcorsaro/lib/bgpcorsaro_io.h
@@ -38,15 +38,16 @@
  */
 
 /** The suffix used to detect gzip output is desired */
-#define BGPCORSARO_IO_ZLIB_SUFFIX   ".gz"
+#define BGPCORSARO_IO_ZLIB_SUFFIX ".gz"
 
 /** The suffix used to detect bzip output is desired */
-#define BGPCORSARO_IO_BZ2_SUFFIX   ".bz2"
+#define BGPCORSARO_IO_BZ2_SUFFIX ".bz2"
 
 /** The character to replace with the name of the plugin */
-#define BGPCORSARO_IO_PLUGIN_PATTERN  'X'
-/** The pattern to replace in the output file name with the name of the plugin */
-#define BGPCORSARO_IO_PLUGIN_PATTERN_STR  "%X"
+#define BGPCORSARO_IO_PLUGIN_PATTERN 'X'
+/** The pattern to replace in the output file name with the name of the plugin
+ */
+#define BGPCORSARO_IO_PLUGIN_PATTERN_STR "%X"
 
 /** The character to replace with the monitor name */
 #define BGPCORSARO_IO_MONITOR_PATTERN 'N'
@@ -54,7 +55,7 @@
 #define BGPCORSARO_IO_MONITOR_PATTERN_STR "%N"
 
 /** The name to use for the log 'plugin' file */
-#define BGPCORSARO_IO_LOG_NAME        "log"
+#define BGPCORSARO_IO_LOG_NAME "log"
 
 /** Uses the given settings to open an bgpcorsaro file for the given plugin
  *
@@ -68,11 +69,10 @@
  * @return A pointer to a new wandio output file, or NULL if an error occurs
  */
 iow_t *bgpcorsaro_io_prepare_file_full(bgpcorsaro_t *bgpcorsaro,
-					     const char *plugin_name,
-					     bgpcorsaro_interval_t *interval,
-					     int compress,
-					     int compress_level,
-					     int flags);
+                                       const char *plugin_name,
+                                       bgpcorsaro_interval_t *interval,
+                                       int compress, int compress_level,
+                                       int flags);
 
 /** Uses the current settings to open an bgpcorsaro file for the given plugin
  *
@@ -82,9 +82,9 @@ iow_t *bgpcorsaro_io_prepare_file_full(bgpcorsaro_t *bgpcorsaro,
  *                     (inserted into the template)
  * @return A pointer to a new wandio output file, or NULL if an error occurs
  */
-iow_t *bgpcorsaro_io_prepare_file(bgpcorsaro_t* bgpcorsaro,
-				  const char *plugin_name,
-				  bgpcorsaro_interval_t *interval);
+iow_t *bgpcorsaro_io_prepare_file(bgpcorsaro_t *bgpcorsaro,
+                                  const char *plugin_name,
+                                  bgpcorsaro_interval_t *interval);
 
 /** Validates a output file template for needed features
  *
@@ -109,7 +109,7 @@ int bgpcorsaro_io_template_has_timestamp(bgpcorsaro_t *bgpcorsaro);
  * @return The amount of data written, or -1 if an error occurs
  */
 off_t bgpcorsaro_io_write_interval_start(bgpcorsaro_t *bgpcorsaro, iow_t *file,
-					 bgpcorsaro_interval_t *int_start);
+                                         bgpcorsaro_interval_t *int_start);
 
 /** Write the interval headers to stdout
  *
@@ -125,7 +125,7 @@ void bgpcorsaro_io_print_interval_start(bgpcorsaro_interval_t *int_start);
  * @return The amount of data written, or -1 if an error occurs
  */
 off_t bgpcorsaro_io_write_interval_end(bgpcorsaro_t *bgpcorsaro, iow_t *file,
-				       bgpcorsaro_interval_t *int_end);
+                                       bgpcorsaro_interval_t *int_end);
 
 /** Write the interval trailers to stdout
  *
@@ -141,7 +141,7 @@ void bgpcorsaro_io_print_interval_end(bgpcorsaro_interval_t *int_end);
  * @return The amount of data written, or -1 if an error occurs
  */
 off_t bgpcorsaro_io_write_plugin_start(bgpcorsaro_t *bgpcorsaro, iow_t *file,
-				       bgpcorsaro_plugin_t *plugin);
+                                       bgpcorsaro_plugin_t *plugin);
 
 /** Write the appropriate plugin trailer to the file
  *
@@ -151,6 +151,6 @@ off_t bgpcorsaro_io_write_plugin_start(bgpcorsaro_t *bgpcorsaro, iow_t *file,
  * @return The amount of data written, or -1 if an error occurs
  */
 off_t bgpcorsaro_io_write_plugin_end(bgpcorsaro_t *bgpcorsaro, iow_t *file,
-				     bgpcorsaro_plugin_t *plugin);
+                                     bgpcorsaro_plugin_t *plugin);
 
 #endif /* __BGPCORSARO_IO_H */

--- a/bgpcorsaro/lib/bgpcorsaro_log.c
+++ b/bgpcorsaro/lib/bgpcorsaro_log.c
@@ -20,19 +20,19 @@
  * You should have received a copy of the GNU General Public License along with
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "config.h"
 #include "bgpcorsaro_int.h"
+#include "config.h"
 
 #include <assert.h>
-#include <stdarg.h>
 #include <inttypes.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
@@ -49,29 +49,30 @@
 
 static char *timestamp_str(char *buf, const size_t len)
 {
-  struct timeval  tv;
-  struct tm      *tm;
-  int             ms;
-  time_t          t;
+  struct timeval tv;
+  struct tm *tm;
+  int ms;
+  time_t t;
 
   buf[0] = '\0';
   gettimeofday_wrap(&tv);
   t = tv.tv_sec;
-  if((tm = localtime(&t)) == NULL) return buf;
+  if ((tm = localtime(&t)) == NULL)
+    return buf;
 
   ms = tv.tv_usec / 1000;
-  snprintf(buf, len, "[%02d:%02d:%02d:%03d] ",
-	   tm->tm_hour, tm->tm_min, tm->tm_sec, ms);
+  snprintf(buf, len, "[%02d:%02d:%02d:%03d] ", tm->tm_hour, tm->tm_min,
+           tm->tm_sec, ms);
 
   return buf;
 }
 
 void generic_log(const char *func, iow_t *logfile, const char *format,
-		 va_list ap)
+                 va_list ap)
 {
-  char     message[512];
-  char     ts[16];
-  char     fs[64];
+  char message[512];
+  char ts[16];
+  char fs[64];
 
   assert(format != NULL);
 
@@ -79,36 +80,35 @@ void generic_log(const char *func, iow_t *logfile, const char *format,
 
   timestamp_str(ts, sizeof(ts));
 
-  if(func != NULL) snprintf(fs, sizeof(fs), "%s: ", func);
-  else             fs[0] = '\0';
-
-  if(logfile == NULL)
-    {
-      fprintf(stderr, "%s%s%s\n", ts, fs, message);
-      fflush(stderr);
-    }
+  if (func != NULL)
+    snprintf(fs, sizeof(fs), "%s: ", func);
   else
-    {
-      wandio_printf(logfile, "%s%s%s\n", ts, fs, message);
-      /*wandio_flush(logfile);*/
+    fs[0] = '\0';
+
+  if (logfile == NULL) {
+    fprintf(stderr, "%s%s%s\n", ts, fs, message);
+    fflush(stderr);
+  } else {
+    wandio_printf(logfile, "%s%s%s\n", ts, fs, message);
+/*wandio_flush(logfile);*/
 
 #ifdef DEBUG
-      /* we've been asked to dump debugging information */
-      fprintf(stderr, "%s%s%s\n", ts, fs, message);
-      fflush(stderr);
+    /* we've been asked to dump debugging information */
+    fprintf(stderr, "%s%s%s\n", ts, fs, message);
+    fflush(stderr);
 #endif
-    }
+  }
 }
 
 void bgpcorsaro_log_va(const char *func, bgpcorsaro_t *bgpcorsaro,
-		  const char *format, va_list args)
+                       const char *format, va_list args)
 {
   iow_t *lf = (bgpcorsaro == NULL) ? NULL : bgpcorsaro->logfile;
   generic_log(func, lf, format, args);
 }
 
 void bgpcorsaro_log(const char *func, bgpcorsaro_t *bgpcorsaro,
-		    const char *format, ...)
+                    const char *format, ...)
 {
   va_list ap;
   va_start(ap, format);
@@ -116,8 +116,8 @@ void bgpcorsaro_log(const char *func, bgpcorsaro_t *bgpcorsaro,
   va_end(ap);
 }
 
-void bgpcorsaro_log_file(const char *func, iow_t *logfile,
-			 const char *format, ...)
+void bgpcorsaro_log_file(const char *func, iow_t *logfile, const char *format,
+                         ...)
 {
   va_list ap;
   va_start(ap, format);
@@ -127,25 +127,19 @@ void bgpcorsaro_log_file(const char *func, iow_t *logfile,
 
 int bgpcorsaro_log_init(bgpcorsaro_t *bgpcorsaro)
 {
-  if((bgpcorsaro->logfile = bgpcorsaro_io_prepare_file_full(bgpcorsaro,
-				    BGPCORSARO_IO_LOG_NAME,
-				    &bgpcorsaro->interval_start,
-				    WANDIO_COMPRESS_NONE,
-				    0, O_CREAT)) == NULL)
-    {
-      fprintf(stderr, "could not open log for writing\n");
-      return -1;
-    }
+  if ((bgpcorsaro->logfile = bgpcorsaro_io_prepare_file_full(
+         bgpcorsaro, BGPCORSARO_IO_LOG_NAME, &bgpcorsaro->interval_start,
+         WANDIO_COMPRESS_NONE, 0, O_CREAT)) == NULL) {
+    fprintf(stderr, "could not open log for writing\n");
+    return -1;
+  }
   return 0;
 }
 
 void bgpcorsaro_log_close(bgpcorsaro_t *bgpcorsaro)
 {
-  if(bgpcorsaro->logfile != NULL)
-    {
-      wandio_wdestroy( bgpcorsaro->logfile);
-      bgpcorsaro->logfile = NULL;
-    }
+  if (bgpcorsaro->logfile != NULL) {
+    wandio_wdestroy(bgpcorsaro->logfile);
+    bgpcorsaro->logfile = NULL;
+  }
 }
-
-

--- a/bgpcorsaro/lib/bgpcorsaro_log.h
+++ b/bgpcorsaro/lib/bgpcorsaro_log.h
@@ -47,7 +47,7 @@
  * This function takes the same style of arguments that printf(3) does.
  */
 void bgpcorsaro_log_va(const char *func, bgpcorsaro_t *bgpcorsaro,
-		       const char *format, va_list args);
+                       const char *format, va_list args);
 
 /** Write a formatted string to the logfile associated with an bgpcorsaro object
  *
@@ -59,7 +59,7 @@ void bgpcorsaro_log_va(const char *func, bgpcorsaro_t *bgpcorsaro,
  * This function takes the same style of arguments that printf(3) does.
  */
 void bgpcorsaro_log(const char *func, bgpcorsaro_t *bgpcorsaro,
-		    const char *format, ...);
+                    const char *format, ...);
 
 /** Write a formatted string to a generic log file
  *
@@ -70,8 +70,8 @@ void bgpcorsaro_log(const char *func, bgpcorsaro_t *bgpcorsaro,
  *
  * This function takes the same style of arguments that printf(3) does.
  */
-void bgpcorsaro_log_file(const char *func, iow_t *logfile,
-			 const char *format, ...);
+void bgpcorsaro_log_file(const char *func, iow_t *logfile, const char *format,
+                         ...);
 
 /** Initialize the logging sub-system for an bgpcorsaro output object
  *

--- a/bgpcorsaro/lib/bgpcorsaro_plugin.c
+++ b/bgpcorsaro/lib/bgpcorsaro_plugin.c
@@ -20,15 +20,15 @@
  * You should have received a copy of the GNU General Public License along with
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "config.h"
 #include "bgpcorsaro_int.h"
+#include "config.h"
 
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include "parse_cmd.h"
 #include "utils.h"
+#include "parse_cmd.h"
 
 #include "bgpcorsaro_log.h"
 
@@ -55,21 +55,18 @@
  * #endif
  */
 
-
 /** Shortcut to get the logfile pointer from the manager */
 #define LOG(manager) (manager->logfile)
 
 #define MAXOPTS 1024
 
-#define PLUGIN_INIT_ADD(plugin)					  \
-  {								  \
-    tail = add_plugin(manager, tail, plugin##_alloc(),	  \
-		      "##plugin##");				  \
-    if(list == NULL)						  \
-      {								  \
-	list = tail;						  \
-      }								  \
-    plugin_cnt++;						  \
+#define PLUGIN_INIT_ADD(plugin)                                                \
+  {                                                                            \
+    tail = add_plugin(manager, tail, plugin##_alloc(), "##plugin##");          \
+    if (list == NULL) {                                                        \
+      list = tail;                                                             \
+    }                                                                          \
+    plugin_cnt++;                                                              \
   }
 
 #ifdef DEBUG
@@ -96,34 +93,30 @@ static void bgpcorsaro_plugin_verify(bgpcorsaro_plugin_t *plugin)
 
 #ifdef ED_PLUGIN_INIT_ALL_ENABLED
 static bgpcorsaro_plugin_t *add_plugin(bgpcorsaro_plugin_manager_t *manager,
-				       bgpcorsaro_plugin_t *tail,
-				       bgpcorsaro_plugin_t *p,
-				       const char *name)
+                                       bgpcorsaro_plugin_t *tail,
+                                       bgpcorsaro_plugin_t *p, const char *name)
 {
   bgpcorsaro_plugin_t *plugin = NULL;
 
   /* before we add this plugin, let's check that the user wants it */
-  if(bgpcorsaro_plugin_is_enabled(manager, p) == 0)
-    {
-      return tail;
-    }
+  if (bgpcorsaro_plugin_is_enabled(manager, p) == 0) {
+    return tail;
+  }
 
   /* we assume that we need to copy the plugin structure that the plugin
      gives us. this allows us to use the same plugin twice at once */
-  if((plugin = malloc(sizeof(bgpcorsaro_plugin_t))) == NULL)
-    {
-      bgpcorsaro_log_file(__func__, NULL, "could not malloc plugin");
-      return NULL;
-    }
+  if ((plugin = malloc(sizeof(bgpcorsaro_plugin_t))) == NULL) {
+    bgpcorsaro_log_file(__func__, NULL, "could not malloc plugin");
+    return NULL;
+  }
   memcpy(plugin, p, sizeof(bgpcorsaro_plugin_t));
 
   /* make sure it initialized */
-  if(plugin == NULL)
-    {
-      bgpcorsaro_log_file(__func__, LOG(manager),
-		       "%s plugin failed to initialize", name);
-      return tail;
-    }
+  if (plugin == NULL) {
+    bgpcorsaro_log_file(__func__, LOG(manager),
+                        "%s plugin failed to initialize", name);
+    return tail;
+  }
 
 #ifdef DEBUG
   bgpcorsaro_plugin_verify(plugin);
@@ -132,60 +125,52 @@ static bgpcorsaro_plugin_t *add_plugin(bgpcorsaro_plugin_manager_t *manager,
   /* create the default argv for the plugin */
   plugin->argc = 1;
   /* malloc the pointers for the array */
-  if((plugin->argv = malloc(sizeof(char*) * (plugin->argc+1))) == NULL)
-    {
-      bgpcorsaro_log_file(__func__, LOG(manager), "could not malloc plugin argv");
-      return NULL;
-    }
+  if ((plugin->argv = malloc(sizeof(char *) * (plugin->argc + 1))) == NULL) {
+    bgpcorsaro_log_file(__func__, LOG(manager), "could not malloc plugin argv");
+    return NULL;
+  }
   plugin->argv[0] = strdup(plugin->name);
   plugin->argv[1] = NULL;
 
-  if(tail != NULL)
-    {
-      assert(tail->next == NULL);
-      tail->next = plugin;
-    }
+  if (tail != NULL) {
+    assert(tail->next == NULL);
+    tail->next = plugin;
+  }
   /*plugin->next = head;*/
   return plugin;
 }
 #endif
 
 static int populate_plugin_arrays(bgpcorsaro_plugin_manager_t *manager,
-				  int plugin_cnt,
-				  bgpcorsaro_plugin_t *plugin_list)
+                                  int plugin_cnt,
+                                  bgpcorsaro_plugin_t *plugin_list)
 {
   bgpcorsaro_plugin_t *tmp = NULL;
 
-  if(plugin_cnt == 0)
-    {
+  if (plugin_cnt == 0) {
+    bgpcorsaro_log_file(__func__, LOG(manager),
+                        "WARNING: No plugins are initialized");
+  } else {
+    /* build the plugins array */
+    if ((manager->plugins = malloc_zero(sizeof(bgpcorsaro_plugin_t *) *
+                                        (BGPCORSARO_PLUGIN_ID_MAX))) == NULL) {
       bgpcorsaro_log_file(__func__, LOG(manager),
-		       "WARNING: No plugins are initialized");
+                          "could not malloc plugin array");
+      return -1;
     }
-  else
-    {
-      /* build the plugins array */
-      if((manager->plugins = malloc_zero(sizeof(bgpcorsaro_plugin_t*)
-                                         *(BGPCORSARO_PLUGIN_ID_MAX))) == NULL)
-        {
-          bgpcorsaro_log_file(__func__, LOG(manager),
-			   "could not malloc plugin array");
-          return -1;
-        }
-      /* allocate the plugin state array */
-      if((manager->plugins_state = malloc_zero(sizeof(void*)
-                                               *(BGPCORSARO_PLUGIN_ID_MAX))) == NULL)
-        {
-          bgpcorsaro_log_file(__func__, LOG(manager),
-			   "could not malloc plugin state array");
-          return -1;
-        }
-      for(tmp=plugin_list;tmp!=NULL;tmp=tmp->next)
-        {
-          manager->plugins[tmp->id-1] = tmp;
-        }
-      manager->first_plugin = plugin_list;
-      manager->plugins_cnt = plugin_cnt;
+    /* allocate the plugin state array */
+    if ((manager->plugins_state =
+           malloc_zero(sizeof(void *) * (BGPCORSARO_PLUGIN_ID_MAX))) == NULL) {
+      bgpcorsaro_log_file(__func__, LOG(manager),
+                          "could not malloc plugin state array");
+      return -1;
     }
+    for (tmp = plugin_list; tmp != NULL; tmp = tmp->next) {
+      manager->plugins[tmp->id - 1] = tmp;
+    }
+    manager->first_plugin = plugin_list;
+    manager->plugins_cnt = plugin_cnt;
+  }
   return 0;
 }
 
@@ -195,16 +180,14 @@ static int copy_argv(bgpcorsaro_plugin_t *plugin, int argc, char *argv[])
   plugin->argc = argc;
 
   /* malloc the pointers for the array */
-  if((plugin->argv = malloc(sizeof(char*) * (plugin->argc+1))) == NULL)
-    {
-      return -1;
-    }
+  if ((plugin->argv = malloc(sizeof(char *) * (plugin->argc + 1))) == NULL) {
+    return -1;
+  }
 
   for (i = 0; i < plugin->argc; i++) {
-    if((plugin->argv[i] = malloc(strlen(argv[i]) + 1)) == NULL)
-      {
-	return -1;
-      }
+    if ((plugin->argv[i] = malloc(strlen(argv[i]) + 1)) == NULL) {
+      return -1;
+    }
     strncpy(plugin->argv[i], argv[i], strlen(argv[i]) + 1);
   }
 
@@ -229,33 +212,31 @@ bgpcorsaro_plugin_manager_t *bgpcorsaro_plugin_manager_init(iow_t *logfile)
   int plugin_cnt = 0;
 
   /* allocate the manager structure */
-  if((manager = malloc_zero(sizeof(bgpcorsaro_plugin_manager_t))) == NULL)
-    {
-      bgpcorsaro_log_file(__func__, logfile, "failed to malloc plugin manager");
-      return NULL;
-    }
+  if ((manager = malloc_zero(sizeof(bgpcorsaro_plugin_manager_t))) == NULL) {
+    bgpcorsaro_log_file(__func__, logfile, "failed to malloc plugin manager");
+    return NULL;
+  }
 
   /* set the log file */
   manager->logfile = logfile;
 
-  /* NOTE: the order that plugins are listed in configure.ac
-     will be the order that they are run. */
+/* NOTE: the order that plugins are listed in configure.ac
+   will be the order that they are run. */
 
-  /* this macro is generated by ED_WITH_PLUGIN macro calls in configure.ac */
-  /* basically, what will happen is that an ordered linked list of plugins
-     will be built, which we will then turn into an array and store in the
-     manager structure. this allows plugins to be accessed in both
-     sequential and random access fashion */
+/* this macro is generated by ED_WITH_PLUGIN macro calls in configure.ac */
+/* basically, what will happen is that an ordered linked list of plugins
+   will be built, which we will then turn into an array and store in the
+   manager structure. this allows plugins to be accessed in both
+   sequential and random access fashion */
 
 #ifdef ED_PLUGIN_INIT_ALL_ENABLED
   ED_PLUGIN_INIT_ALL_ENABLED
 #endif
 
-    if(populate_plugin_arrays(manager, plugin_cnt, list) != 0)
-      {
-	bgpcorsaro_plugin_manager_free(manager);
-	return NULL;
-      }
+  if (populate_plugin_arrays(manager, plugin_cnt, list) != 0) {
+    bgpcorsaro_plugin_manager_free(manager);
+    return NULL;
+  }
 
   return manager;
 }
@@ -267,40 +248,35 @@ int bgpcorsaro_plugin_manager_start(bgpcorsaro_plugin_manager_t *manager)
   bgpcorsaro_plugin_t *tail = NULL;
   bgpcorsaro_plugin_t *head = NULL;
 
-  if(manager->plugins_enabled != NULL)
-    {
-      /* we need to go through the list of plugins and recreate the list
-	 with only plugins which are in the plugins_enabled array */
-      for(i = 0; i < manager->plugins_enabled_cnt; i++)
-	{
-	  p = manager->plugins[manager->plugins_enabled[i]-1];
+  if (manager->plugins_enabled != NULL) {
+    /* we need to go through the list of plugins and recreate the list
+       with only plugins which are in the plugins_enabled array */
+    for (i = 0; i < manager->plugins_enabled_cnt; i++) {
+      p = manager->plugins[manager->plugins_enabled[i] - 1];
 
-	  /* if this is the first enabled plugin, then this will be the head */
-	  if(head == NULL)
-	    {
-	      head = p;
-	    }
+      /* if this is the first enabled plugin, then this will be the head */
+      if (head == NULL) {
+        head = p;
+      }
 
-	  /* if there was a plugin before, connect it to this one */
-	  if(tail != NULL)
-	    {
-	      tail->next = p;
-	    }
+      /* if there was a plugin before, connect it to this one */
+      if (tail != NULL) {
+        tail->next = p;
+      }
 
-	  /* make this the last plugin in the list (so far) */
-	  tail = p;
+      /* make this the last plugin in the list (so far) */
+      tail = p;
 
-	  /* disconnect the rest of the list */
-	  tail->next = NULL;
-	}
-
-      /* NB we dont need to free any unused plugins as the all plugins
-	 get free'd anyway when the manager gets free'd */
-
-      /* we now have a list starting at head */
-      manager->first_plugin = head;
-
+      /* disconnect the rest of the list */
+      tail->next = NULL;
     }
+
+    /* NB we dont need to free any unused plugins as the all plugins
+       get free'd anyway when the manager gets free'd */
+
+    /* we now have a list starting at head */
+    manager->first_plugin = head;
+  }
 
   return 0;
 }
@@ -311,44 +287,38 @@ void bgpcorsaro_plugin_manager_free(bgpcorsaro_plugin_manager_t *manager)
 
   assert(manager != NULL);
 
-  if(manager->plugins != NULL)
-    {
-      /* each plugin MUST already have been closed by now */
-      for(i = 0; i < BGPCORSARO_PLUGIN_ID_MAX; i++)
-	{
-	  if(manager->plugins[i] != NULL)
-	    {
-	      /* free the argument strings */
-	      for(j = 0; j < manager->plugins[i]->argc; j++)
-		{
-		  free(manager->plugins[i]->argv[j]);
-		  manager->plugins[i]->argv[j] = NULL;
-		}
-	      free(manager->plugins[i]->argv);
-	      manager->plugins[i]->argv = NULL;
-	      manager->plugins[i]->argc = 0;
+  if (manager->plugins != NULL) {
+    /* each plugin MUST already have been closed by now */
+    for (i = 0; i < BGPCORSARO_PLUGIN_ID_MAX; i++) {
+      if (manager->plugins[i] != NULL) {
+        /* free the argument strings */
+        for (j = 0; j < manager->plugins[i]->argc; j++) {
+          free(manager->plugins[i]->argv[j]);
+          manager->plugins[i]->argv[j] = NULL;
+        }
+        free(manager->plugins[i]->argv);
+        manager->plugins[i]->argv = NULL;
+        manager->plugins[i]->argc = 0;
 
-	      free(manager->plugins[i]);
-	      manager->plugins[i] = NULL;
-	    }
-	}
-      free(manager->plugins);
-      manager->plugins = NULL;
+        free(manager->plugins[i]);
+        manager->plugins[i] = NULL;
+      }
     }
+    free(manager->plugins);
+    manager->plugins = NULL;
+  }
 
-  if(manager->plugins_state != NULL)
-    {
-      /* as above, state will be freed by calls to the each plugins close
-	 function */
-      free(manager->plugins_state);
-      manager->plugins_state = NULL;
-    }
+  if (manager->plugins_state != NULL) {
+    /* as above, state will be freed by calls to the each plugins close
+       function */
+    free(manager->plugins_state);
+    manager->plugins_state = NULL;
+  }
 
-  if(manager->plugins_enabled != NULL)
-    {
-      free(manager->plugins_enabled);
-      manager->plugins_enabled = NULL;
-    }
+  if (manager->plugins_enabled != NULL) {
+    free(manager->plugins_enabled);
+    manager->plugins_enabled = NULL;
+  }
 
   manager->first_plugin = NULL;
   manager->plugins_cnt = 0;
@@ -359,108 +329,101 @@ void bgpcorsaro_plugin_manager_free(bgpcorsaro_plugin_manager_t *manager)
   free(manager);
 }
 
-bgpcorsaro_plugin_t *bgpcorsaro_plugin_get_by_id(bgpcorsaro_plugin_manager_t *manager,
-						 int id)
+bgpcorsaro_plugin_t *
+bgpcorsaro_plugin_get_by_id(bgpcorsaro_plugin_manager_t *manager, int id)
 {
   assert(manager != NULL);
-  if(id < 0 || id > BGPCORSARO_PLUGIN_ID_MAX)
-    {
-      return NULL;
-    }
+  if (id < 0 || id > BGPCORSARO_PLUGIN_ID_MAX) {
+    return NULL;
+  }
 
-  return manager->plugins[id-1];
+  return manager->plugins[id - 1];
 }
 
-bgpcorsaro_plugin_t *bgpcorsaro_plugin_get_by_name(bgpcorsaro_plugin_manager_t *manager,
-						   const char *name)
+bgpcorsaro_plugin_t *
+bgpcorsaro_plugin_get_by_name(bgpcorsaro_plugin_manager_t *manager,
+                              const char *name)
 {
   bgpcorsaro_plugin_t *p = NULL;
-  while((p = bgpcorsaro_plugin_next(manager, p)) != NULL)
-    {
-      if(strlen(name) == strlen(p->name) &&
-	 strncasecmp(name, p->name, strlen(p->name)) == 0)
-	{
-	  return p;
-	}
+  while ((p = bgpcorsaro_plugin_next(manager, p)) != NULL) {
+    if (strlen(name) == strlen(p->name) &&
+        strncasecmp(name, p->name, strlen(p->name)) == 0) {
+      return p;
     }
+  }
   return NULL;
 }
 
-bgpcorsaro_plugin_t *bgpcorsaro_plugin_next(bgpcorsaro_plugin_manager_t *manager,
-					    bgpcorsaro_plugin_t *plugin)
+bgpcorsaro_plugin_t *
+bgpcorsaro_plugin_next(bgpcorsaro_plugin_manager_t *manager,
+                       bgpcorsaro_plugin_t *plugin)
 {
   /* plugins have already been freed, or not init'd */
-  assert(manager != NULL && manager->plugins != NULL
-	 && manager->plugins_cnt != 0);
+  assert(manager != NULL && manager->plugins != NULL &&
+         manager->plugins_cnt != 0);
 
   /* they are asking for the beginning of the list */
-  if(plugin == NULL)
-    {
-      return manager->first_plugin;
-    }
+  if (plugin == NULL) {
+    return manager->first_plugin;
+  }
 
   /* otherwise, give them the next one */
   return plugin->next;
 }
 
 void bgpcorsaro_plugin_register_state(bgpcorsaro_plugin_manager_t *manager,
-				      bgpcorsaro_plugin_t *plugin,
-				      void *state)
+                                      bgpcorsaro_plugin_t *plugin, void *state)
 {
   assert(manager != NULL);
   assert(plugin != NULL);
   assert(state != NULL);
 
-  manager->plugins_state[plugin->id-1] = state;
+  manager->plugins_state[plugin->id - 1] = state;
 }
 
 void bgpcorsaro_plugin_free_state(bgpcorsaro_plugin_manager_t *manager,
-				  bgpcorsaro_plugin_t *plugin)
+                                  bgpcorsaro_plugin_t *plugin)
 {
   assert(manager != NULL);
   assert(plugin != NULL);
 
-  free(manager->plugins_state[plugin->id-1]);
-  manager->plugins_state[plugin->id-1] = NULL;
+  free(manager->plugins_state[plugin->id - 1]);
+  manager->plugins_state[plugin->id - 1] = NULL;
 }
 
-const char *bgpcorsaro_plugin_get_name_by_id(bgpcorsaro_plugin_manager_t *manager,
-					     int id)
+const char *
+bgpcorsaro_plugin_get_name_by_id(bgpcorsaro_plugin_manager_t *manager, int id)
 {
   bgpcorsaro_plugin_t *plugin = NULL;
-  if((plugin = bgpcorsaro_plugin_get_by_id(manager, id)) == NULL)
-    {
-      return NULL;
-    }
+  if ((plugin = bgpcorsaro_plugin_get_by_id(manager, id)) == NULL) {
+    return NULL;
+  }
   return plugin->name;
 }
 
 int bgpcorsaro_plugin_is_enabled(bgpcorsaro_plugin_manager_t *manager,
-				 bgpcorsaro_plugin_t *plugin)
+                                 bgpcorsaro_plugin_t *plugin)
 {
   int i;
 
-  if(manager->plugins_enabled == NULL)
-    {
-      /* no plugins have been explicitly enabled, therefore all plugins
-	 are implicitly enabled */
+  if (manager->plugins_enabled == NULL) {
+    /* no plugins have been explicitly enabled, therefore all plugins
+       are implicitly enabled */
+    return 1;
+  }
+
+  for (i = 0; i < manager->plugins_enabled_cnt; i++) {
+    if (manager->plugins_enabled[i] == plugin->id) {
       return 1;
     }
-
-  for(i=0; i<manager->plugins_enabled_cnt; i++)
-    {
-      if(manager->plugins_enabled[i] == plugin->id)
-	{
-	  return 1;
-	}
-    }
+  }
 
   return 0;
 }
 
 int bgpcorsaro_plugin_enable_plugin(bgpcorsaro_plugin_manager_t *manager,
-				    const char *plugin_name,
-				    const char *plugin_args)
+                                    const char *plugin_name,
+                                    const char *plugin_args)
 {
   bgpcorsaro_plugin_t *plugin = NULL;
   int i;
@@ -471,76 +434,65 @@ int bgpcorsaro_plugin_enable_plugin(bgpcorsaro_plugin_manager_t *manager,
   assert(manager != NULL);
 
   /* first, let us find the plugin with this name */
-  if((plugin = bgpcorsaro_plugin_get_by_name(manager, plugin_name)) == NULL)
-    {
-      bgpcorsaro_log_file(__func__, LOG(manager),
-		       "No plugin found with the name '%s'", plugin_name);
-      bgpcorsaro_log_file(__func__, LOG(manager),
-		       "Is bgpcorsaro compiled with all necessary plugins?");
-      return -1;
-    }
+  if ((plugin = bgpcorsaro_plugin_get_by_name(manager, plugin_name)) == NULL) {
+    bgpcorsaro_log_file(__func__, LOG(manager),
+                        "No plugin found with the name '%s'", plugin_name);
+    bgpcorsaro_log_file(__func__, LOG(manager),
+                        "Is bgpcorsaro compiled with all necessary plugins?");
+    return -1;
+  }
 
   bgpcorsaro_log(__func__, NULL, "enabling %s", plugin_name);
 
   /* now lets set the arguments for the plugin */
   /* we do this here, before we check if it is enabled to allow the args
      to be re-set, so long as it is before the plugin is started */
-  if(plugin_args != NULL && strlen(plugin_args) > 0)
-    {
-      /* parse the args into argc and argv */
-      local_args = strdup(plugin_args);
-      parse_cmd(local_args, &process_argc, process_argv, MAXOPTS, plugin_name);
-    }
+  if (plugin_args != NULL && strlen(plugin_args) > 0) {
+    /* parse the args into argc and argv */
+    local_args = strdup(plugin_args);
+    parse_cmd(local_args, &process_argc, process_argv, MAXOPTS, plugin_name);
+  }
 
   /* remove the default arguments from the plugin (but only if new ones have
      been given to us */
   assert(plugin->argv != NULL && plugin->argc == 1);
-  if(process_argc > 0)
-    {
-      free(plugin->argv[0]);
-      free(plugin->argv);
-      plugin->argc = 0;
+  if (process_argc > 0) {
+    free(plugin->argv[0]);
+    free(plugin->argv);
+    plugin->argc = 0;
 
-      if(copy_argv(plugin, process_argc, process_argv) != 0)
-	{
-	  if(local_args != NULL)
-	    {
-	      bgpcorsaro_log(__func__, NULL, "freeing local args");
-	      free(local_args);
-	    }
-	  return -1;
-	}
-
-      if(local_args != NULL)
-	{
-	  /* this is the storage for the strings until copy_argv is complete */
-	  free(local_args);
-	}
-    }
-
-  /* now we need to ensure it isn't already enabled */
-  for(i = 0; i < manager->plugins_enabled_cnt; i++)
-    {
-      if(plugin->id == manager->plugins_enabled[i])
-	{
-	  return 0;
-	}
-    }
-
-  /* now we need to remalloc the array */
-  if((manager->plugins_enabled = realloc(manager->plugins_enabled,
-					 sizeof(uint16_t)*
-					 (manager->plugins_enabled_cnt+1)
-					 )) == NULL)
-    {
-      bgpcorsaro_log_file(__func__, LOG(manager),
-		       "could not extend the enabled plugins array");
+    if (copy_argv(plugin, process_argc, process_argv) != 0) {
+      if (local_args != NULL) {
+        bgpcorsaro_log(__func__, NULL, "freeing local args");
+        free(local_args);
+      }
       return -1;
     }
+
+    if (local_args != NULL) {
+      /* this is the storage for the strings until copy_argv is complete */
+      free(local_args);
+    }
+  }
+
+  /* now we need to ensure it isn't already enabled */
+  for (i = 0; i < manager->plugins_enabled_cnt; i++) {
+    if (plugin->id == manager->plugins_enabled[i]) {
+      return 0;
+    }
+  }
+
+  /* now we need to remalloc the array */
+  if ((manager->plugins_enabled = realloc(
+         manager->plugins_enabled,
+         sizeof(uint16_t) * (manager->plugins_enabled_cnt + 1))) == NULL) {
+    bgpcorsaro_log_file(__func__, LOG(manager),
+                        "could not extend the enabled plugins array");
+    return -1;
+  }
 
   /* now we shall store this id in this spot! */
   manager->plugins_enabled[manager->plugins_enabled_cnt++] = plugin->id;
 
   return 0;
 }
-

--- a/bgpcorsaro/lib/bgpcorsaro_plugin.h
+++ b/bgpcorsaro/lib/bgpcorsaro_plugin.h
@@ -33,57 +33,56 @@
  *
  */
 
-/** Convenience macro that defines all the function prototypes for the bgpcorsaro
+/** Convenience macro that defines all the function prototypes for the
+ * bgpcorsaro
  * plugin API
  *
  * @todo split this into bgpcorsaro-out and bgpcorsaro-in macros
  */
-#define BGPCORSARO_PLUGIN_GENERATE_PROTOS(plugin)			\
-  bgpcorsaro_plugin_t * plugin##_alloc();				\
-  int plugin##_init_output(struct bgpcorsaro *bgpcorsaro);		\
-  int plugin##_close_output(struct bgpcorsaro *bgpcorsaro);		\
-  int plugin##_start_interval(struct bgpcorsaro *bgpcorsaro,		\
-			      struct bgpcorsaro_interval *int_start);	\
-  int plugin##_end_interval(struct bgpcorsaro *bgpcorsaro,		\
-			    struct bgpcorsaro_interval *int_end);	\
-  int plugin##_process_record(struct bgpcorsaro *bgpcorsaro,		\
-			      struct bgpcorsaro_record *record);
+#define BGPCORSARO_PLUGIN_GENERATE_PROTOS(plugin)                              \
+  bgpcorsaro_plugin_t *plugin##_alloc();                                       \
+  int plugin##_init_output(struct bgpcorsaro *bgpcorsaro);                     \
+  int plugin##_close_output(struct bgpcorsaro *bgpcorsaro);                    \
+  int plugin##_start_interval(struct bgpcorsaro *bgpcorsaro,                   \
+                              struct bgpcorsaro_interval *int_start);          \
+  int plugin##_end_interval(struct bgpcorsaro *bgpcorsaro,                     \
+                            struct bgpcorsaro_interval *int_end);              \
+  int plugin##_process_record(struct bgpcorsaro *bgpcorsaro,                   \
+                              struct bgpcorsaro_record *record);
 
 /** Convenience macro that defines all the function pointers for the bgpcorsaro
  * plugin API
  */
-#define BGPCORSARO_PLUGIN_GENERATE_PTRS(plugin)		\
-    plugin##_init_output,				\
-    plugin##_close_output,				\
-    plugin##_start_interval,				\
-    plugin##_end_interval,				\
-    plugin##_process_record
+#define BGPCORSARO_PLUGIN_GENERATE_PTRS(plugin)                                \
+  plugin##_init_output, plugin##_close_output, plugin##_start_interval,        \
+    plugin##_end_interval, plugin##_process_record
 
-/** Convenience macro that defines all the 'remaining' blank fields in a bgpcorsaro
+/** Convenience macro that defines all the 'remaining' blank fields in a
+ * bgpcorsaro
  *  plugin object
  *
  *  This becomes useful if we add more fields to the end of the plugin
  *  structure, because each plugin does not need to be updated in order to
  *  correctly 'zero' these fields.
  */
-#define BGPCORSARO_PLUGIN_GENERATE_TAIL		\
-  NULL,				/* next */	\
-    0,				/* argc */	\
-    NULL                        /* argv */
+#define BGPCORSARO_PLUGIN_GENERATE_TAIL                                        \
+  NULL,  /* next */                                                            \
+    0,   /* argc */                                                            \
+    NULL /* argv */
 
 /** Convenience macro to cast the state pointer in the plugin
  *
  * Plugins should use extend this macro to provide access to their state
  */
-#define BGPCORSARO_PLUGIN_STATE(bgpcorsaro, type, id)			\
-  ((struct bgpcorsaro_##type##_state_t*)				\
-   ((bgpcorsaro)->plugin_manager->plugins_state[(id)-1]))
+#define BGPCORSARO_PLUGIN_STATE(bgpcorsaro, type, id)                          \
+  ((struct bgpcorsaro_##type##_state_t                                         \
+      *)((bgpcorsaro)->plugin_manager->plugins_state[(id)-1]))
 
 /** Convenience macro to get this plugin from bgpcorsaro
  *
  * Plugins should use extend this macro to provide access to themself
  */
-#define BGPCORSARO_PLUGIN_PLUGIN(bgpcorsaro, id)	\
+#define BGPCORSARO_PLUGIN_PLUGIN(bgpcorsaro, id)                               \
   ((bgpcorsaro)->plugin_manager->plugins[(id)-1])
 
 /** A unique identifier for a plugin, used when writing binary data
@@ -93,25 +92,23 @@
  *       ED_WITH_PLUGIN macros in configure.ac, or by the order of the plugins
  *       that have been explicitly enabled using \ref bgpcorsaro_enable_plugin
  */
-typedef enum bgpcorsaro_plugin_id
-{
+typedef enum bgpcorsaro_plugin_id {
   /** Prefix Monitor plugin */
-  BGPCORSARO_PLUGIN_ID_PFXMONITOR       = 1,
+  BGPCORSARO_PLUGIN_ID_PFXMONITOR = 1,
 
   /** Pacifier plugin */
-  BGPCORSARO_PLUGIN_ID_PACIFIER         = 2,
+  BGPCORSARO_PLUGIN_ID_PACIFIER = 2,
 
   /** AS Monitor plugin */
-  BGPCORSARO_PLUGIN_ID_ASMONITOR        = 3,
+  BGPCORSARO_PLUGIN_ID_ASMONITOR = 3,
 
   /** Maximum plugin ID assigned */
-  BGPCORSARO_PLUGIN_ID_MAX              = BGPCORSARO_PLUGIN_ID_ASMONITOR
+  BGPCORSARO_PLUGIN_ID_MAX = BGPCORSARO_PLUGIN_ID_ASMONITOR
 } bgpcorsaro_plugin_id_t;
 
 /** An bgpcorsaro packet processing plugin */
 /* All functions should return -1, or NULL on failure */
-typedef struct bgpcorsaro_plugin
-{
+typedef struct bgpcorsaro_plugin {
   /** The name of this plugin used in the ascii output and eventually to allow
    * plugins to be enabled and disabled */
   const char *name;
@@ -143,7 +140,7 @@ typedef struct bgpcorsaro_plugin
    * @return 0 if successful, -1 if an error occurs
    */
   int (*start_interval)(struct bgpcorsaro *bgpcorsaro,
-			bgpcorsaro_interval_t *int_start);
+                        bgpcorsaro_interval_t *int_start);
 
   /** Ends an interval
    *
@@ -154,7 +151,7 @@ typedef struct bgpcorsaro_plugin
    * This is likely when the plugin will write it's data to it's output file
    */
   int (*end_interval)(struct bgpcorsaro *bgpcorsaro,
-		      bgpcorsaro_interval_t *int_end);
+                      bgpcorsaro_interval_t *int_end);
 
   /**
    * Process a record
@@ -168,7 +165,7 @@ typedef struct bgpcorsaro_plugin
    * bgpcorsaro_record_state object to pass on discoveries to later plugins.
    */
   int (*process_record)(struct bgpcorsaro *bgpcorsaro,
-			struct bgpcorsaro_record *record);
+                        struct bgpcorsaro_record *record);
 
   /** Next pointer. Used by the plugin manager. */
   struct bgpcorsaro_plugin *next;
@@ -206,8 +203,7 @@ typedef struct bgpcorsaro_plugin
  * This allows both bgpcorsaro_t and bgpcorsaro_in_t objects to use the plugin
  * infrastructure without needing to pass references to themselves
  */
-typedef struct bgpcorsaro_plugin_manager
-{
+typedef struct bgpcorsaro_plugin_manager {
   /** An array of plugin ids that have been enabled by the user
    *
    * If this array is NULL, then assume all have been enabled.
@@ -263,9 +259,8 @@ void bgpcorsaro_plugin_manager_free(bgpcorsaro_plugin_manager_t *manager);
  * @param id        The id of the plugin to get
  * @return the plugin corresponding to the id if found, NULL otherwise
  */
-bgpcorsaro_plugin_t *bgpcorsaro_plugin_get_by_id(
-					   bgpcorsaro_plugin_manager_t *manager,
-					   int id);
+bgpcorsaro_plugin_t *
+bgpcorsaro_plugin_get_by_id(bgpcorsaro_plugin_manager_t *manager, int id);
 
 /** Attempt to retrieve a plugin by name
  *
@@ -273,9 +268,9 @@ bgpcorsaro_plugin_t *bgpcorsaro_plugin_get_by_id(
  * @param name      The name of the plugin to get
  * @return the plugin corresponding to the name if found, NULL otherwise
  */
-bgpcorsaro_plugin_t *bgpcorsaro_plugin_get_by_name(
-					   bgpcorsaro_plugin_manager_t *manager,
-					   const char *name);
+bgpcorsaro_plugin_t *
+bgpcorsaro_plugin_get_by_name(bgpcorsaro_plugin_manager_t *manager,
+                              const char *name);
 
 /** Retrieve the next plugin in the list
  *
@@ -285,9 +280,9 @@ bgpcorsaro_plugin_t *bgpcorsaro_plugin_get_by_name(
  * plugin list has been reached. If plugin is NULL, the first plugin will be
  * returned.
  */
-bgpcorsaro_plugin_t *bgpcorsaro_plugin_next(
-					   bgpcorsaro_plugin_manager_t *manager,
-					   bgpcorsaro_plugin_t *plugin);
+bgpcorsaro_plugin_t *
+bgpcorsaro_plugin_next(bgpcorsaro_plugin_manager_t *manager,
+                       bgpcorsaro_plugin_t *plugin);
 
 /** Register the state for a plugin
  *
@@ -296,8 +291,7 @@ bgpcorsaro_plugin_t *bgpcorsaro_plugin_next(
  * @param state     A pointer to the state object to register
  */
 void bgpcorsaro_plugin_register_state(bgpcorsaro_plugin_manager_t *manager,
-				      bgpcorsaro_plugin_t *plugin,
-				      void *state);
+                                      bgpcorsaro_plugin_t *plugin, void *state);
 
 /** Free the state for a plugin
  *
@@ -305,7 +299,7 @@ void bgpcorsaro_plugin_register_state(bgpcorsaro_plugin_manager_t *manager,
  * @param plugin    The plugin to free state for
  */
 void bgpcorsaro_plugin_free_state(bgpcorsaro_plugin_manager_t *manager,
-				  bgpcorsaro_plugin_t *plugin);
+                                  bgpcorsaro_plugin_t *plugin);
 
 /** Get the name of a plugin given it's ID number
  *
@@ -314,9 +308,8 @@ void bgpcorsaro_plugin_free_state(bgpcorsaro_plugin_manager_t *manager,
  * @return the name of the plugin as a string, NULL if no plugin matches
  * the given id
  */
-const char *bgpcorsaro_plugin_get_name_by_id(
-					   bgpcorsaro_plugin_manager_t *manager,
-					   int id);
+const char *
+bgpcorsaro_plugin_get_name_by_id(bgpcorsaro_plugin_manager_t *manager, int id);
 
 /** Determine whether this plugin is enabled for use
  *
@@ -328,7 +321,7 @@ const char *bgpcorsaro_plugin_get_name_by_id(
  *  function, or implicitly because all plugins are enabled.
  */
 int bgpcorsaro_plugin_is_enabled(bgpcorsaro_plugin_manager_t *manager,
-				 bgpcorsaro_plugin_t *plugin);
+                                 bgpcorsaro_plugin_t *plugin);
 
 /** Attempt to enable a plugin by its name
  *
@@ -340,8 +333,7 @@ int bgpcorsaro_plugin_is_enabled(bgpcorsaro_plugin_manager_t *manager,
  * See bgpcorsaro_enable_plugin for more details.
  */
 int bgpcorsaro_plugin_enable_plugin(bgpcorsaro_plugin_manager_t *manager,
-				    const char *plugin_name,
-				    const char *plugin_args);
+                                    const char *plugin_name,
+                                    const char *plugin_args);
 
 #endif /* __BGPCORSARO_PLUGIN_H */
-

--- a/bgpcorsaro/lib/plugins/bgpcorsaro_asmonitor.c
+++ b/bgpcorsaro/lib/plugins/bgpcorsaro_asmonitor.c
@@ -20,8 +20,8 @@
  * You should have received a copy of the GNU General Public License along with
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "config.h"
 #include "bgpcorsaro_int.h"
+#include "config.h"
 
 #include <assert.h>
 #include <stdio.h>
@@ -37,8 +37,8 @@
 
 #include "bgpcorsaro_asmonitor.h"
 
-#include "khash.h"
 #include "bgpstream_utils.h"
+#include "khash.h"
 
 /** @file
  *
@@ -70,7 +70,8 @@
 /** Minimum number of peer ASns to declare prefix visible */
 #define ASMONITOR_DEFAULT_PEER_ASNS_THRESHOLD 10
 
-/** How long it takes for a prefix to be discarded from monitoring (if not announced) */
+/** How long it takes for a prefix to be discarded from monitoring (if not
+ * announced) */
 #define ASMONITOR_DEFAULT_PREFIX_WINDOW 3600 * 24
 
 /** Maximum string length for the metric prefix */
@@ -79,23 +80,20 @@
 /** Maximum string length for the log entries */
 #define MAX_LOG_BUFFER_LEN 1024
 
-#define DUMP_METRIC(value, time, fmt, ...)                              \
-  do {                                                                  \
-    fprintf(stdout, fmt" %"PRIu32" %"PRIu32"\n",                        \
-            __VA_ARGS__, value, time);                                  \
-  } while(0)
-
+#define DUMP_METRIC(value, time, fmt, ...)                                     \
+  do {                                                                         \
+    fprintf(stdout, fmt " %" PRIu32 " %" PRIu32 "\n", __VA_ARGS__, value,      \
+            time);                                                             \
+  } while (0)
 
 /** Common plugin information across all instances */
 static bgpcorsaro_plugin_t bgpcorsaro_asmonitor_plugin = {
-  PLUGIN_NAME,                                            /* name */
-  PLUGIN_VERSION,                                         /* version */
+  PLUGIN_NAME,                                           /* name */
+  PLUGIN_VERSION,                                        /* version */
   BGPCORSARO_PLUGIN_ID_ASMONITOR,                        /* id */
   BGPCORSARO_PLUGIN_GENERATE_PTRS(bgpcorsaro_asmonitor), /* func ptrs */
   BGPCORSARO_PLUGIN_GENERATE_TAIL,
 };
-
-
 
 /** Data structure associated with each prefix
  *  in the patricia tree (attached to the user
@@ -107,25 +105,22 @@ typedef struct perpfx_info {
 
 } perpfx_info_t;
 
-
 /** A set that contains a unique set of path segments */
 KHASH_INIT(path_segments, bgpstream_as_path_seg_t *, char, 0,
            bgpstream_as_path_seg_hash, bgpstream_as_path_seg_equal);
 typedef khash_t(path_segments) path_segments_t;
 
-
 /** A map that contains, for each origin the number of peer ASns observing it */
-KHASH_INIT(asn_count_map, uint32_t, uint32_t, 1,
-           kh_int_hash_func, kh_int_hash_equal);
+KHASH_INIT(asn_count_map, uint32_t, uint32_t, 1, kh_int_hash_func,
+           kh_int_hash_equal);
 
 /** A map that contains the origin observed by a specific peer */
-KHASH_INIT(peer_asn_map, uint32_t, uint32_t, 1,
-           kh_int_hash_func, kh_int_hash_equal);
+KHASH_INIT(peer_asn_map, uint32_t, uint32_t, 1, kh_int_hash_func,
+           kh_int_hash_equal);
 
 /** A map that contains information for each prefix */
-KHASH_INIT(pfx_info_map, bgpstream_pfx_storage_t, khash_t(peer_asn_map)*, 1,
+KHASH_INIT(pfx_info_map, bgpstream_pfx_storage_t, khash_t(peer_asn_map) *, 1,
            bgpstream_pfx_storage_hash_val, bgpstream_pfx_storage_equal_val);
-
 
 /** Holds the state for an instance of this plugin */
 struct bgpcorsaro_asmonitor_state_t {
@@ -153,7 +148,7 @@ struct bgpcorsaro_asmonitor_state_t {
   bgpstream_id_set_t *peer_asns;
 
   /** Prefix info map */
-  khash_t(pfx_info_map) *pfx_info;
+  khash_t(pfx_info_map) * pfx_info;
 
   /** origins' set to compute unique origin
    *  ASns  */
@@ -171,19 +166,17 @@ struct bgpcorsaro_asmonitor_state_t {
 
   /** IP space name */
   char ip_space_name[ASMONITOR_METRIC_PFX_LEN];
-
 };
 
 /** Extends the generic plugin state convenience macro in bgpcorsaro_plugin.h */
-#define STATE(bgpcorsaro)						\
-  (BGPCORSARO_PLUGIN_STATE(bgpcorsaro, asmonitor,                      \
+#define STATE(bgpcorsaro)                                                      \
+  (BGPCORSARO_PLUGIN_STATE(bgpcorsaro, asmonitor,                              \
                            BGPCORSARO_PLUGIN_ID_ASMONITOR))
 
-/** Extends the generic plugin plugin convenience macro in bgpcorsaro_plugin.h */
-#define PLUGIN(bgpcorsaro)						\
+/** Extends the generic plugin plugin convenience macro in bgpcorsaro_plugin.h
+ */
+#define PLUGIN(bgpcorsaro)                                                     \
   (BGPCORSARO_PLUGIN_PLUGIN(bgpcorsaro, BGPCORSARO_PLUGIN_ID_ASMONITOR))
-
-
 
 /* ================ per prefix info management ================ */
 
@@ -191,11 +184,10 @@ struct bgpcorsaro_asmonitor_state_t {
 static perpfx_info_t *perpfx_info_create(uint32_t ts)
 {
   perpfx_info_t *ppi;
-  if((ppi = (perpfx_info_t *) malloc_zero(sizeof(perpfx_info_t))) == NULL)
-    {
-      fprintf(stderr, "Warning could not alloc perpfx_info_t\n");
-      return NULL;
-    }
+  if ((ppi = (perpfx_info_t *)malloc_zero(sizeof(perpfx_info_t))) == NULL) {
+    fprintf(stderr, "Warning could not alloc perpfx_info_t\n");
+    return NULL;
+  }
   ppi->last_observed = ts;
   return ppi;
 }
@@ -210,31 +202,26 @@ static void perpfx_info_set_ts(perpfx_info_t *ppi, uint32_t ts)
 /** Destroy the perpfx info structure */
 static void perpfx_info_destroy(void *ppi)
 {
-  if(ppi!=NULL)
-    {
-      free((perpfx_info_t *)ppi);
-    }
+  if (ppi != NULL) {
+    free((perpfx_info_t *)ppi);
+  }
 }
 
 void remove_old_prefixes(bgpstream_patricia_tree_t *pt,
-                         bgpstream_patricia_node_t * node,
-                         void* data)
+                         bgpstream_patricia_node_t *node, void *data)
 {
-  uint32_t *last_valid_ts = (uint32_t *) data;
+  uint32_t *last_valid_ts = (uint32_t *)data;
   perpfx_info_t *info = (perpfx_info_t *)bgpstream_patricia_tree_get_user(node);
-  if(info != NULL)
-    {
-      if(info->last_observed < *last_valid_ts)
-        {
-          bgpstream_patricia_tree_remove_node(pt, node);
-        }
+  if (info != NULL) {
+    if (info->last_observed < *last_valid_ts) {
+      bgpstream_patricia_tree_remove_node(pt, node);
     }
+  }
 }
 
 /* ================ output stats  ================ */
 
-static int
-output_stats_and_reset(bgpcorsaro_t *bgpcorsaro)
+static int output_stats_and_reset(bgpcorsaro_t *bgpcorsaro)
 {
   struct bgpcorsaro_asmonitor_state_t *state = STATE(bgpcorsaro);
 
@@ -246,183 +233,160 @@ output_stats_and_reset(bgpcorsaro_t *bgpcorsaro)
   int v;
   uint32_t unique_pfxs[BGPSTREAM_MAX_IP_VERSION_IDX];
   uint32_t overlapping_pfxs[BGPSTREAM_MAX_IP_VERSION_IDX];
-  khash_t(peer_asn_map) *pam;
+  khash_t(peer_asn_map) * pam;
   /* origin_asn -> num peer ASns*/
   khash_t(asn_count_map) *asn_np = NULL;
 
-  if((asn_np = kh_init(asn_count_map)) == NULL)
-    {
-      return -1;
-    }
+  if ((asn_np = kh_init(asn_count_map)) == NULL) {
+    return -1;
+  }
 
   /* init counters */
-  for(v=0; v < BGPSTREAM_MAX_IP_VERSION_IDX; v++)
-    {
-      unique_pfxs[v] = bgpstream_patricia_prefix_count(state->patricia, bgpstream_idx2ipv(v));
-      overlapping_pfxs[v] = 0;
-    }
+  for (v = 0; v < BGPSTREAM_MAX_IP_VERSION_IDX; v++) {
+    unique_pfxs[v] =
+      bgpstream_patricia_prefix_count(state->patricia, bgpstream_idx2ipv(v));
+    overlapping_pfxs[v] = 0;
+  }
 
   /* for each prefix go through all peers */
-  for (k = kh_begin(state->pfx_info); k != kh_end(state->pfx_info); ++k)
-    {
-      if (kh_exist(state->pfx_info, k) == 0)
-        {
-          continue;
-        }
-      /* reset counters */
-      kh_clear(asn_count_map, asn_np);
+  for (k = kh_begin(state->pfx_info); k != kh_end(state->pfx_info); ++k) {
+    if (kh_exist(state->pfx_info, k) == 0) {
+      continue;
+    }
+    /* reset counters */
+    kh_clear(asn_count_map, asn_np);
 
-      /* get prefix version index */
-      v = bgpstream_ipv2idx(kh_key(state->pfx_info, k).address.version);
+    /* get prefix version index */
+    v = bgpstream_ipv2idx(kh_key(state->pfx_info, k).address.version);
 
-      /* get peer-asn map for this prefix */
-      pam = kh_value(state->pfx_info, k);
+    /* get peer-asn map for this prefix */
+    pam = kh_value(state->pfx_info, k);
 
-      /* save the origin asn visibility (i.e. how many peers' ASns
-       * observe such information */
+    /* save the origin asn visibility (i.e. how many peers' ASns
+     * observe such information */
 
-      /* for each peer, go through all origins */
-      for (p = kh_begin(pam); p != kh_end(pam); ++p)
-        {
-          if (kh_exist(pam, p) == 0)
-            {
-              continue;
-            }
-          /* increment the counter for this ASN */
-          if((a = kh_get(asn_count_map, asn_np, kh_value(pam,p))) ==
-             kh_end(asn_np))
-            {
-              a = kh_put(asn_count_map, asn_np, kh_value(pam,p), &khret);
-              kh_value(asn_np,a) = 1;
-            }
-          else
-            {
-              kh_value(asn_np,a)++;
-            }
-        }
-
-      /* now asn_np has a complete count of the number of peers' ASns that observed
-         each origin ASN */
-
-      /* count the prefix and origins if their visibility
-       * is above the threshold */
-      pfx_visible = 0;
-      for (a = kh_begin(asn_np); a != kh_end(asn_np); ++a)
-        {
-          if (kh_exist(asn_np, a) == 0)
-            {
-              continue;
-            }
-          /* the information is accounted only if it is
-           * consistent on at least threshold peers' ASns */
-          if(kh_value(asn_np, a) >= state->peer_asns_th)
-            {
-              pfx_visible = 1;
-
-              bgpstream_id_set_insert(state->unique_origins[v], kh_key(asn_np, a));
-            }
-        }
-
-      /* updating counters */
-      overlapping_pfxs[v] += pfx_visible;
+    /* for each peer, go through all origins */
+    for (p = kh_begin(pam); p != kh_end(pam); ++p) {
+      if (kh_exist(pam, p) == 0) {
+        continue;
+      }
+      /* increment the counter for this ASN */
+      if ((a = kh_get(asn_count_map, asn_np, kh_value(pam, p))) ==
+          kh_end(asn_np)) {
+        a = kh_put(asn_count_map, asn_np, kh_value(pam, p), &khret);
+        kh_value(asn_np, a) = 1;
+      } else {
+        kh_value(asn_np, a)++;
+      }
     }
 
-  for(v=0; v < BGPSTREAM_MAX_IP_VERSION_IDX; v++)
-    {
-      DUMP_METRIC(unique_pfxs[v], state->interval_start, "%s.%s.%s.v%d.%s",
-               state->metric_prefix, PLUGIN_NAME, state->ip_space_name, bgpstream_idx2number(v),
-               "prefixes_cnt" );
-      DUMP_METRIC(overlapping_pfxs[v], state->interval_start, "%s.%s.%s.v%d.%s",
-               state->metric_prefix, PLUGIN_NAME, state->ip_space_name, bgpstream_idx2number(v),
-               "overlapping_prefixes_cnt" );
-      DUMP_METRIC(bgpstream_id_set_size(state->unique_origins[v]), state->interval_start, "%s.%s.%s.v%d.%s",
-               state->metric_prefix, PLUGIN_NAME, state->ip_space_name, bgpstream_idx2number(v), 
-               "origin_ASN_cnt" );
+    /* now asn_np has a complete count of the number of peers' ASns that
+       observed
+       each origin ASN */
+
+    /* count the prefix and origins if their visibility
+     * is above the threshold */
+    pfx_visible = 0;
+    for (a = kh_begin(asn_np); a != kh_end(asn_np); ++a) {
+      if (kh_exist(asn_np, a) == 0) {
+        continue;
+      }
+      /* the information is accounted only if it is
+       * consistent on at least threshold peers' ASns */
+      if (kh_value(asn_np, a) >= state->peer_asns_th) {
+        pfx_visible = 1;
+
+        bgpstream_id_set_insert(state->unique_origins[v], kh_key(asn_np, a));
+      }
     }
-  
+
+    /* updating counters */
+    overlapping_pfxs[v] += pfx_visible;
+  }
+
+  for (v = 0; v < BGPSTREAM_MAX_IP_VERSION_IDX; v++) {
+    DUMP_METRIC(unique_pfxs[v], state->interval_start, "%s.%s.%s.v%d.%s",
+                state->metric_prefix, PLUGIN_NAME, state->ip_space_name,
+                bgpstream_idx2number(v), "prefixes_cnt");
+    DUMP_METRIC(overlapping_pfxs[v], state->interval_start, "%s.%s.%s.v%d.%s",
+                state->metric_prefix, PLUGIN_NAME, state->ip_space_name,
+                bgpstream_idx2number(v), "overlapping_prefixes_cnt");
+    DUMP_METRIC(bgpstream_id_set_size(state->unique_origins[v]),
+                state->interval_start, "%s.%s.%s.v%d.%s", state->metric_prefix,
+                PLUGIN_NAME, state->ip_space_name, bgpstream_idx2number(v),
+                "origin_ASN_cnt");
+  }
 
   /* resetting data structures and removing from the patricia
    * tree prefixes that are older than a given window */
   uint32_t last_valid_ts = 0;
-  if(state->interval_start > state->pfx_window)
-    {
-      last_valid_ts = state->interval_start - state->pfx_window;
-    }
-  bgpstream_patricia_tree_walk(state->patricia, remove_old_prefixes, (void *) &last_valid_ts);
+  if (state->interval_start > state->pfx_window) {
+    last_valid_ts = state->interval_start - state->pfx_window;
+  }
+  bgpstream_patricia_tree_walk(state->patricia, remove_old_prefixes,
+                               (void *)&last_valid_ts);
 
   /* now we check again all the stored prefixes and remove those
    * that do not overlap anymore */
   uint8_t overlap;
 
-  for (k = kh_begin(state->pfx_info); k != kh_end(state->pfx_info); ++k)
-    {
-      if (kh_exist(state->pfx_info, k))
-        {
-          overlap = bgpstream_patricia_tree_get_pfx_overlap_info(state->patricia,
-                                                                 (bgpstream_pfx_t *) &kh_key(state->pfx_info, k));
-          if(overlap == 0 ||
-             (state->more_specific &&
-              !(overlap & (BGPSTREAM_PATRICIA_LESS_SPECIFICS | BGPSTREAM_PATRICIA_EXACT_MATCH))))
-            {
-              kh_destroy(peer_asn_map, kh_val(state->pfx_info, k));
-              kh_del(pfx_info_map, state->pfx_info, k);
-            }
-        }
+  for (k = kh_begin(state->pfx_info); k != kh_end(state->pfx_info); ++k) {
+    if (kh_exist(state->pfx_info, k)) {
+      overlap = bgpstream_patricia_tree_get_pfx_overlap_info(
+        state->patricia, (bgpstream_pfx_t *)&kh_key(state->pfx_info, k));
+      if (overlap == 0 || (state->more_specific &&
+                           !(overlap & (BGPSTREAM_PATRICIA_LESS_SPECIFICS |
+                                        BGPSTREAM_PATRICIA_EXACT_MATCH)))) {
+        kh_destroy(peer_asn_map, kh_val(state->pfx_info, k));
+        kh_del(pfx_info_map, state->pfx_info, k);
+      }
     }
+  }
 
-  for(v=0; v < BGPSTREAM_MAX_IP_VERSION_IDX; v++)
-    {
-      bgpstream_id_set_clear(state->unique_origins[v]);
-    }
+  for (v = 0; v < BGPSTREAM_MAX_IP_VERSION_IDX; v++) {
+    bgpstream_id_set_clear(state->unique_origins[v]);
+  }
   kh_destroy(asn_count_map, asn_np);
 
   return 0;
 }
 
 /* set the origin ASN for a given prefix as observed by a given peer */
-static int
-set_pfx_peer_origin(struct bgpcorsaro_asmonitor_state_t *state,
-                    const bgpstream_pfx_storage_t *pfx,
-                    uint32_t peer_asn,
-                    bgpstream_as_path_seg_t *origin_seg)
+static int set_pfx_peer_origin(struct bgpcorsaro_asmonitor_state_t *state,
+                               const bgpstream_pfx_storage_t *pfx,
+                               uint32_t peer_asn,
+                               bgpstream_as_path_seg_t *origin_seg)
 {
   khiter_t k;
   int khret;
-  khash_t(peer_asn_map) *pam;
+  khash_t(peer_asn_map) * pam;
 
-
-  if(origin_seg == NULL || origin_seg->type != BGPSTREAM_AS_PATH_SEG_ASN)
-    {
-      fprintf(stderr, "WARN: ignoring AS sets and confederations\n");
-      return 0;
-    }
+  if (origin_seg == NULL || origin_seg->type != BGPSTREAM_AS_PATH_SEG_ASN) {
+    fprintf(stderr, "WARN: ignoring AS sets and confederations\n");
+    return 0;
+  }
   /* simple origin ASN */
-  uint32_t origin_asn = ((bgpstream_as_path_seg_asn_t*)origin_seg)->asn;
+  uint32_t origin_asn = ((bgpstream_as_path_seg_asn_t *)origin_seg)->asn;
 
   /* does the prefix already exist, if not, create it */
-  if((k = kh_get(pfx_info_map, state->pfx_info, *pfx))
-     == kh_end(state->pfx_info))
-    {
-      /* no, insert it */
-      k = kh_put(pfx_info_map, state->pfx_info, *pfx, &khret);
+  if ((k = kh_get(pfx_info_map, state->pfx_info, *pfx)) ==
+      kh_end(state->pfx_info)) {
+    /* no, insert it */
+    k = kh_put(pfx_info_map, state->pfx_info, *pfx, &khret);
 
-      /* create a peer-asn map */
-      if((pam = kh_init(peer_asn_map)) == NULL)
-        {
-          return -1;
-        }
-      kh_value(state->pfx_info, k) = pam;
+    /* create a peer-asn map */
+    if ((pam = kh_init(peer_asn_map)) == NULL) {
+      return -1;
     }
-  else
-    {
-      pam = kh_value(state->pfx_info, k);
-    }
+    kh_value(state->pfx_info, k) = pam;
+  } else {
+    pam = kh_value(state->pfx_info, k);
+  }
 
   /* does the peer exist? ({pfx}{peer}), if not, create it */
-  if((k = kh_get(peer_asn_map, pam, peer_asn)) == kh_end(pam))
-    {
-      k = kh_put(peer_asn_map, pam, peer_asn, &khret);
-    }
+  if ((k = kh_get(peer_asn_map, pam, peer_asn)) == kh_end(pam)) {
+    k = kh_put(peer_asn_map, pam, peer_asn, &khret);
+  }
   /* set the origin ASN for this pfx/peer combo */
   kh_value(pam, k) = origin_asn;
 
@@ -431,25 +395,22 @@ set_pfx_peer_origin(struct bgpcorsaro_asmonitor_state_t *state,
 
 /* remove pfx/peer from state */
 static void rm_pfx_peer(struct bgpcorsaro_asmonitor_state_t *state,
-                        const bgpstream_pfx_storage_t *pfx,
-                        uint32_t peer_asn)
+                        const bgpstream_pfx_storage_t *pfx, uint32_t peer_asn)
 {
   khiter_t k;
-  khash_t(peer_asn_map) *pam;
+  khash_t(peer_asn_map) * pam;
 
   /* does the pfx exist? */
-  if((k = kh_get(pfx_info_map, state->pfx_info, *pfx))
-     == kh_end(state->pfx_info))
-    {
-      return;
-    }
+  if ((k = kh_get(pfx_info_map, state->pfx_info, *pfx)) ==
+      kh_end(state->pfx_info)) {
+    return;
+  }
   pam = kh_value(state->pfx_info, k);
 
   /* does this peer exist for this pfx */
-  if((k = kh_get(peer_asn_map, pam, peer_asn)) == kh_end(pam))
-    {
-      return;
-    }
+  if ((k = kh_get(peer_asn_map, pam, peer_asn)) == kh_end(pam)) {
+    return;
+  }
 
   /* deallocate memory for segment */
   kh_del(peer_asn_map, pam, k);
@@ -457,89 +418,82 @@ static void rm_pfx_peer(struct bgpcorsaro_asmonitor_state_t *state,
   return;
 }
 
-static int
-process_overlapping_pfx(struct bgpcorsaro_asmonitor_state_t *state,
-                        const bgpstream_record_t * bs_record, const bgpstream_elem_t *elem)
+static int process_overlapping_pfx(struct bgpcorsaro_asmonitor_state_t *state,
+                                   const bgpstream_record_t *bs_record,
+                                   const bgpstream_elem_t *elem)
 {
   char log_buffer[MAX_LOG_BUFFER_LEN] = "";
 
-
-  if(elem->type == BGPSTREAM_ELEM_TYPE_WITHDRAWAL)
-    {
-      /* remove pfx/peer from state structure */
-      rm_pfx_peer(state, &elem->prefix, elem->peer_asnumber);
+  if (elem->type == BGPSTREAM_ELEM_TYPE_WITHDRAWAL) {
+    /* remove pfx/peer from state structure */
+    rm_pfx_peer(state, &elem->prefix, elem->peer_asnumber);
+  } else /* (announcement or rib) */
+  {
+    /* get the origin asn segment and update the data structure */
+    if (set_pfx_peer_origin(state, &elem->prefix, elem->peer_asnumber,
+                            bgpstream_as_path_get_origin_seg(elem->aspath)) !=
+        0) {
+      return -1;
     }
-  else /* (announcement or rib) */
-    {
-      /* get the origin asn segment and update the data structure */
-      if(set_pfx_peer_origin(state, &elem->prefix, elem->peer_asnumber,
-                             bgpstream_as_path_get_origin_seg(elem->aspath)) != 0)
-        {
-          return -1;
-        }
-    }
+  }
 
   /* we always print all the info to the log */
-  bgpstream_record_elem_snprintf(log_buffer, MAX_LOG_BUFFER_LEN, bs_record, elem);
+  bgpstream_record_elem_snprintf(log_buffer, MAX_LOG_BUFFER_LEN, bs_record,
+                                 elem);
   wandio_printf(state->outfile, "%s\n", log_buffer);
   return 0;
 }
 
-static int
-add_asns_from_file(bgpstream_id_set_t *monitored_ases, char* as_file_string)
+static int add_asns_from_file(bgpstream_id_set_t *monitored_ases,
+                              char *as_file_string)
 {
 
   char as_line[MAX_LOG_BUFFER_LEN];
   io_t *file = NULL;
   uint32_t monitor_asn;
 
-  if(as_file_string == NULL)
-    {
-      return -1;
-    }
+  if (as_file_string == NULL) {
+    return -1;
+  }
 
-  if((file = wandio_create(as_file_string)) == NULL)
-    {
-      fprintf(stderr, "ERROR: Could not open ASns file (%s)\n",
-              as_file_string);
-      return -1;
-    }
+  if ((file = wandio_create(as_file_string)) == NULL) {
+    fprintf(stderr, "ERROR: Could not open ASns file (%s)\n", as_file_string);
+    return -1;
+  }
 
-  while(wandio_fgets(file, &as_line, MAX_LOG_BUFFER_LEN, 1) > 0)
-    {
-      /* treat # as comment line, and ignore empty lines */
-      if(as_line[0] == '#' || as_line[0] == '\0')
-        {
-          continue;
-        }
-      monitor_asn = strtoul (as_line, NULL, 10);
-      bgpstream_id_set_insert(monitored_ases, monitor_asn);
+  while (wandio_fgets(file, &as_line, MAX_LOG_BUFFER_LEN, 1) > 0) {
+    /* treat # as comment line, and ignore empty lines */
+    if (as_line[0] == '#' || as_line[0] == '\0') {
+      continue;
     }
+    monitor_asn = strtoul(as_line, NULL, 10);
+    bgpstream_id_set_insert(monitored_ases, monitor_asn);
+  }
   wandio_destroy(file);
   return 0;
 }
 
 /* ================ command line args management ================ */
 
-
 /** Print usage information to stderr */
 static void usage(bgpcorsaro_plugin_t *plugin)
 {
-  fprintf(stderr,
-	  "plugin usage: %s -a <asn> [options] \n"
-	  "       -m <prefix>        metric prefix (default: %s)\n"
-	  "       -a <asn>           ASn to monitor*\n"
-	  "       -A <asns-file>     read the ASn to monitor from file*\n"
-          "       -M                 consider only more specifics (default: false)\n"
-          "       -w <pfx-window>    how long a prefix is to be considered valid for monitoring purposes (default: %d s)\n"
-          "       -n <peer_cnt>      minimum number of unique peers' ASNs to declare prefix visible (default: %d)\n"
-          "       -i <name>          IP space name (default: %s)\n"
-	  "* denotes an option that can be given multiple times\n",
-	  plugin->argv[0],
-          ASMONITOR_DEFAULT_METRIC_PFX,
-          ASMONITOR_DEFAULT_PREFIX_WINDOW,
-          ASMONITOR_DEFAULT_PEER_ASNS_THRESHOLD,
-          ASMONITOR_DEFAULT_IPSPACE_NAME);
+  fprintf(
+    stderr,
+    "plugin usage: %s -a <asn> [options] \n"
+    "       -m <prefix>        metric prefix (default: %s)\n"
+    "       -a <asn>           ASn to monitor*\n"
+    "       -A <asns-file>     read the ASn to monitor from file*\n"
+    "       -M                 consider only more specifics (default: false)\n"
+    "       -w <pfx-window>    how long a prefix is to be considered valid for "
+    "monitoring purposes (default: %d s)\n"
+    "       -n <peer_cnt>      minimum number of unique peers' ASNs to declare "
+    "prefix visible (default: %d)\n"
+    "       -i <name>          IP space name (default: %s)\n"
+    "* denotes an option that can be given multiple times\n",
+    plugin->argv[0], ASMONITOR_DEFAULT_METRIC_PFX,
+    ASMONITOR_DEFAULT_PREFIX_WINDOW, ASMONITOR_DEFAULT_PEER_ASNS_THRESHOLD,
+    ASMONITOR_DEFAULT_IPSPACE_NAME);
 }
 
 /** Parse the arguments given to the plugin */
@@ -550,83 +504,72 @@ static int parse_args(bgpcorsaro_t *bgpcorsaro)
   int opt;
   uint32_t monitor_asn;
 
-  if(plugin->argc <= 0)
-    {
-      return 0;
-    }
+  if (plugin->argc <= 0) {
+    return 0;
+  }
 
   /* NB: remember to reset optind to 1 before using getopt! */
   optind = 1;
 
-  while((opt = getopt(plugin->argc, plugin->argv, ":a:A:w:m:n:i:M?")) >= 0)
-    {
-      switch(opt)
-	{
-	case 'm':
-          if(optarg != NULL && strlen(optarg)-1 <= ASMONITOR_METRIC_PFX_LEN)
-            {
-              strncpy(state->metric_prefix, optarg,
-                      ASMONITOR_METRIC_PFX_LEN);
-            }
-          else
-            {
-              fprintf(stderr, "Error: could not set metric prefix\n");
-              usage(plugin);
-              return -1;
-            }
-	  break;
+  while ((opt = getopt(plugin->argc, plugin->argv, ":a:A:w:m:n:i:M?")) >= 0) {
+    switch (opt) {
+    case 'm':
+      if (optarg != NULL && strlen(optarg) - 1 <= ASMONITOR_METRIC_PFX_LEN) {
+        strncpy(state->metric_prefix, optarg, ASMONITOR_METRIC_PFX_LEN);
+      } else {
+        fprintf(stderr, "Error: could not set metric prefix\n");
+        usage(plugin);
+        return -1;
+      }
+      break;
 
-	case 'i':
-          if(optarg != NULL && strlen(optarg)-1 <= ASMONITOR_METRIC_PFX_LEN)
-            {
-              strncpy(state->ip_space_name, optarg, ASMONITOR_METRIC_PFX_LEN);
-            }
-          else
-            {
-              fprintf(stderr, "Error: could not set IP space name\n");
-              usage(plugin);
-              return -1;
-            }
-	  break;
+    case 'i':
+      if (optarg != NULL && strlen(optarg) - 1 <= ASMONITOR_METRIC_PFX_LEN) {
+        strncpy(state->ip_space_name, optarg, ASMONITOR_METRIC_PFX_LEN);
+      } else {
+        fprintf(stderr, "Error: could not set IP space name\n");
+        usage(plugin);
+        return -1;
+      }
+      break;
 
-        case 'a':
-          monitor_asn = strtoul(optarg, NULL, 10);
-          bgpstream_id_set_insert(state->monitored_ases, monitor_asn);
-	  break;
-        case 'A':
-	  if(add_asns_from_file(state->monitored_ases, optarg) != 0)
-            {
-              return -1;
-            }
-	  break;
+    case 'a':
+      monitor_asn = strtoul(optarg, NULL, 10);
+      bgpstream_id_set_insert(state->monitored_ases, monitor_asn);
+      break;
+    case 'A':
+      if (add_asns_from_file(state->monitored_ases, optarg) != 0) {
+        return -1;
+      }
+      break;
 
-	case 'w':
-          state->pfx_window = strtoul(optarg, NULL, 10);;
-	  break;
+    case 'w':
+      state->pfx_window = strtoul(optarg, NULL, 10);
+      ;
+      break;
 
-        case 'M':
-          state->more_specific = 1;
-          break;
+    case 'M':
+      state->more_specific = 1;
+      break;
 
-	case 'n':
-          state->peer_asns_th = atoi(optarg);
-	  break;
+    case 'n':
+      state->peer_asns_th = atoi(optarg);
+      break;
 
-	case '?':
-	case ':':
-	default:
-	  usage(plugin);
-	  return -1;
-	}
-    }
-
-  /* if no prefixes were provided,  */
-  if(bgpstream_id_set_size(state->monitored_ases) == 0)
-    {
-      fprintf(stderr, "Error: no valid ASns provided\n");
+    case '?':
+    case ':':
+    default:
       usage(plugin);
       return -1;
     }
+  }
+
+  /* if no prefixes were provided,  */
+  if (bgpstream_id_set_size(state->monitored_ases) == 0) {
+    fprintf(stderr, "Error: no valid ASns provided\n");
+    usage(plugin);
+    return -1;
+  }
 
   return 0;
 }
@@ -647,34 +590,30 @@ int bgpcorsaro_asmonitor_init_output(bgpcorsaro_t *bgpcorsaro)
   bgpcorsaro_plugin_t *plugin = PLUGIN(bgpcorsaro);
   assert(plugin != NULL);
 
-  if((state =
-      malloc_zero(sizeof(struct bgpcorsaro_asmonitor_state_t))) == NULL)
-    {
-      bgpcorsaro_log(__func__, bgpcorsaro,
-		     "could not malloc bgpcorsaro_asmonitor_state_t");
-      goto err;
-    }
+  if ((state = malloc_zero(sizeof(struct bgpcorsaro_asmonitor_state_t))) ==
+      NULL) {
+    bgpcorsaro_log(__func__, bgpcorsaro,
+                   "could not malloc bgpcorsaro_asmonitor_state_t");
+    goto err;
+  }
   bgpcorsaro_plugin_register_state(bgpcorsaro->plugin_manager, plugin, state);
-
 
   /* initialize state with default values */
   state = STATE(bgpcorsaro);
   strcpy(state->metric_prefix, ASMONITOR_DEFAULT_METRIC_PFX);
   strcpy(state->ip_space_name, ASMONITOR_DEFAULT_IPSPACE_NAME);
 
-  if((state->monitored_ases = bgpstream_id_set_create()) == NULL)
-    {
-      goto err;
-    }
+  if ((state->monitored_ases = bgpstream_id_set_create()) == NULL) {
+    goto err;
+  }
   state->pfx_window = ASMONITOR_DEFAULT_PREFIX_WINDOW;
   state->peer_asns_th = ASMONITOR_DEFAULT_PEER_ASNS_THRESHOLD;
   state->more_specific = 0;
 
   /* parse the arguments */
-  if(parse_args(bgpcorsaro) != 0)
-    {
-      goto err;
-    }
+  if (parse_args(bgpcorsaro) != 0) {
+    goto err;
+  }
 
   /* we do not graphite_safe the prefix, it could be
    * hierarchical on purpose:
@@ -683,26 +622,24 @@ int bgpcorsaro_asmonitor_init_output(bgpcorsaro_t *bgpcorsaro)
    * state->ip_space_name; */
 
   /* create all the sets and maps we need */
-  if((state->patricia = bgpstream_patricia_tree_create(perpfx_info_destroy)) == NULL ||
-     (state->pfx_info = kh_init(pfx_info_map)) == NULL ||
-     (state->peer_asns = bgpstream_id_set_create()) == NULL)
-    {
+  if ((state->patricia = bgpstream_patricia_tree_create(perpfx_info_destroy)) ==
+        NULL ||
+      (state->pfx_info = kh_init(pfx_info_map)) == NULL ||
+      (state->peer_asns = bgpstream_id_set_create()) == NULL) {
+    goto err;
+  }
+
+  for (v = 0; v < BGPSTREAM_MAX_IP_VERSION_IDX; v++) {
+    if ((state->unique_origins[v] = bgpstream_id_set_create()) == NULL) {
       goto err;
     }
-
-  for(v=0; v < BGPSTREAM_MAX_IP_VERSION_IDX; v++)
-    {
-      if((state->unique_origins[v] = bgpstream_id_set_create()) == NULL)
-        {
-          goto err;
-        }
-    }
+  }
 
   /* defer opening the output file until we start the first interval */
 
   return 0;
 
- err:
+err:
   bgpcorsaro_asmonitor_close_output(bgpcorsaro);
   return -1;
 }
@@ -713,60 +650,50 @@ int bgpcorsaro_asmonitor_close_output(bgpcorsaro_t *bgpcorsaro)
   int i;
   struct bgpcorsaro_asmonitor_state_t *state = STATE(bgpcorsaro);
   khiter_t k;
-  khash_t(peer_asn_map) *v;
+  khash_t(peer_asn_map) * v;
 
-  if(state == NULL)
-    {
-      return 0;
-    }
+  if (state == NULL) {
+    return 0;
+  }
 
   /* close all the outfile pointers */
-  for(i = 0; i < OUTFILE_POINTERS; i++)
-    {
-      if(state->outfile_p[i] != NULL)
-        {
-          wandio_wdestroy(state->outfile_p[i]);
-          state->outfile_p[i] = NULL;
-        }
+  for (i = 0; i < OUTFILE_POINTERS; i++) {
+    if (state->outfile_p[i] != NULL) {
+      wandio_wdestroy(state->outfile_p[i]);
+      state->outfile_p[i] = NULL;
     }
+  }
   state->outfile = NULL;
-  if(state->patricia != NULL)
-    {
-      bgpstream_patricia_tree_destroy(state->patricia);
-      state->patricia = NULL;
-    }
+  if (state->patricia != NULL) {
+    bgpstream_patricia_tree_destroy(state->patricia);
+    state->patricia = NULL;
+  }
 
   /* deallocate the dynamic memory in use */
 
-  if(state->peer_asns != NULL)
-    {
-      bgpstream_id_set_destroy(state->peer_asns);
-      state->peer_asns = NULL;
-    }
+  if (state->peer_asns != NULL) {
+    bgpstream_id_set_destroy(state->peer_asns);
+    state->peer_asns = NULL;
+  }
 
-  if(state->pfx_info != NULL)
-    {
-      for (k = kh_begin(state->pfx_info); k != kh_end(state->pfx_info); ++k)
-        {
-          if (kh_exist(state->pfx_info, k))
-            {
-              v = kh_val(state->pfx_info, k);
-              kh_destroy(peer_asn_map, v);
-            }
-        }
-      kh_destroy(pfx_info_map, state->pfx_info);
-      state->pfx_info = NULL;
+  if (state->pfx_info != NULL) {
+    for (k = kh_begin(state->pfx_info); k != kh_end(state->pfx_info); ++k) {
+      if (kh_exist(state->pfx_info, k)) {
+        v = kh_val(state->pfx_info, k);
+        kh_destroy(peer_asn_map, v);
+      }
     }
+    kh_destroy(pfx_info_map, state->pfx_info);
+    state->pfx_info = NULL;
+  }
 
   int vers_id;
-  for(vers_id=0; vers_id < BGPSTREAM_MAX_IP_VERSION_IDX; vers_id++)
-    {
-      if(state->unique_origins[vers_id] != NULL)
-        {
-          bgpstream_id_set_destroy(state->unique_origins[vers_id]);
-          state->unique_origins[vers_id] = NULL;
-        }
+  for (vers_id = 0; vers_id < BGPSTREAM_MAX_IP_VERSION_IDX; vers_id++) {
+    if (state->unique_origins[vers_id] != NULL) {
+      bgpstream_id_set_destroy(state->unique_origins[vers_id]);
+      state->unique_origins[vers_id] = NULL;
     }
+  }
 
   bgpcorsaro_plugin_free_state(bgpcorsaro->plugin_manager, PLUGIN(bgpcorsaro));
   return 0;
@@ -779,21 +706,15 @@ int bgpcorsaro_asmonitor_start_interval(bgpcorsaro_t *bgpcorsaro,
   struct bgpcorsaro_asmonitor_state_t *state = STATE(bgpcorsaro);
 
   /* open an output file */
-  if(state->outfile == NULL)
-    {
-      if((
-	  state->outfile_p[state->outfile_n] =
-	  bgpcorsaro_io_prepare_file(bgpcorsaro,
-				     PLUGIN(bgpcorsaro)->name,
-				     int_start)) == NULL)
-	{
-	  bgpcorsaro_log(__func__, bgpcorsaro, "could not open %s output file",
-			 PLUGIN(bgpcorsaro)->name);
-	  return -1;
-	}
-      state->outfile = state->
-	outfile_p[state->outfile_n];
+  if (state->outfile == NULL) {
+    if ((state->outfile_p[state->outfile_n] = bgpcorsaro_io_prepare_file(
+           bgpcorsaro, PLUGIN(bgpcorsaro)->name, int_start)) == NULL) {
+      bgpcorsaro_log(__func__, bgpcorsaro, "could not open %s output file",
+                     PLUGIN(bgpcorsaro)->name);
+      return -1;
     }
+    state->outfile = state->outfile_p[state->outfile_n];
+  }
 
   bgpcorsaro_io_write_interval_start(bgpcorsaro, state->outfile, int_start);
 
@@ -812,24 +733,21 @@ int bgpcorsaro_asmonitor_end_interval(bgpcorsaro_t *bgpcorsaro,
   bgpcorsaro_io_write_interval_end(bgpcorsaro, state->outfile, int_end);
 
   /* if we are rotating, now is when we should do it */
-  if(bgpcorsaro_is_rotate_interval(bgpcorsaro))
-    {
-      /* leave the current file to finish draining buffers */
-      assert(state->outfile != NULL);
+  if (bgpcorsaro_is_rotate_interval(bgpcorsaro)) {
+    /* leave the current file to finish draining buffers */
+    assert(state->outfile != NULL);
 
-      /* move on to the next output pointer */
-      state->outfile_n = (state->outfile_n+1) %
-	OUTFILE_POINTERS;
+    /* move on to the next output pointer */
+    state->outfile_n = (state->outfile_n + 1) % OUTFILE_POINTERS;
 
-      if(state->outfile_p[state->outfile_n] != NULL)
-	{
-	  /* we're gonna have to wait for this to close */
-	  wandio_wdestroy(state->outfile_p[state->outfile_n]);
-	  state->outfile_p[state->outfile_n] =  NULL;
-	}
-
-      state->outfile = NULL;
+    if (state->outfile_p[state->outfile_n] != NULL) {
+      /* we're gonna have to wait for this to close */
+      wandio_wdestroy(state->outfile_p[state->outfile_n]);
+      state->outfile_p[state->outfile_n] = NULL;
     }
+
+    state->outfile = NULL;
+  }
 
   output_stats_and_reset(bgpcorsaro);
 
@@ -851,77 +769,70 @@ int bgpcorsaro_asmonitor_process_record(bgpcorsaro_t *bgpcorsaro,
 
   /* no point carrying on if a previous plugin has already decided we should
      ignore this record */
-  if((record->state.flags & BGPCORSARO_RECORD_STATE_FLAG_IGNORE) != 0)
-    {
-      return 0;
-    }
+  if ((record->state.flags & BGPCORSARO_RECORD_STATE_FLAG_IGNORE) != 0) {
+    return 0;
+  }
 
   /* consider only valid records */
-  if(bs_record->status != BGPSTREAM_RECORD_STATUS_VALID_RECORD)
-    {
-      return 0;
-    }
+  if (bs_record->status != BGPSTREAM_RECORD_STATUS_VALID_RECORD) {
+    return 0;
+  }
 
   /* process all elems in the record */
-  while((elem = bgpstream_record_get_next_elem(bs_record)) != NULL)
-    {
-      if(elem->type == BGPSTREAM_ELEM_TYPE_PEERSTATE)
-        {
-          continue;
-        }
-
-      /* consider only prefixes announced by the peers (not the collector) */
-      if(elem->type != BGPSTREAM_ELEM_TYPE_WITHDRAWAL &&
-         bgpstream_as_path_get_len(elem->aspath) == 0)
-        {
-          continue;
-        }
-
-      /* Check if the origin is one of the ASns to monitor */
-      if(elem->type == BGPSTREAM_ELEM_TYPE_RIB || elem->type == BGPSTREAM_ELEM_TYPE_ANNOUNCEMENT )
-        {
-          origin_seg = bgpstream_as_path_get_origin_seg(elem->aspath);
-          if(origin_seg == NULL || origin_seg->type != BGPSTREAM_AS_PATH_SEG_ASN)
-            {
-              return 0;
-            }
-          origin_asn = ((bgpstream_as_path_seg_asn_t*)origin_seg)->asn;
-
-          if(bgpstream_id_set_exists(state->monitored_ases, origin_asn))
-            {
-              /* if the origin match, then add the prefix to the tree and
-               * update the timestamp if it already exist */
-              n = bgpstream_patricia_tree_insert(state->patricia, (bgpstream_pfx_t *) &elem->prefix);
-              info = (perpfx_info_t *)bgpstream_patricia_tree_get_user(n);
-              if(info != NULL)
-                {
-                  perpfx_info_set_ts(info, state->interval_start);
-                }
-              else
-                {
-                  /* tmp_buffer[0] = '\0'; */
-                  /* fprintf(stderr, "Adding a new prefix to the PT: %s\n", */
-                  /*         bgpstream_pfx_snprintf(tmp_buffer, 1024, (bgpstream_pfx_t *) &elem->prefix)); */
-                  bgpstream_patricia_tree_set_user(state->patricia, n, perpfx_info_create(state->interval_start));
-                }
-
-            }
-        }
-
-      /* consider only prefixes that overlap with the set provided */
-      overlap = bgpstream_patricia_tree_get_pfx_overlap_info(state->patricia,(bgpstream_pfx_t *) &elem->prefix);
-
-      /* if the more specific flag is set, then we accept only more specifics or exact matches */
-      if(overlap > 0 &&
-         (!state->more_specific || overlap & (BGPSTREAM_PATRICIA_LESS_SPECIFICS | BGPSTREAM_PATRICIA_EXACT_MATCH)))
-        {
-          /* fprintf(stderr, "Overlapping prefix message: %s\n", */
-          /*         bgpstream_record_elem_snprintf(tmp_buffer, 1024, bs_record, elem)); */
-          process_overlapping_pfx(state, bs_record, elem);
-        }
-
+  while ((elem = bgpstream_record_get_next_elem(bs_record)) != NULL) {
+    if (elem->type == BGPSTREAM_ELEM_TYPE_PEERSTATE) {
+      continue;
     }
+
+    /* consider only prefixes announced by the peers (not the collector) */
+    if (elem->type != BGPSTREAM_ELEM_TYPE_WITHDRAWAL &&
+        bgpstream_as_path_get_len(elem->aspath) == 0) {
+      continue;
+    }
+
+    /* Check if the origin is one of the ASns to monitor */
+    if (elem->type == BGPSTREAM_ELEM_TYPE_RIB ||
+        elem->type == BGPSTREAM_ELEM_TYPE_ANNOUNCEMENT) {
+      origin_seg = bgpstream_as_path_get_origin_seg(elem->aspath);
+      if (origin_seg == NULL || origin_seg->type != BGPSTREAM_AS_PATH_SEG_ASN) {
+        return 0;
+      }
+      origin_asn = ((bgpstream_as_path_seg_asn_t *)origin_seg)->asn;
+
+      if (bgpstream_id_set_exists(state->monitored_ases, origin_asn)) {
+        /* if the origin match, then add the prefix to the tree and
+         * update the timestamp if it already exist */
+        n = bgpstream_patricia_tree_insert(state->patricia,
+                                           (bgpstream_pfx_t *)&elem->prefix);
+        info = (perpfx_info_t *)bgpstream_patricia_tree_get_user(n);
+        if (info != NULL) {
+          perpfx_info_set_ts(info, state->interval_start);
+        } else {
+          /* tmp_buffer[0] = '\0'; */
+          /* fprintf(stderr, "Adding a new prefix to the PT: %s\n", */
+          /*         bgpstream_pfx_snprintf(tmp_buffer, 1024, (bgpstream_pfx_t
+           * *) &elem->prefix)); */
+          bgpstream_patricia_tree_set_user(
+            state->patricia, n, perpfx_info_create(state->interval_start));
+        }
+      }
+    }
+
+    /* consider only prefixes that overlap with the set provided */
+    overlap = bgpstream_patricia_tree_get_pfx_overlap_info(
+      state->patricia, (bgpstream_pfx_t *)&elem->prefix);
+
+    /* if the more specific flag is set, then we accept only more specifics or
+     * exact matches */
+    if (overlap > 0 && (!state->more_specific ||
+                        overlap & (BGPSTREAM_PATRICIA_LESS_SPECIFICS |
+                                   BGPSTREAM_PATRICIA_EXACT_MATCH))) {
+      /* fprintf(stderr, "Overlapping prefix message: %s\n", */
+      /*         bgpstream_record_elem_snprintf(tmp_buffer, 1024, bs_record,
+       * elem)); */
+      process_overlapping_pfx(state, bs_record, elem);
+    }
+  }
 
   return 0;
 }
-

--- a/bgpcorsaro/lib/plugins/bgpcorsaro_pfxmonitor.c
+++ b/bgpcorsaro/lib/plugins/bgpcorsaro_pfxmonitor.c
@@ -20,8 +20,8 @@
  * You should have received a copy of the GNU General Public License along with
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "config.h"
 #include "bgpcorsaro_int.h"
+#include "config.h"
 
 #include <assert.h>
 #include <stdio.h>
@@ -37,8 +37,8 @@
 
 #include "bgpcorsaro_pfxmonitor.h"
 
-#include "khash.h"
 #include "bgpstream_utils.h"
+#include "khash.h"
 
 /** @file
  *
@@ -74,11 +74,11 @@
 /** Maximum string length for the log entries */
 #define MAX_LOG_BUFFER_LEN 1024
 
-#define DUMP_METRIC(value, time, fmt, ...)                              \
-  do {                                                                  \
-    fprintf(stdout, fmt" %"PRIu32" %"PRIu32"\n",                        \
-            __VA_ARGS__, value, time);                                  \
-  } while(0)
+#define DUMP_METRIC(value, time, fmt, ...)                                     \
+  do {                                                                         \
+    fprintf(stdout, fmt " %" PRIu32 " %" PRIu32 "\n", __VA_ARGS__, value,      \
+            time);                                                             \
+  } while (0)
 
 /** Common plugin information across all instances */
 static bgpcorsaro_plugin_t bgpcorsaro_pfxmonitor_plugin = {
@@ -91,42 +91,36 @@ static bgpcorsaro_plugin_t bgpcorsaro_pfxmonitor_plugin = {
 
 /* Transform a string to be safe for use with Graphite
    (http://graphite.readthedocs.org/en/latest/) */
-static char *
-graphite_safe(char *p)
+static char *graphite_safe(char *p)
 {
-  if(p == NULL)
-    {
-      return p;
-    }
+  if (p == NULL) {
+    return p;
+  }
 
   char *r = p;
-  while(*p != '\0')
-    {
-      if(*p == '.')
-	{
-	  *p = '-';
-	}
-      if(*p == '*')
-	{
-	  *p = '-';
-	}
-      p++;
+  while (*p != '\0') {
+    if (*p == '.') {
+      *p = '-';
     }
+    if (*p == '*') {
+      *p = '-';
+    }
+    p++;
+  }
   return r;
 }
 
 /** A map that contains, for each origin the number of peer ASns observing it */
-KHASH_INIT(asn_count_map, uint32_t, uint32_t, 1,
-           kh_int_hash_func, kh_int_hash_equal);
+KHASH_INIT(asn_count_map, uint32_t, uint32_t, 1, kh_int_hash_func,
+           kh_int_hash_equal);
 
 /** A map that contains the origin observed by a specific peer */
-KHASH_INIT(peer_asn_map, uint32_t, uint32_t, 1,
-           kh_int_hash_func, kh_int_hash_equal);
+KHASH_INIT(peer_asn_map, uint32_t, uint32_t, 1, kh_int_hash_func,
+           kh_int_hash_equal);
 
 /** A map that contains information for each prefix */
-KHASH_INIT(pfx_info_map, bgpstream_pfx_storage_t, khash_t(peer_asn_map)*, 1,
+KHASH_INIT(pfx_info_map, bgpstream_pfx_storage_t, khash_t(peer_asn_map) *, 1,
            bgpstream_pfx_storage_hash_val, bgpstream_pfx_storage_equal_val);
-
 
 /** Holds the state for an instance of this plugin */
 struct bgpcorsaro_pfxmonitor_state_t {
@@ -152,7 +146,7 @@ struct bgpcorsaro_pfxmonitor_state_t {
   bgpstream_id_set_t *peer_asns;
 
   /** Prefix info map */
-  khash_t(pfx_info_map) *pfx_info;
+  khash_t(pfx_info_map) * pfx_info;
 
   /** utility set to compute unique origin
    *  ASns  */
@@ -173,17 +167,17 @@ struct bgpcorsaro_pfxmonitor_state_t {
 };
 
 /** Extends the generic plugin state convenience macro in bgpcorsaro_plugin.h */
-#define STATE(bgpcorsaro)						\
-  (BGPCORSARO_PLUGIN_STATE(bgpcorsaro, pfxmonitor,                      \
+#define STATE(bgpcorsaro)                                                      \
+  (BGPCORSARO_PLUGIN_STATE(bgpcorsaro, pfxmonitor,                             \
                            BGPCORSARO_PLUGIN_ID_PFXMONITOR))
 
-/** Extends the generic plugin plugin convenience macro in bgpcorsaro_plugin.h */
-#define PLUGIN(bgpcorsaro)						\
+/** Extends the generic plugin plugin convenience macro in bgpcorsaro_plugin.h
+ */
+#define PLUGIN(bgpcorsaro)                                                     \
   (BGPCORSARO_PLUGIN_PLUGIN(bgpcorsaro, BGPCORSARO_PLUGIN_ID_PFXMONITOR))
 
-static int
-output_stats_and_reset(struct bgpcorsaro_pfxmonitor_state_t *state,
-                       uint32_t interval_start)
+static int output_stats_and_reset(struct bgpcorsaro_pfxmonitor_state_t *state,
+                                  uint32_t interval_start)
 {
   khiter_t k;
   khiter_t p;
@@ -191,84 +185,73 @@ output_stats_and_reset(struct bgpcorsaro_pfxmonitor_state_t *state,
   int khret;
   uint8_t pfx_visible;
   uint32_t unique_pfxs = 0;
-  khash_t(peer_asn_map) *pam;
+  khash_t(peer_asn_map) * pam;
   /* origin_asn -> num peer ASns*/
   khash_t(asn_count_map) *asn_np = NULL;
 
-  if((asn_np = kh_init(asn_count_map)) == NULL)
-    {
-      return -1;
-    }
+  if ((asn_np = kh_init(asn_count_map)) == NULL) {
+    return -1;
+  }
 
   /* for each prefix go through all peers */
-  for (k = kh_begin(state->pfx_info); k != kh_end(state->pfx_info); ++k)
-    {
-      if (kh_exist(state->pfx_info, k) == 0)
-        {
-          continue;
-        }
-      /* reset counters */
-      kh_clear(asn_count_map, asn_np);
+  for (k = kh_begin(state->pfx_info); k != kh_end(state->pfx_info); ++k) {
+    if (kh_exist(state->pfx_info, k) == 0) {
+      continue;
+    }
+    /* reset counters */
+    kh_clear(asn_count_map, asn_np);
 
-      /* get peer-asn map for this prefix */
-      pam = kh_value(state->pfx_info, k);
+    /* get peer-asn map for this prefix */
+    pam = kh_value(state->pfx_info, k);
 
-      /* save the origin asn visibility (i.e. how many peers' ASns
-       * observe such information */
+    /* save the origin asn visibility (i.e. how many peers' ASns
+     * observe such information */
 
-      /* for each peer, go through all origins */
-      for (p = kh_begin(pam); p != kh_end(pam); ++p)
-        {
-          if (kh_exist(pam, p) == 0)
-            {
-              continue;
-            }
-          /* increment the counter for this ASN */
-          if((a = kh_get(asn_count_map, asn_np, kh_value(pam,p))) ==
-             kh_end(asn_np))
-            {
-              a = kh_put(asn_count_map, asn_np, kh_value(pam,p), &khret);
-              kh_value(asn_np,a) = 1;
-            }
-          else
-            {
-              kh_value(asn_np,a)++;
-            }
-        }
-
-      /* now asn_np has a complete count of the number of peers' ASns that observed
-         each origin ASN */
-
-      /* count the prefix and origins if their visibility
-       * is above the threshold */
-      pfx_visible = 0;
-      for (a = kh_begin(asn_np); a != kh_end(asn_np); ++a)
-        {
-          if (kh_exist(asn_np, a) == 0)
-            {
-              continue;
-            }
-          /* the information is accounted only if it is
-           * consistent on at least threshold peers' ASns */
-          if(kh_value(asn_np, a) >= state->peer_asns_th)
-            {
-              pfx_visible = 1;
-              bgpstream_id_set_insert(state->unique_origins, kh_key(asn_np, a));
-            }
-        }
-
-      /* updating counters */
-      unique_pfxs += pfx_visible;
+    /* for each peer, go through all origins */
+    for (p = kh_begin(pam); p != kh_end(pam); ++p) {
+      if (kh_exist(pam, p) == 0) {
+        continue;
+      }
+      /* increment the counter for this ASN */
+      if ((a = kh_get(asn_count_map, asn_np, kh_value(pam, p))) ==
+          kh_end(asn_np)) {
+        a = kh_put(asn_count_map, asn_np, kh_value(pam, p), &khret);
+        kh_value(asn_np, a) = 1;
+      } else {
+        kh_value(asn_np, a)++;
+      }
     }
 
-  DUMP_METRIC(unique_pfxs, state->interval_start,
-              "%s.%s.%s.%s", state->metric_prefix, PLUGIN_NAME,
-              state->ip_space_name, "prefixes_cnt");
+    /* now asn_np has a complete count of the number of peers' ASns that
+       observed
+       each origin ASN */
+
+    /* count the prefix and origins if their visibility
+     * is above the threshold */
+    pfx_visible = 0;
+    for (a = kh_begin(asn_np); a != kh_end(asn_np); ++a) {
+      if (kh_exist(asn_np, a) == 0) {
+        continue;
+      }
+      /* the information is accounted only if it is
+       * consistent on at least threshold peers' ASns */
+      if (kh_value(asn_np, a) >= state->peer_asns_th) {
+        pfx_visible = 1;
+        bgpstream_id_set_insert(state->unique_origins, kh_key(asn_np, a));
+      }
+    }
+
+    /* updating counters */
+    unique_pfxs += pfx_visible;
+  }
+
+  DUMP_METRIC(unique_pfxs, state->interval_start, "%s.%s.%s.%s",
+              state->metric_prefix, PLUGIN_NAME, state->ip_space_name,
+              "prefixes_cnt");
 
   DUMP_METRIC(bgpstream_id_set_size(state->unique_origins),
-              state->interval_start,
-              "%s.%s.%s.%s", state->metric_prefix, PLUGIN_NAME,
-              state->ip_space_name, "origin_ASns_cnt");
+              state->interval_start, "%s.%s.%s.%s", state->metric_prefix,
+              PLUGIN_NAME, state->ip_space_name, "origin_ASns_cnt");
 
   bgpstream_id_set_clear(state->unique_origins);
   kh_destroy(asn_count_map, asn_np);
@@ -277,40 +260,33 @@ output_stats_and_reset(struct bgpcorsaro_pfxmonitor_state_t *state,
 }
 
 /* set the origin ASN for a given prefix as observed by a given peer */
-static int
-set_pfx_peer_origin(struct bgpcorsaro_pfxmonitor_state_t *state,
-                    const bgpstream_pfx_storage_t *pfx,
-                    uint32_t peer_asn,
-                    uint32_t origin_asn)
+static int set_pfx_peer_origin(struct bgpcorsaro_pfxmonitor_state_t *state,
+                               const bgpstream_pfx_storage_t *pfx,
+                               uint32_t peer_asn, uint32_t origin_asn)
 {
   khiter_t k;
   int khret;
-  khash_t(peer_asn_map) *pam;
+  khash_t(peer_asn_map) * pam;
 
   /* does the prefix already exist, if not, create it */
-  if((k = kh_get(pfx_info_map, state->pfx_info, *pfx))
-     == kh_end(state->pfx_info))
-    {
-      /* no, insert it */
-      k = kh_put(pfx_info_map, state->pfx_info, *pfx, &khret);
+  if ((k = kh_get(pfx_info_map, state->pfx_info, *pfx)) ==
+      kh_end(state->pfx_info)) {
+    /* no, insert it */
+    k = kh_put(pfx_info_map, state->pfx_info, *pfx, &khret);
 
-      /* create a peer-asn map */
-      if((pam = kh_init(peer_asn_map)) == NULL)
-        {
-          return -1;
-        }
-      kh_value(state->pfx_info, k) = pam;
+    /* create a peer-asn map */
+    if ((pam = kh_init(peer_asn_map)) == NULL) {
+      return -1;
     }
-  else
-    {
-      pam = kh_value(state->pfx_info, k);
-    }
+    kh_value(state->pfx_info, k) = pam;
+  } else {
+    pam = kh_value(state->pfx_info, k);
+  }
 
   /* does the peer exist? ({pfx}{peer}), if not, create it */
-  if((k = kh_get(peer_asn_map, pam, peer_asn)) == kh_end(pam))
-    {
-      k = kh_put(peer_asn_map, pam, peer_asn, &khret);
-    }
+  if ((k = kh_get(peer_asn_map, pam, peer_asn)) == kh_end(pam)) {
+    k = kh_put(peer_asn_map, pam, peer_asn, &khret);
+  }
 
   /* set the origin ASN for this pfx/peer combo */
   kh_value(pam, k) = origin_asn;
@@ -319,72 +295,64 @@ set_pfx_peer_origin(struct bgpcorsaro_pfxmonitor_state_t *state,
 
 /* remove pfx/peer from state */
 static void rm_pfx_peer(struct bgpcorsaro_pfxmonitor_state_t *state,
-                       const bgpstream_pfx_storage_t *pfx,
-                       uint32_t peer_asn)
+                        const bgpstream_pfx_storage_t *pfx, uint32_t peer_asn)
 {
   khiter_t k;
-  khash_t(peer_asn_map) *pam;
+  khash_t(peer_asn_map) * pam;
 
   /* does the pfx exist? */
-  if((k = kh_get(pfx_info_map, state->pfx_info, *pfx))
-     == kh_end(state->pfx_info))
-    {
-      return;
-    }
+  if ((k = kh_get(pfx_info_map, state->pfx_info, *pfx)) ==
+      kh_end(state->pfx_info)) {
+    return;
+  }
   pam = kh_value(state->pfx_info, k);
 
   /* does this peer exist for this pfx */
-  if((k = kh_get(peer_asn_map, pam, peer_asn)) == kh_end(pam))
-    {
-      return;
-    }
+  if ((k = kh_get(peer_asn_map, pam, peer_asn)) == kh_end(pam)) {
+    return;
+  }
 
   kh_del(peer_asn_map, pam, k);
 
   return;
 }
 
-static int
-process_overlapping_pfx(struct bgpcorsaro_pfxmonitor_state_t *state,
-                        const bgpstream_record_t * bs_record, const bgpstream_elem_t *elem)
+static int process_overlapping_pfx(struct bgpcorsaro_pfxmonitor_state_t *state,
+                                   const bgpstream_record_t *bs_record,
+                                   const bgpstream_elem_t *elem)
 {
   char log_buffer[MAX_LOG_BUFFER_LEN] = "";
   bgpstream_as_path_seg_t *origin_seg = NULL;
   uint32_t origin_asn = 0;
 
-  if(elem->type == BGPSTREAM_ELEM_TYPE_WITHDRAWAL)
-    {
-      /* remove pfx/peer from state structure */
-      rm_pfx_peer(state, &elem->prefix, elem->peer_asnumber);
+  if (elem->type == BGPSTREAM_ELEM_TYPE_WITHDRAWAL) {
+    /* remove pfx/peer from state structure */
+    rm_pfx_peer(state, &elem->prefix, elem->peer_asnumber);
+  } else /* (announcement or rib) */
+  {
+    /* get the origin asn (sets and confederations are ignored) */
+    origin_seg = bgpstream_as_path_get_origin_seg(elem->aspath);
+    if (origin_seg == NULL || origin_seg->type != BGPSTREAM_AS_PATH_SEG_ASN) {
+      fprintf(stderr, "WARN: ignoring AS sets and confederations\n");
+    } else {
+      /* valid origin ASN */
+      origin_asn = ((bgpstream_as_path_seg_asn_t *)origin_seg)->asn;
+      if (set_pfx_peer_origin(state, &elem->prefix, elem->peer_asnumber,
+                              origin_asn) != 0) {
+        return -1;
+      }
     }
-  else /* (announcement or rib) */
-    {
-      /* get the origin asn (sets and confederations are ignored) */
-      origin_seg = bgpstream_as_path_get_origin_seg(elem->aspath);
-      if(origin_seg == NULL || origin_seg->type != BGPSTREAM_AS_PATH_SEG_ASN)
-        {
-          fprintf(stderr, "WARN: ignoring AS sets and confederations\n");
-        }
-      else
-        {
-          /* valid origin ASN */
-          origin_asn = ((bgpstream_as_path_seg_asn_t*)origin_seg)->asn;
-          if(set_pfx_peer_origin(state, &elem->prefix, elem->peer_asnumber,
-                                 origin_asn) != 0)
-            {
-              return -1;
-            }
-        }
-    }
+  }
 
   /* we always print all the info to the log */
-  bgpstream_record_elem_snprintf(log_buffer, MAX_LOG_BUFFER_LEN, bs_record, elem);
+  bgpstream_record_elem_snprintf(log_buffer, MAX_LOG_BUFFER_LEN, bs_record,
+                                 elem);
   wandio_printf(state->outfile, "%s\n", log_buffer);
   return 0;
 }
 
-static int
-add_prefixes_from_file(bgpstream_ip_counter_t *poi, char* pfx_file_string)
+static int add_prefixes_from_file(bgpstream_ip_counter_t *poi,
+                                  char *pfx_file_string)
 {
 
   char pfx_line[MAX_LOG_BUFFER_LEN];
@@ -392,55 +360,48 @@ add_prefixes_from_file(bgpstream_ip_counter_t *poi, char* pfx_file_string)
 
   bgpstream_pfx_storage_t pfx_st;
 
-  if(pfx_file_string == NULL)
-    {
+  if (pfx_file_string == NULL) {
+    return -1;
+  }
+
+  if ((file = wandio_create(pfx_file_string)) == NULL) {
+    fprintf(stderr, "ERROR: Could not open prefix file (%s)\n",
+            pfx_file_string);
+    return -1;
+  }
+
+  while (wandio_fgets(file, &pfx_line, MAX_LOG_BUFFER_LEN, 1) > 0) {
+    /* treat # as comment line, and ignore empty lines */
+    if (pfx_line[0] == '#' || pfx_line[0] == '\0') {
+      continue;
+    }
+
+    if (bgpstream_str2pfx(pfx_line, &pfx_st) == NULL ||
+        bgpstream_ip_counter_add(poi, (bgpstream_pfx_t *)&pfx_st) != 0) {
+      /* failed to parse/insert the prefix */
       return -1;
     }
-
-  if((file = wandio_create(pfx_file_string)) == NULL)
-    {
-      fprintf(stderr, "ERROR: Could not open prefix file (%s)\n",
-              pfx_file_string);
-      return -1;
-    }
-
-  while(wandio_fgets(file, &pfx_line, MAX_LOG_BUFFER_LEN, 1) > 0)
-    {
-      /* treat # as comment line, and ignore empty lines */
-      if(pfx_line[0] == '#' || pfx_line[0] == '\0')
-        {
-          continue;
-        }
-
-      if(bgpstream_str2pfx(pfx_line, &pfx_st) == NULL ||
-         bgpstream_ip_counter_add(poi, (bgpstream_pfx_t *) &pfx_st) != 0)
-        {
-          /* failed to parse/insert the prefix */
-          return -1;
-        }
-    }
+  }
   wandio_destroy(file);
   return 0;
 }
 
-
-
 /** Print usage information to stderr */
 static void usage(bgpcorsaro_plugin_t *plugin)
 {
-  fprintf(stderr,
-	  "plugin usage: %s -l <pfx> \n"
-	  "       -m <prefix>        metric prefix (default: %s)\n"
-	  "       -l <prefix>        prefix to monitor*\n"
-	  "       -L <prefix-file>   read the prefixes to monitor from file*\n"
-          "       -M                 consider only more specifics (default: false)\n"
-          "       -n <peer_cnt>   minimum number of unique peers' ASNs to declare prefix visible (default: %d)\n"
-          "       -i <name>          IP space name (default: %s)\n"
-	  "* denotes an option that can be given multiple times\n",
-	  plugin->argv[0],
-          PFXMONITOR_DEFAULT_METRIC_PFX,
-          PFXMONITOR_DEFAULT_PEER_ASNS_THRESHOLD,
-          PFXMONITOR_DEFAULT_IPSPACE_NAME);
+  fprintf(
+    stderr,
+    "plugin usage: %s -l <pfx> \n"
+    "       -m <prefix>        metric prefix (default: %s)\n"
+    "       -l <prefix>        prefix to monitor*\n"
+    "       -L <prefix-file>   read the prefixes to monitor from file*\n"
+    "       -M                 consider only more specifics (default: false)\n"
+    "       -n <peer_cnt>   minimum number of unique peers' ASNs to declare "
+    "prefix visible (default: %d)\n"
+    "       -i <name>          IP space name (default: %s)\n"
+    "* denotes an option that can be given multiple times\n",
+    plugin->argv[0], PFXMONITOR_DEFAULT_METRIC_PFX,
+    PFXMONITOR_DEFAULT_PEER_ASNS_THRESHOLD, PFXMONITOR_DEFAULT_IPSPACE_NAME);
 }
 
 /** Parse the arguments given to the plugin */
@@ -451,87 +412,75 @@ static int parse_args(bgpcorsaro_t *bgpcorsaro)
   int opt;
   bgpstream_pfx_storage_t pfx_st;
 
-  if(plugin->argc <= 0)
-    {
-      return 0;
-    }
+  if (plugin->argc <= 0) {
+    return 0;
+  }
 
   /* NB: remember to reset optind to 1 before using getopt! */
   optind = 1;
 
-  while((opt = getopt(plugin->argc, plugin->argv, ":l:L:m:n:i:M?")) >= 0)
-    {
-      switch(opt)
-	{
-	case 'm':
-          if(optarg != NULL && strlen(optarg)-1 <= PFXMONITOR_METRIC_PFX_LEN)
-            {
-              strncpy(state->metric_prefix, optarg,
-                      PFXMONITOR_METRIC_PFX_LEN);
-            }
-          else
-            {
-              fprintf(stderr, "Error: could not set metric prefix\n");
-              usage(plugin);
-              return -1;
-            }
-	  break;
+  while ((opt = getopt(plugin->argc, plugin->argv, ":l:L:m:n:i:M?")) >= 0) {
+    switch (opt) {
+    case 'm':
+      if (optarg != NULL && strlen(optarg) - 1 <= PFXMONITOR_METRIC_PFX_LEN) {
+        strncpy(state->metric_prefix, optarg, PFXMONITOR_METRIC_PFX_LEN);
+      } else {
+        fprintf(stderr, "Error: could not set metric prefix\n");
+        usage(plugin);
+        return -1;
+      }
+      break;
 
-	case 'i':
-          if(optarg != NULL && strlen(optarg)-1 <= PFXMONITOR_METRIC_PFX_LEN)
-            {
-              strncpy(state->ip_space_name, optarg, PFXMONITOR_METRIC_PFX_LEN);
-            }
-          else
-            {
-              fprintf(stderr, "Error: could not set IP space name\n");
-              usage(plugin);
-              return -1;
-            }
-	  break;
+    case 'i':
+      if (optarg != NULL && strlen(optarg) - 1 <= PFXMONITOR_METRIC_PFX_LEN) {
+        strncpy(state->ip_space_name, optarg, PFXMONITOR_METRIC_PFX_LEN);
+      } else {
+        fprintf(stderr, "Error: could not set IP space name\n");
+        usage(plugin);
+        return -1;
+      }
+      break;
 
-        case 'l':
-          if(bgpstream_str2pfx(optarg, &pfx_st) == NULL)
-             {
-               fprintf(stderr, "Error: Could not parse prefix (%s)\n",
-                       optarg);
-               usage(plugin);
-               return -1;
-             }
-          bgpstream_ip_counter_add(state->poi, (bgpstream_pfx_t *) &pfx_st);
-	  break;
+    case 'l':
+      if (bgpstream_str2pfx(optarg, &pfx_st) == NULL) {
+        fprintf(stderr, "Error: Could not parse prefix (%s)\n", optarg);
+        usage(plugin);
+        return -1;
+      }
+      bgpstream_ip_counter_add(state->poi, (bgpstream_pfx_t *)&pfx_st);
+      break;
 
-        case 'L':
-	  if(add_prefixes_from_file(state->poi, optarg) != 0)
-            {
-              return -1;
-            }
-	  break;
+    case 'L':
+      if (add_prefixes_from_file(state->poi, optarg) != 0) {
+        return -1;
+      }
+      break;
 
-        case 'M':
-          state->more_specific = 1;
-          break;
+    case 'M':
+      state->more_specific = 1;
+      break;
 
-	case 'n':
-          state->peer_asns_th = atoi(optarg);
-	  break;
+    case 'n':
+      state->peer_asns_th = atoi(optarg);
+      break;
 
-	case '?':
-	case ':':
-	default:
-	  usage(plugin);
-	  return -1;
-	}
-    }
-
-  /* if no prefixes were provided,  */
-  if(bgpstream_ip_counter_get_ipcount(state->poi, BGPSTREAM_ADDR_VERSION_IPV4) == 0 &&
-     bgpstream_ip_counter_get_ipcount(state->poi, BGPSTREAM_ADDR_VERSION_IPV6) == 0 )
-    {
-      fprintf(stderr, "Error: no valid prefixes provided\n");
+    case '?':
+    case ':':
+    default:
       usage(plugin);
       return -1;
     }
+  }
+
+  /* if no prefixes were provided,  */
+  if (bgpstream_ip_counter_get_ipcount(state->poi,
+                                       BGPSTREAM_ADDR_VERSION_IPV4) == 0 &&
+      bgpstream_ip_counter_get_ipcount(state->poi,
+                                       BGPSTREAM_ADDR_VERSION_IPV6) == 0) {
+    fprintf(stderr, "Error: no valid prefixes provided\n");
+    usage(plugin);
+    return -1;
+  }
 
   return 0;
 }
@@ -551,15 +500,13 @@ int bgpcorsaro_pfxmonitor_init_output(bgpcorsaro_t *bgpcorsaro)
   bgpcorsaro_plugin_t *plugin = PLUGIN(bgpcorsaro);
   assert(plugin != NULL);
 
-  if((state =
-      malloc_zero(sizeof(struct bgpcorsaro_pfxmonitor_state_t))) == NULL)
-    {
-      bgpcorsaro_log(__func__, bgpcorsaro,
-		     "could not malloc bgpcorsaro_pfxmonitor_state_t");
-      goto err;
-    }
+  if ((state = malloc_zero(sizeof(struct bgpcorsaro_pfxmonitor_state_t))) ==
+      NULL) {
+    bgpcorsaro_log(__func__, bgpcorsaro,
+                   "could not malloc bgpcorsaro_pfxmonitor_state_t");
+    goto err;
+  }
   bgpcorsaro_plugin_register_state(bgpcorsaro->plugin_manager, plugin, state);
-
 
   /* initialize state with default values */
   state = STATE(bgpcorsaro);
@@ -568,39 +515,36 @@ int bgpcorsaro_pfxmonitor_init_output(bgpcorsaro_t *bgpcorsaro)
   strncpy(state->ip_space_name, PFXMONITOR_DEFAULT_IPSPACE_NAME,
           PFXMONITOR_METRIC_PFX_LEN);
 
-  if((state->poi = bgpstream_ip_counter_create()) == NULL)
-    {
-      goto err;
-    }
+  if ((state->poi = bgpstream_ip_counter_create()) == NULL) {
+    goto err;
+  }
   state->peer_asns_th = PFXMONITOR_DEFAULT_PEER_ASNS_THRESHOLD;
   state->more_specific = 0;
 
   /* parse the arguments */
-  if(parse_args(bgpcorsaro) != 0)
-    {
-      goto err;
-    }
-  
+  if (parse_args(bgpcorsaro) != 0) {
+    goto err;
+  }
+
   graphite_safe(state->metric_prefix);
   graphite_safe(state->ip_space_name);
 
   /* create all the sets and maps we need */
-  if((state->overlapping_pfx_cache =
-      bgpstream_pfx_storage_set_create()) == NULL ||
-     (state->non_overlapping_pfx_cache =
-      bgpstream_pfx_storage_set_create()) == NULL ||
-     (state->pfx_info = kh_init(pfx_info_map)) == NULL ||
-     (state->unique_origins = bgpstream_id_set_create()) == NULL ||
-     (state->peer_asns = bgpstream_id_set_create()) == NULL)
-    {
-      goto err;
-    }
+  if ((state->overlapping_pfx_cache = bgpstream_pfx_storage_set_create()) ==
+        NULL ||
+      (state->non_overlapping_pfx_cache = bgpstream_pfx_storage_set_create()) ==
+        NULL ||
+      (state->pfx_info = kh_init(pfx_info_map)) == NULL ||
+      (state->unique_origins = bgpstream_id_set_create()) == NULL ||
+      (state->peer_asns = bgpstream_id_set_create()) == NULL) {
+    goto err;
+  }
 
   /* defer opening the output file until we start the first interval */
 
   return 0;
 
- err:
+err:
   bgpcorsaro_pfxmonitor_close_output(bgpcorsaro);
   return -1;
 }
@@ -611,67 +555,56 @@ int bgpcorsaro_pfxmonitor_close_output(bgpcorsaro_t *bgpcorsaro)
   int i;
   struct bgpcorsaro_pfxmonitor_state_t *state = STATE(bgpcorsaro);
   khiter_t k;
-  khash_t(peer_asn_map) *v;
+  khash_t(peer_asn_map) * v;
 
-  if(state == NULL)
-    {
-      return 0;
-    }
+  if (state == NULL) {
+    return 0;
+  }
 
   /* close all the outfile pointers */
-  for(i = 0; i < OUTFILE_POINTERS; i++)
-    {
-      if(state->outfile_p[i] != NULL)
-        {
-          wandio_wdestroy(state->outfile_p[i]);
-          state->outfile_p[i] = NULL;
-        }
+  for (i = 0; i < OUTFILE_POINTERS; i++) {
+    if (state->outfile_p[i] != NULL) {
+      wandio_wdestroy(state->outfile_p[i]);
+      state->outfile_p[i] = NULL;
     }
+  }
   state->outfile = NULL;
-  if(state->poi != NULL)
-    {
-      bgpstream_ip_counter_destroy(state->poi);
-      state->poi = NULL;
-    }
+  if (state->poi != NULL) {
+    bgpstream_ip_counter_destroy(state->poi);
+    state->poi = NULL;
+  }
 
   /* deallocate the dynamic memory in use */
-  if(state->overlapping_pfx_cache != NULL)
-    {
-      bgpstream_pfx_storage_set_destroy(state->overlapping_pfx_cache);
-      state->overlapping_pfx_cache = NULL;
-    }
+  if (state->overlapping_pfx_cache != NULL) {
+    bgpstream_pfx_storage_set_destroy(state->overlapping_pfx_cache);
+    state->overlapping_pfx_cache = NULL;
+  }
 
-  if(state->non_overlapping_pfx_cache != NULL)
-    {
-      bgpstream_pfx_storage_set_destroy(state->non_overlapping_pfx_cache);
-      state->non_overlapping_pfx_cache = NULL;
-    }
+  if (state->non_overlapping_pfx_cache != NULL) {
+    bgpstream_pfx_storage_set_destroy(state->non_overlapping_pfx_cache);
+    state->non_overlapping_pfx_cache = NULL;
+  }
 
-  if(state->peer_asns != NULL)
-    {
-      bgpstream_id_set_destroy(state->peer_asns);
-      state->peer_asns = NULL;
-    }
+  if (state->peer_asns != NULL) {
+    bgpstream_id_set_destroy(state->peer_asns);
+    state->peer_asns = NULL;
+  }
 
-  if(state->pfx_info != NULL)
-    {
-      for (k = kh_begin(state->pfx_info); k != kh_end(state->pfx_info); ++k)
-        {
-          if (kh_exist(state->pfx_info, k))
-            {
-              v = kh_val(state->pfx_info, k);
-              kh_destroy(peer_asn_map, v);
-            }
-        }
-      kh_destroy(pfx_info_map, state->pfx_info);
-      state->pfx_info = NULL;
+  if (state->pfx_info != NULL) {
+    for (k = kh_begin(state->pfx_info); k != kh_end(state->pfx_info); ++k) {
+      if (kh_exist(state->pfx_info, k)) {
+        v = kh_val(state->pfx_info, k);
+        kh_destroy(peer_asn_map, v);
+      }
     }
+    kh_destroy(pfx_info_map, state->pfx_info);
+    state->pfx_info = NULL;
+  }
 
-  if(state->unique_origins != NULL)
-    {
-      bgpstream_id_set_destroy(state->unique_origins);
-      state->unique_origins = NULL;
-    }
+  if (state->unique_origins != NULL) {
+    bgpstream_id_set_destroy(state->unique_origins);
+    state->unique_origins = NULL;
+  }
 
   bgpcorsaro_plugin_free_state(bgpcorsaro->plugin_manager, PLUGIN(bgpcorsaro));
   return 0;
@@ -684,21 +617,15 @@ int bgpcorsaro_pfxmonitor_start_interval(bgpcorsaro_t *bgpcorsaro,
   struct bgpcorsaro_pfxmonitor_state_t *state = STATE(bgpcorsaro);
 
   /* open an output file */
-  if(state->outfile == NULL)
-    {
-      if((
-	  state->outfile_p[state->outfile_n] =
-	  bgpcorsaro_io_prepare_file(bgpcorsaro,
-				     PLUGIN(bgpcorsaro)->name,
-				     int_start)) == NULL)
-	{
-	  bgpcorsaro_log(__func__, bgpcorsaro, "could not open %s output file",
-			 PLUGIN(bgpcorsaro)->name);
-	  return -1;
-	}
-      state->outfile = state->
-	outfile_p[state->outfile_n];
+  if (state->outfile == NULL) {
+    if ((state->outfile_p[state->outfile_n] = bgpcorsaro_io_prepare_file(
+           bgpcorsaro, PLUGIN(bgpcorsaro)->name, int_start)) == NULL) {
+      bgpcorsaro_log(__func__, bgpcorsaro, "could not open %s output file",
+                     PLUGIN(bgpcorsaro)->name);
+      return -1;
     }
+    state->outfile = state->outfile_p[state->outfile_n];
+  }
 
   bgpcorsaro_io_write_interval_start(bgpcorsaro, state->outfile, int_start);
 
@@ -717,24 +644,21 @@ int bgpcorsaro_pfxmonitor_end_interval(bgpcorsaro_t *bgpcorsaro,
   bgpcorsaro_io_write_interval_end(bgpcorsaro, state->outfile, int_end);
 
   /* if we are rotating, now is when we should do it */
-  if(bgpcorsaro_is_rotate_interval(bgpcorsaro))
-    {
-      /* leave the current file to finish draining buffers */
-      assert(state->outfile != NULL);
+  if (bgpcorsaro_is_rotate_interval(bgpcorsaro)) {
+    /* leave the current file to finish draining buffers */
+    assert(state->outfile != NULL);
 
-      /* move on to the next output pointer */
-      state->outfile_n = (state->outfile_n+1) %
-	OUTFILE_POINTERS;
+    /* move on to the next output pointer */
+    state->outfile_n = (state->outfile_n + 1) % OUTFILE_POINTERS;
 
-      if(state->outfile_p[state->outfile_n] != NULL)
-	{
-	  /* we're gonna have to wait for this to close */
-	  wandio_wdestroy(state->outfile_p[state->outfile_n]);
-	  state->outfile_p[state->outfile_n] =  NULL;
-	}
-
-      state->outfile = NULL;
+    if (state->outfile_p[state->outfile_n] != NULL) {
+      /* we're gonna have to wait for this to close */
+      wandio_wdestroy(state->outfile_p[state->outfile_n]);
+      state->outfile_p[state->outfile_n] = NULL;
     }
+
+    state->outfile = NULL;
+  }
 
   output_stats_and_reset(state, state->interval_start);
 
@@ -753,73 +677,61 @@ int bgpcorsaro_pfxmonitor_process_record(bgpcorsaro_t *bgpcorsaro,
 
   /* no point carrying on if a previous plugin has already decided we should
      ignore this record */
-  if((record->state.flags & BGPCORSARO_RECORD_STATE_FLAG_IGNORE) != 0)
-    {
-      return 0;
-    }
+  if ((record->state.flags & BGPCORSARO_RECORD_STATE_FLAG_IGNORE) != 0) {
+    return 0;
+  }
 
   /* consider only valid records */
-  if(bs_record->status != BGPSTREAM_RECORD_STATUS_VALID_RECORD)
-    {
-      return 0;
-    }
+  if (bs_record->status != BGPSTREAM_RECORD_STATUS_VALID_RECORD) {
+    return 0;
+  }
 
   /* process all elems in the record */
-  while((elem = bgpstream_record_get_next_elem(bs_record)) != NULL)
-    {
-      if(elem->type != BGPSTREAM_ELEM_TYPE_ANNOUNCEMENT &&
-         elem->type != BGPSTREAM_ELEM_TYPE_WITHDRAWAL &&
-         elem->type != BGPSTREAM_ELEM_TYPE_RIB)
-        {
-          continue;
-        }
-
-      /* consider only prefixes announced by the peers (not the collector) */
-      if(elem->type != BGPSTREAM_ELEM_TYPE_WITHDRAWAL &&
-         bgpstream_as_path_get_len(elem->aspath) == 0)
-        {
-          continue;
-        }
-
-      /* consider only prefixes that overlap with the set provided */
-
-      /* first, check the non overlapping pfxs cache */
-      if(bgpstream_pfx_storage_set_exists(state->non_overlapping_pfx_cache,
-                                          &elem->prefix) != 0)
-        {
-          /* confirmed as non-overlapping */
-          continue;
-        }
-
-      /* check the overlapping pfxs cache */
-      if(bgpstream_pfx_storage_set_exists(state->overlapping_pfx_cache,
-                                          &elem->prefix) == 0)
-        {
-          /* not cached, but could still be overlapping, need to check */
-          more_specific = 0;
-          overlap =
-            bgpstream_ip_counter_is_overlapping(state->poi,
-                                                (bgpstream_pfx_t *)&elem->prefix,
-                                                &more_specific);
-
-          if(overlap > 0 && (!state->more_specific || more_specific))
-            {
-              bgpstream_pfx_storage_set_insert(state->overlapping_pfx_cache,
-                                               &elem->prefix);
-              /* overlapping */
-            }
-          else
-            {
-              bgpstream_pfx_storage_set_insert(state->non_overlapping_pfx_cache,
-                                               &elem->prefix);
-              /* non-overlapping */
-              continue;
-            }
-        }
-
-      /* by here, confirmed as overlapping, process the elem */
-      process_overlapping_pfx(state, bs_record, elem);
+  while ((elem = bgpstream_record_get_next_elem(bs_record)) != NULL) {
+    if (elem->type != BGPSTREAM_ELEM_TYPE_ANNOUNCEMENT &&
+        elem->type != BGPSTREAM_ELEM_TYPE_WITHDRAWAL &&
+        elem->type != BGPSTREAM_ELEM_TYPE_RIB) {
+      continue;
     }
+
+    /* consider only prefixes announced by the peers (not the collector) */
+    if (elem->type != BGPSTREAM_ELEM_TYPE_WITHDRAWAL &&
+        bgpstream_as_path_get_len(elem->aspath) == 0) {
+      continue;
+    }
+
+    /* consider only prefixes that overlap with the set provided */
+
+    /* first, check the non overlapping pfxs cache */
+    if (bgpstream_pfx_storage_set_exists(state->non_overlapping_pfx_cache,
+                                         &elem->prefix) != 0) {
+      /* confirmed as non-overlapping */
+      continue;
+    }
+
+    /* check the overlapping pfxs cache */
+    if (bgpstream_pfx_storage_set_exists(state->overlapping_pfx_cache,
+                                         &elem->prefix) == 0) {
+      /* not cached, but could still be overlapping, need to check */
+      more_specific = 0;
+      overlap = bgpstream_ip_counter_is_overlapping(
+        state->poi, (bgpstream_pfx_t *)&elem->prefix, &more_specific);
+
+      if (overlap > 0 && (!state->more_specific || more_specific)) {
+        bgpstream_pfx_storage_set_insert(state->overlapping_pfx_cache,
+                                         &elem->prefix);
+        /* overlapping */
+      } else {
+        bgpstream_pfx_storage_set_insert(state->non_overlapping_pfx_cache,
+                                         &elem->prefix);
+        /* non-overlapping */
+        continue;
+      }
+    }
+
+    /* by here, confirmed as overlapping, process the elem */
+    process_overlapping_pfx(state, bs_record, elem);
+  }
 
   return 0;
 }

--- a/bgpcorsaro/tools/bgpcorsaro.c
+++ b/bgpcorsaro/tools/bgpcorsaro.c
@@ -36,14 +36,15 @@
 
 /** @file
  *
- * @brief Code which uses libbgpcorsaro to process a trace file and generate output
+ * @brief Code which uses libbgpcorsaro to process a trace file and generate
+ * output
  *
  * @author Alistair King
  *
  */
 
 #define PROJECT_CMD_CNT 10
-#define TYPE_CMD_CNT    10
+#define TYPE_CMD_CNT 10
 #define COLLECTOR_CMD_CNT 100
 #define PREFIX_CMD_CNT 1000
 #define COMMUNITY_CMD_CNT 1000
@@ -87,12 +88,10 @@ static bgpstream_data_interface_info_t *datasource_info = NULL;
 static void catch_sigint(int sig)
 {
   bgpcorsaro_shutdown++;
-  if(bgpcorsaro_shutdown == HARD_SHUTDOWN)
-    {
-      fprintf(stderr, "caught %d SIGINT's. shutting down NOW\n",
-	      HARD_SHUTDOWN);
-      exit(-1);
-    }
+  if (bgpcorsaro_shutdown == HARD_SHUTDOWN) {
+    fprintf(stderr, "caught %d SIGINT's. shutting down NOW\n", HARD_SHUTDOWN);
+    exit(-1);
+  }
 
   fprintf(stderr, "caught SIGINT, shutting down at the next opportunity\n");
 
@@ -102,19 +101,18 @@ static void catch_sigint(int sig)
 /** Clean up all state before exit */
 static void clean()
 {
-  if(record != NULL)
-    {
-      bgpstream_record_destroy(record);
-      record = NULL;
-    }
+  if (record != NULL) {
+    bgpstream_record_destroy(record);
+    record = NULL;
+  }
 
-  if(bgpcorsaro != NULL)
-    {
-      bgpcorsaro_finalize_output(bgpcorsaro);
-    }
+  if (bgpcorsaro != NULL) {
+    bgpcorsaro_finalize_output(bgpcorsaro);
+  }
 }
 
-static void data_if_usage() {
+static void data_if_usage()
+{
   bgpstream_data_interface_id_t *ids = NULL;
   int id_cnt = 0;
   int i;
@@ -123,41 +121,35 @@ static void data_if_usage() {
 
   id_cnt = bgpstream_get_data_interfaces(stream, &ids);
 
-  for(i=0; i<id_cnt; i++)
-    {
-      info = bgpstream_get_data_interface_info(stream, ids[i]);
+  for (i = 0; i < id_cnt; i++) {
+    info = bgpstream_get_data_interface_info(stream, ids[i]);
 
-      if(info != NULL)
-        {
-          fprintf(stderr,
-                  "       %-13s%s%s\n", info->name, info->description,
-                  (ids[i] == datasource_id_default) ? " (default)" : "");
-        }
+    if (info != NULL) {
+      fprintf(stderr, "       %-13s%s%s\n", info->name, info->description,
+              (ids[i] == datasource_id_default) ? " (default)" : "");
     }
+  }
 }
 
-static void dump_if_options() {
+static void dump_if_options()
+{
   assert(datasource_id != 0);
 
   bgpstream_data_interface_option_t *options;
   int opt_cnt = 0;
   int i;
 
-  opt_cnt = bgpstream_get_data_interface_options(stream, datasource_id, &options);
+  opt_cnt =
+    bgpstream_get_data_interface_options(stream, datasource_id, &options);
 
   fprintf(stderr, "Data interface options for '%s':\n", datasource_info->name);
-  if(opt_cnt == 0)
-    {
-      fprintf(stderr, "   [NONE]\n");
+  if (opt_cnt == 0) {
+    fprintf(stderr, "   [NONE]\n");
+  } else {
+    for (i = 0; i < opt_cnt; i++) {
+      fprintf(stderr, "   %-13s%s\n", options[i].name, options[i].description);
     }
-  else
-    {
-      for(i=0; i<opt_cnt; i++)
-        {
-          fprintf(stderr, "   %-13s%s\n",
-                  options[i].name, options[i].description);
-        }
-    }
+  }
   fprintf(stderr, "\n");
 }
 
@@ -167,67 +159,78 @@ static void usage()
   int i;
   char **plugin_names;
   int plugin_cnt;
-  if((plugin_cnt = bgpcorsaro_get_plugin_names(&plugin_names)) < 0)
-    {
-      /* not much we can do */
-      fprintf(stderr, "bgpcorsaro_get_plugin_names failed\n");
-      return;
-    }
+  if ((plugin_cnt = bgpcorsaro_get_plugin_names(&plugin_names)) < 0) {
+    /* not much we can do */
+    fprintf(stderr, "bgpcorsaro_get_plugin_names failed\n");
+    return;
+  }
 
   fprintf(stderr,
-	  "usage: bgpcorsaro -w <start>[,<end>] -O outfile [<options>]\n"
-	  "Available options are:\n"
-          "   -d <interface> use the given bgpstream data interface to find available data\n"
+          "usage: bgpcorsaro -w <start>[,<end>] -O outfile [<options>]\n"
+          "Available options are:\n"
+          "   -d <interface> use the given bgpstream data interface to find "
+          "available data\n"
           "                   available data interfaces are:\n");
   data_if_usage();
-  fprintf(stderr,
-          "   -o <option-name,option-value>*\n"
-          "                  set an option for the current data interface.\n"
-          "                  use '-o ?' to get a list of available options for the current\n"
-          "                  data interface. (data interface can be selected using -d)\n"
-	  "   -p <project>   process records from only the given project (routeviews, ris)*\n"
-	  "   -c <collector> process records from only the given collector*\n"
-	  "   -t <type>      process records with only the given type (ribs, updates)*\n"
-          "   -w <start>[,<end>]\n"
-          "                  process records within the given time window\n"
-          "                    (omitting the end parameter enables live mode)*\n"
-          "   -P <period>    process a rib files every <period> seconds (bgp time)\n"
-          "   -j <peer ASN>  return valid elems originated by a specific peer ASN*\n"
-          "   -k <prefix>    return valid elems associated with a specific prefix*\n"
-          "   -y <community> return valid elems with the specified community* \n"
-          "                  (format: asn:value, the '*' metacharacter is recognized)\n"
-	  "   -l             enable live mode (make blocking requests for BGP records)\n"
-	  "                  allows bgpcorsaro to be used to process data in real-time\n"
-          "\n"
-	  "   -i <interval>  distribution interval in seconds (default: %d)\n"
-	  "   -a             align the end time of the first interval\n"
-          "   -g <gap-limit> maximum allowed gap between packets (0 is no limit) (default: %d)\n"
-	  "   -L             disable logging to a file\n"
-          "\n",
-          BGPCORSARO_INTERVAL_DEFAULT,
-          GAP_LIMIT_DEFAULT);
-  fprintf(stderr,
-	  "   -x <plugin>    enable the given plugin (default: all)*\n"
-	  "                   available plugins:\n");
+  fprintf(
+    stderr,
+    "   -o <option-name,option-value>*\n"
+    "                  set an option for the current data interface.\n"
+    "                  use '-o ?' to get a list of available options for the "
+    "current\n"
+    "                  data interface. (data interface can be selected using "
+    "-d)\n"
+    "   -p <project>   process records from only the given project "
+    "(routeviews, ris)*\n"
+    "   -c <collector> process records from only the given collector*\n"
+    "   -t <type>      process records with only the given type (ribs, "
+    "updates)*\n"
+    "   -w <start>[,<end>]\n"
+    "                  process records within the given time window\n"
+    "                    (omitting the end parameter enables live mode)*\n"
+    "   -P <period>    process a rib files every <period> seconds (bgp time)\n"
+    "   -j <peer ASN>  return valid elems originated by a specific peer ASN*\n"
+    "   -k <prefix>    return valid elems associated with a specific prefix*\n"
+    "   -y <community> return valid elems with the specified community* \n"
+    "                  (format: asn:value, the '*' metacharacter is "
+    "recognized)\n"
+    "   -l             enable live mode (make blocking requests for BGP "
+    "records)\n"
+    "                  allows bgpcorsaro to be used to process data in "
+    "real-time\n"
+    "\n"
+    "   -i <interval>  distribution interval in seconds (default: %d)\n"
+    "   -a             align the end time of the first interval\n"
+    "   -g <gap-limit> maximum allowed gap between packets (0 is no limit) "
+    "(default: %d)\n"
+    "   -L             disable logging to a file\n"
+    "\n",
+    BGPCORSARO_INTERVAL_DEFAULT, GAP_LIMIT_DEFAULT);
+  fprintf(stderr, "   -x <plugin>    enable the given plugin (default: all)*\n"
+                  "                   available plugins:\n");
 
-  for(i = 0; i < plugin_cnt; i++)
-    {
-      fprintf(stderr, "                    - %s\n", plugin_names[i]);
-    }
-  fprintf(stderr,
-	  "                   use -p \"<plugin_name> -?\" to see plugin options\n"
-          "   -n <name>      monitor name (default: "
-	  STR(BGPCORSARO_MONITOR_NAME)")\n"
-	  "   -O <outfile>   use <outfile> as a template for file names.\n"
-	  "                   - %%X => plugin name\n"
-	  "                   - %%N => monitor name\n"
-	  "                   - see man strftime(3) for more options\n"
-	  "   -r <intervals> rotate output files after n intervals\n"
-	  "   -R <intervals> rotate bgpcorsaro meta files after n intervals\n"
-          "\n"
-          "   -h             print this help menu\n"
-	  "* denotes an option that can be given multiple times\n"
-	  );
+  for (i = 0; i < plugin_cnt; i++) {
+    fprintf(stderr, "                    - %s\n", plugin_names[i]);
+  }
+  fprintf(
+    stderr,
+    "                   use -p \"<plugin_name> -?\" to see plugin options\n"
+    "   -n <name>      monitor name (default: " STR(
+      BGPCORSARO_MONITOR_NAME) ")\n"
+                               "   -O <outfile>   use <outfile> as a template "
+                               "for file names.\n"
+                               "                   - %%X => plugin name\n"
+                               "                   - %%N => monitor name\n"
+                               "                   - see man strftime(3) for "
+                               "more options\n"
+                               "   -r <intervals> rotate output files after n "
+                               "intervals\n"
+                               "   -R <intervals> rotate bgpcorsaro meta files "
+                               "after n intervals\n"
+                               "\n"
+                               "   -h             print this help menu\n"
+                               "* denotes an option that can be given multiple "
+                               "times\n");
 
   bgpcorsaro_free_plugin_names(plugin_names, plugin_cnt);
 }
@@ -287,222 +290,195 @@ int main(int argc, char *argv[])
 
   signal(SIGINT, catch_sigint);
 
-
-  if((stream = bgpstream_create()) == NULL)
-    {
-      fprintf(stderr, "ERROR: Could not create BGPStream instance\n");
-      return -1;
-    }
+  if ((stream = bgpstream_create()) == NULL) {
+    fprintf(stderr, "ERROR: Could not create BGPStream instance\n");
+    return -1;
+  }
   datasource_id_default = datasource_id =
     bgpstream_get_data_interface_id(stream);
-  datasource_info =
-    bgpstream_get_data_interface_info(stream, datasource_id);
+  datasource_info = bgpstream_get_data_interface_info(stream, datasource_id);
   assert(datasource_id != 0);
 
-  while(prevoptind = optind,
-        (opt = getopt(argc, argv, ":d:o:p:c:t:w:j:k:y:P:i:ag:lLx:n:O:r:R:hv?")) >= 0)
-    {
-      if (optind == prevoptind + 2 && (optarg == NULL || *optarg == '-') ) {
-        opt = ':';
-        -- optind;
-      }
-      switch(opt)
-	{
-	case 'd':
-          if((datasource_id =
-              bgpstream_get_data_interface_id_by_name(stream, optarg)) == 0)
-            {
-              fprintf(stderr, "ERROR: Invalid data interface name '%s'\n",
-                      optarg);
-              usage();
-              exit(-1);
-            }
-          datasource_info =
-            bgpstream_get_data_interface_info(stream, datasource_id);
-	  break;
-
-	case 'p':
-	  if(projects_cnt == PROJECT_CMD_CNT)
-	    {
-	      fprintf(stderr,
-		      "ERROR: A maximum of %d projects can be specified on "
-		      "the command line\n",
-		      PROJECT_CMD_CNT);
-	      usage();
-	      exit(-1);
-	    }
-	  projects[projects_cnt++] = strdup(optarg);
-	  break;
-
-	case 'c':
-	  if(collectors_cnt == COLLECTOR_CMD_CNT)
-	    {
-	      fprintf(stderr,
-		      "ERROR: A maximum of %d collectors can be specified on "
-		      "the command line\n",
-		      COLLECTOR_CMD_CNT);
-	      usage();
-	      exit(-1);
-	    }
-	  collectors[collectors_cnt++] = strdup(optarg);
-	  break;
-
-	case 't':
-	  if(types_cnt == TYPE_CMD_CNT)
-	    {
-	      fprintf(stderr,
-		      "ERROR: A maximum of %d types can be specified on "
-		      "the command line\n",
-		      TYPE_CMD_CNT);
-	      usage();
-	      exit(-1);
-	    }
-	  types[types_cnt++] = strdup(optarg);
-	  break;
-
-	case 'w':
-	  if(windows_cnt == WINDOW_CMD_CNT)
-	    {
-	      fprintf(stderr,
-		      "ERROR: A maximum of %d windows can be specified on "
-		      "the command line\n",
-		      WINDOW_CMD_CNT);
-	      usage();
-	      exit(-1);
-	    }
-	  /* split the window into a start and end */
-	  if((endp = strchr(optarg, ',')) == NULL)
-	    {
-              windows[windows_cnt].end = BGPSTREAM_FOREVER;
-	    }
-          else
-            {
-              *endp = '\0';
-              endp++;
-              windows[windows_cnt].end =  atoi(endp);
-            }
-	  windows[windows_cnt].start = atoi(optarg);
-	  windows_cnt++;
-	  break;
-
-        case 'j':
-	  if(peerasns_cnt == PEERASN_CMD_CNT)
-	    {
-	      fprintf(stderr,
-		      "ERROR: A maximum of %d peer asns can be specified on "
-		      "the command line\n",
-		      PEERASN_CMD_CNT);
-	      usage();
-	      exit(-1);
-	    }
-	  peerasns[peerasns_cnt++] = strdup(optarg);
-	  break;
-
-        case 'k':
-	  if(prefixes_cnt == PREFIX_CMD_CNT)
-	    {
-	      fprintf(stderr,
-		      "ERROR: A maximum of %d peer asns can be specified on "
-		      "the command line\n",
-		      PREFIX_CMD_CNT);
-	      usage();
-	      exit(-1);
-	    }
-	  prefixes[prefixes_cnt++] = strdup(optarg);
-	  break;
-
-        case 'y':
-	  if(communities_cnt == COMMUNITY_CMD_CNT)
-	    {
-	      fprintf(stderr,
-		      "ERROR: A maximum of %d communities can be specified on "
-		      "the command line\n",
-		      PREFIX_CMD_CNT);
-	      usage();
-	      exit(-1);
-	    }
-	  communities[communities_cnt++] = strdup(optarg);
-	  break;
-
-        case 'o':
-          if(interface_options_cnt == OPTION_CMD_CNT)
-	    {
-	      fprintf(stderr,
-		      "ERROR: A maximum of %d interface options can be specified\n",
-		      OPTION_CMD_CNT);
-	      usage();
-	      exit(-1);
-	    }
-	  interface_options[interface_options_cnt++] = strdup(optarg);
-          break;
-
-	case 'P':
-	  rib_period = atoi(optarg);
-	  break;
-
-	case 'l':
-	  live = 1;
-	  break;
-
-        case 'g':
-          gap_limit = atoi(optarg);
-          break;
-
-
-	case 'a':
-	  align = 1;
-	  break;
-
-
-	case 'i':
-	  interval = atoi(optarg);
-	  break;
-
-	case 'L':
-	  logfile_disable = 1;
-	  break;
-
-	case 'n':
-	  name = strdup(optarg);
-	  break;
-
-	case 'O':
-	  tmpl = strdup(optarg);
-	  break;
-
-	case 'x':
-	  plugins[plugin_cnt++] = strdup(optarg);
-	  break;
-
-	case 'r':
-	  rotate = atoi(optarg);
-	  break;
-
-	case 'R':
-	  meta_rotate = atoi(optarg);
-	  break;
-
-	case ':':
-	  fprintf(stderr, "ERROR: Missing option argument for -%c\n", optopt);
-	  usage();
-	  exit(-1);
-	  break;
-
-	case '?':
-	case 'v':
-	  fprintf(stderr, "bgpcorsaro version %d.%d.%d\n",
-		  BGPSTREAM_MAJOR_VERSION,
-		  BGPSTREAM_MID_VERSION,
-		  BGPSTREAM_MINOR_VERSION);
-	  usage();
-	  exit(0);
-	  break;
-
-	default:
-	  usage();
-	  exit(-1);
-	}
+  while (prevoptind = optind,
+         (opt = getopt(argc, argv,
+                       ":d:o:p:c:t:w:j:k:y:P:i:ag:lLx:n:O:r:R:hv?")) >= 0) {
+    if (optind == prevoptind + 2 && (optarg == NULL || *optarg == '-')) {
+      opt = ':';
+      --optind;
     }
+    switch (opt) {
+    case 'd':
+      if ((datasource_id =
+             bgpstream_get_data_interface_id_by_name(stream, optarg)) == 0) {
+        fprintf(stderr, "ERROR: Invalid data interface name '%s'\n", optarg);
+        usage();
+        exit(-1);
+      }
+      datasource_info =
+        bgpstream_get_data_interface_info(stream, datasource_id);
+      break;
+
+    case 'p':
+      if (projects_cnt == PROJECT_CMD_CNT) {
+        fprintf(stderr, "ERROR: A maximum of %d projects can be specified on "
+                        "the command line\n",
+                PROJECT_CMD_CNT);
+        usage();
+        exit(-1);
+      }
+      projects[projects_cnt++] = strdup(optarg);
+      break;
+
+    case 'c':
+      if (collectors_cnt == COLLECTOR_CMD_CNT) {
+        fprintf(stderr, "ERROR: A maximum of %d collectors can be specified on "
+                        "the command line\n",
+                COLLECTOR_CMD_CNT);
+        usage();
+        exit(-1);
+      }
+      collectors[collectors_cnt++] = strdup(optarg);
+      break;
+
+    case 't':
+      if (types_cnt == TYPE_CMD_CNT) {
+        fprintf(stderr, "ERROR: A maximum of %d types can be specified on "
+                        "the command line\n",
+                TYPE_CMD_CNT);
+        usage();
+        exit(-1);
+      }
+      types[types_cnt++] = strdup(optarg);
+      break;
+
+    case 'w':
+      if (windows_cnt == WINDOW_CMD_CNT) {
+        fprintf(stderr, "ERROR: A maximum of %d windows can be specified on "
+                        "the command line\n",
+                WINDOW_CMD_CNT);
+        usage();
+        exit(-1);
+      }
+      /* split the window into a start and end */
+      if ((endp = strchr(optarg, ',')) == NULL) {
+        windows[windows_cnt].end = BGPSTREAM_FOREVER;
+      } else {
+        *endp = '\0';
+        endp++;
+        windows[windows_cnt].end = atoi(endp);
+      }
+      windows[windows_cnt].start = atoi(optarg);
+      windows_cnt++;
+      break;
+
+    case 'j':
+      if (peerasns_cnt == PEERASN_CMD_CNT) {
+        fprintf(stderr, "ERROR: A maximum of %d peer asns can be specified on "
+                        "the command line\n",
+                PEERASN_CMD_CNT);
+        usage();
+        exit(-1);
+      }
+      peerasns[peerasns_cnt++] = strdup(optarg);
+      break;
+
+    case 'k':
+      if (prefixes_cnt == PREFIX_CMD_CNT) {
+        fprintf(stderr, "ERROR: A maximum of %d peer asns can be specified on "
+                        "the command line\n",
+                PREFIX_CMD_CNT);
+        usage();
+        exit(-1);
+      }
+      prefixes[prefixes_cnt++] = strdup(optarg);
+      break;
+
+    case 'y':
+      if (communities_cnt == COMMUNITY_CMD_CNT) {
+        fprintf(stderr,
+                "ERROR: A maximum of %d communities can be specified on "
+                "the command line\n",
+                PREFIX_CMD_CNT);
+        usage();
+        exit(-1);
+      }
+      communities[communities_cnt++] = strdup(optarg);
+      break;
+
+    case 'o':
+      if (interface_options_cnt == OPTION_CMD_CNT) {
+        fprintf(stderr,
+                "ERROR: A maximum of %d interface options can be specified\n",
+                OPTION_CMD_CNT);
+        usage();
+        exit(-1);
+      }
+      interface_options[interface_options_cnt++] = strdup(optarg);
+      break;
+
+    case 'P':
+      rib_period = atoi(optarg);
+      break;
+
+    case 'l':
+      live = 1;
+      break;
+
+    case 'g':
+      gap_limit = atoi(optarg);
+      break;
+
+    case 'a':
+      align = 1;
+      break;
+
+    case 'i':
+      interval = atoi(optarg);
+      break;
+
+    case 'L':
+      logfile_disable = 1;
+      break;
+
+    case 'n':
+      name = strdup(optarg);
+      break;
+
+    case 'O':
+      tmpl = strdup(optarg);
+      break;
+
+    case 'x':
+      plugins[plugin_cnt++] = strdup(optarg);
+      break;
+
+    case 'r':
+      rotate = atoi(optarg);
+      break;
+
+    case 'R':
+      meta_rotate = atoi(optarg);
+      break;
+
+    case ':':
+      fprintf(stderr, "ERROR: Missing option argument for -%c\n", optopt);
+      usage();
+      exit(-1);
+      break;
+
+    case '?':
+    case 'v':
+      fprintf(stderr, "bgpcorsaro version %d.%d.%d\n", BGPSTREAM_MAJOR_VERSION,
+              BGPSTREAM_MID_VERSION, BGPSTREAM_MINOR_VERSION);
+      usage();
+      exit(0);
+      break;
+
+    default:
+      usage();
+      exit(-1);
+    }
+  }
 
   /* store the value of the last index*/
   /*lastopt = optind;*/
@@ -513,133 +489,109 @@ int main(int argc, char *argv[])
   /* -- call NO library functions which may use getopt before here -- */
   /* this ESPECIALLY means bgpcorsaro_enable_plugin */
 
-  for(i=0; i<interface_options_cnt; i++)
-    {
-      if(*interface_options[i] == '?')
-        {
-          dump_if_options();
-          usage();
-          exit(0);
-        }
-      else
-        {
-          /* actually set this option */
-          if((endp = strchr(interface_options[i], ',')) == NULL)
-            {
-              fprintf(stderr,
-                      "ERROR: Malformed data interface option (%s)\n",
-                      interface_options[i]);
-              fprintf(stderr,
-                      "ERROR: Expecting <option-name>,<option-value>\n");
-              usage();
-              exit(-1);
-            }
-          *endp = '\0';
-          endp++;
-          if((option =
-              bgpstream_get_data_interface_option_by_name(stream, datasource_id,
-                                                          interface_options[i])) == NULL)
-            {
-              fprintf(stderr,
-                      "ERROR: Invalid option '%s' for data interface '%s'\n",
-                      interface_options[i], datasource_info->name);
-              usage();
-              exit(-1);
-            }
-          bgpstream_set_data_interface_option(stream, option, endp);
-        }
-      free(interface_options[i]);
-      interface_options[i] = NULL;
+  for (i = 0; i < interface_options_cnt; i++) {
+    if (*interface_options[i] == '?') {
+      dump_if_options();
+      usage();
+      exit(0);
+    } else {
+      /* actually set this option */
+      if ((endp = strchr(interface_options[i], ',')) == NULL) {
+        fprintf(stderr, "ERROR: Malformed data interface option (%s)\n",
+                interface_options[i]);
+        fprintf(stderr, "ERROR: Expecting <option-name>,<option-value>\n");
+        usage();
+        exit(-1);
+      }
+      *endp = '\0';
+      endp++;
+      if ((option = bgpstream_get_data_interface_option_by_name(
+             stream, datasource_id, interface_options[i])) == NULL) {
+        fprintf(stderr, "ERROR: Invalid option '%s' for data interface '%s'\n",
+                interface_options[i], datasource_info->name);
+        usage();
+        exit(-1);
+      }
+      bgpstream_set_data_interface_option(stream, option, endp);
     }
+    free(interface_options[i]);
+    interface_options[i] = NULL;
+  }
   interface_options_cnt = 0;
 
-  if(windows_cnt == 0)
-    {
-      fprintf(stderr,
-              "ERROR: At least one time window must be specified using -w\n");
-      usage();
-      goto err;
-    }
+  if (windows_cnt == 0) {
+    fprintf(stderr,
+            "ERROR: At least one time window must be specified using -w\n");
+    usage();
+    goto err;
+  }
 
-  if(tmpl == NULL)
-    {
-      fprintf(stderr,
-	      "ERROR: An output file template must be specified using -O\n");
-      usage();
-      goto err;
-    }
+  if (tmpl == NULL) {
+    fprintf(stderr,
+            "ERROR: An output file template must be specified using -O\n");
+    usage();
+    goto err;
+  }
 
   /* alloc bgpcorsaro */
-  if((bgpcorsaro = bgpcorsaro_alloc_output(tmpl)) == NULL)
-    {
+  if ((bgpcorsaro = bgpcorsaro_alloc_output(tmpl)) == NULL) {
+    usage();
+    goto err;
+  }
+
+  if (name != NULL && bgpcorsaro_set_monitorname(bgpcorsaro, name) != 0) {
+    bgpcorsaro_log(__func__, bgpcorsaro, "failed to set monitor name");
+    goto err;
+  }
+
+  if (interval > -1000) {
+    bgpcorsaro_set_interval(bgpcorsaro, interval);
+  }
+
+  if (align == 1) {
+    bgpcorsaro_set_interval_alignment(bgpcorsaro,
+                                      BGPCORSARO_INTERVAL_ALIGN_YES);
+  }
+
+  if (rotate > 0) {
+    bgpcorsaro_set_output_rotation(bgpcorsaro, rotate);
+  }
+
+  if (meta_rotate >= 0) {
+    bgpcorsaro_set_meta_output_rotation(bgpcorsaro, meta_rotate);
+  }
+
+  for (i = 0; i < plugin_cnt; i++) {
+    /* the string at plugins[i] will contain the name of the plugin,
+       optionally followed by a space and then the arguments to pass
+       to the plugin */
+    if ((plugin_arg_ptr = strchr(plugins[i], ' ')) != NULL) {
+      /* set the space to a nul, which allows plugins[i] to be used
+         for the plugin name, and then increment plugin_arg_ptr to
+         point to the next character, which will be the start of the
+         arg string (or at worst case, the terminating \0 */
+      *plugin_arg_ptr = '\0';
+      plugin_arg_ptr++;
+    }
+
+    if (bgpcorsaro_enable_plugin(bgpcorsaro, plugins[i], plugin_arg_ptr) != 0) {
+      fprintf(stderr, "ERROR: Could not enable plugin %s\n", plugins[i]);
       usage();
       goto err;
     }
+  }
 
-  if(name != NULL && bgpcorsaro_set_monitorname(bgpcorsaro, name) != 0)
-    {
-      bgpcorsaro_log(__func__, bgpcorsaro, "failed to set monitor name");
-      goto err;
-    }
+  if (logfile_disable != 0) {
+    bgpcorsaro_disable_logfile(bgpcorsaro);
+  }
 
-  if(interval > -1000)
-    {
-      bgpcorsaro_set_interval(bgpcorsaro, interval);
-    }
-
-  if(align == 1)
-    {
-      bgpcorsaro_set_interval_alignment(bgpcorsaro, BGPCORSARO_INTERVAL_ALIGN_YES);
-    }
-
-  if(rotate > 0)
-    {
-      bgpcorsaro_set_output_rotation(bgpcorsaro, rotate);
-    }
-
-  if(meta_rotate >= 0)
-    {
-      bgpcorsaro_set_meta_output_rotation(bgpcorsaro, meta_rotate);
-    }
-
-  for(i=0;i<plugin_cnt;i++)
-    {
-      /* the string at plugins[i] will contain the name of the plugin,
-	 optionally followed by a space and then the arguments to pass
-	 to the plugin */
-      if((plugin_arg_ptr = strchr(plugins[i], ' ')) != NULL)
-	{
-	  /* set the space to a nul, which allows plugins[i] to be used
-	     for the plugin name, and then increment plugin_arg_ptr to
-	     point to the next character, which will be the start of the
-	     arg string (or at worst case, the terminating \0 */
-	  *plugin_arg_ptr = '\0';
-	  plugin_arg_ptr++;
-	}
-
-      if(bgpcorsaro_enable_plugin(bgpcorsaro, plugins[i], plugin_arg_ptr) != 0)
-	{
-	  fprintf(stderr, "ERROR: Could not enable plugin %s\n",
-		  plugins[i]);
-	  usage();
-	  goto err;
-	}
-    }
-
-  if(logfile_disable != 0)
-    {
-      bgpcorsaro_disable_logfile(bgpcorsaro);
-    }
-
-  if(bgpcorsaro_start_output(bgpcorsaro) != 0)
-    {
-      usage();
-      goto err;
-    }
+  if (bgpcorsaro_start_output(bgpcorsaro) != 0) {
+    usage();
+    goto err;
+  }
 
   /* create a record buffer */
-  if (record == NULL &&
-      (record = bgpstream_record_create()) == NULL) {
+  if (record == NULL && (record = bgpstream_record_create()) == NULL) {
     fprintf(stderr, "ERROR: Could not create BGPStream record\n");
     return -1;
   }
@@ -647,75 +599,69 @@ int main(int argc, char *argv[])
   /* pass along the user's filter requests to bgpstream */
 
   /* types */
-  for(i=0; i<types_cnt; i++)
-    {
-      bgpstream_add_filter(stream, BGPSTREAM_FILTER_TYPE_RECORD_TYPE, types[i]);
-      free(types[i]);
-    }
+  for (i = 0; i < types_cnt; i++) {
+    bgpstream_add_filter(stream, BGPSTREAM_FILTER_TYPE_RECORD_TYPE, types[i]);
+    free(types[i]);
+  }
 
   /* projects */
-  for(i=0; i<projects_cnt; i++)
-    {
-      bgpstream_add_filter(stream, BGPSTREAM_FILTER_TYPE_PROJECT, projects[i]);
-      free(projects[i]);
-    }
+  for (i = 0; i < projects_cnt; i++) {
+    bgpstream_add_filter(stream, BGPSTREAM_FILTER_TYPE_PROJECT, projects[i]);
+    free(projects[i]);
+  }
 
   /* collectors */
-  for(i=0; i<collectors_cnt; i++)
-    {
-      bgpstream_add_filter(stream, BGPSTREAM_FILTER_TYPE_COLLECTOR, collectors[i]);
-      free(collectors[i]);
-    }
+  for (i = 0; i < collectors_cnt; i++) {
+    bgpstream_add_filter(stream, BGPSTREAM_FILTER_TYPE_COLLECTOR,
+                         collectors[i]);
+    free(collectors[i]);
+  }
 
   /* windows */
   int minimum_time = 0;
   int current_time = 0;
-  for(i=0; i<windows_cnt; i++)
-    {
-      bgpstream_add_interval_filter(stream, windows[i].start, windows[i].end);
-      current_time =  windows[i].start;
-      if(minimum_time == 0 || current_time < minimum_time)
-	{
-	  minimum_time = current_time;
-	}
+  for (i = 0; i < windows_cnt; i++) {
+    bgpstream_add_interval_filter(stream, windows[i].start, windows[i].end);
+    current_time = windows[i].start;
+    if (minimum_time == 0 || current_time < minimum_time) {
+      minimum_time = current_time;
     }
+  }
 
-    /* peer asns */
-  for(i=0; i<peerasns_cnt; i++)
-    {
-      bgpstream_add_filter(stream, BGPSTREAM_FILTER_TYPE_ELEM_PEER_ASN, peerasns[i]);
-      free(peerasns[i]);
-    }
+  /* peer asns */
+  for (i = 0; i < peerasns_cnt; i++) {
+    bgpstream_add_filter(stream, BGPSTREAM_FILTER_TYPE_ELEM_PEER_ASN,
+                         peerasns[i]);
+    free(peerasns[i]);
+  }
 
   /* prefixes */
-  for(i=0; i<prefixes_cnt; i++)
-    {
-      bgpstream_add_filter(stream, BGPSTREAM_FILTER_TYPE_ELEM_PREFIX, prefixes[i]);
-      free(prefixes[i]);
-    }
+  for (i = 0; i < prefixes_cnt; i++) {
+    bgpstream_add_filter(stream, BGPSTREAM_FILTER_TYPE_ELEM_PREFIX,
+                         prefixes[i]);
+    free(prefixes[i]);
+  }
 
   /* communities */
-  for(i=0; i<communities_cnt; i++)
-    {
-      bgpstream_add_filter(stream, BGPSTREAM_FILTER_TYPE_ELEM_COMMUNITY, communities[i]);
-      free(communities[i]);
-    }
+  for (i = 0; i < communities_cnt; i++) {
+    bgpstream_add_filter(stream, BGPSTREAM_FILTER_TYPE_ELEM_COMMUNITY,
+                         communities[i]);
+    free(communities[i]);
+  }
 
   /* frequencies */
-  if(rib_period > 0)
-    {
-      bgpstream_add_rib_period_filter(stream, rib_period);
-    }
+  if (rib_period > 0) {
+    bgpstream_add_rib_period_filter(stream, rib_period);
+  }
 
   /* live mode */
-  if(live != 0)
-    {
-      bgpstream_set_live_mode(stream);
-    }
+  if (live != 0) {
+    bgpstream_set_live_mode(stream);
+  }
 
   bgpstream_set_data_interface(stream, datasource_id);
 
-  if(bgpstream_start(stream) < 0) {
+  if (bgpstream_start(stream) < 0) {
     fprintf(stderr, "ERROR: Could not init BGPStream\n");
     return -1;
   }
@@ -724,73 +670,68 @@ int main(int argc, char *argv[])
   bgpcorsaro_set_stream(bgpcorsaro, stream);
 
   while (bgpcorsaro_shutdown == 0 &&
-	 (rc = bgpstream_get_next_record(stream, record)) > 0 ) {
+         (rc = bgpstream_get_next_record(stream, record)) > 0) {
 
     /* remove records that preceed the beginning of the stream */
-    if(record->attributes.record_time < minimum_time)
-      {
-	continue;
-      }
+    if (record->attributes.record_time < minimum_time) {
+      continue;
+    }
 
     /* check the gap limit is not exceeded */
     this_time = record->attributes.record_time;
-    if(gap_limit > 0 && /* gap limit is enabled */
-       last_time > 0 && /* this is not the first packet */
-       ((this_time-last_time) > 0) && /* packet doesn't go backward */
-       (this_time - last_time) > gap_limit) /* packet exceeds gap */
-      {
-        bgpcorsaro_log(__func__, bgpcorsaro,
-                       "gap limit exceeded (prev: %f this: %f diff: %f)",
-                       last_time, this_time, (this_time - last_time));
-        return -1;
-      }
+    if (gap_limit > 0 &&                     /* gap limit is enabled */
+        last_time > 0 &&                     /* this is not the first packet */
+        ((this_time - last_time) > 0) &&     /* packet doesn't go backward */
+        (this_time - last_time) > gap_limit) /* packet exceeds gap */
+    {
+      bgpcorsaro_log(__func__, bgpcorsaro,
+                     "gap limit exceeded (prev: %f this: %f diff: %f)",
+                     last_time, this_time, (this_time - last_time));
+      return -1;
+    }
     last_time = this_time;
 
     /*bgpcorsaro_log(__func__, bgpcorsaro, "got a record!");*/
-    if(bgpcorsaro_per_record(bgpcorsaro, record) != 0)
-      {
-	bgpcorsaro_log(__func__, bgpcorsaro, "bgpcorsaro_per_record failed");
-	return -1;
-      }
+    if (bgpcorsaro_per_record(bgpcorsaro, record) != 0) {
+      bgpcorsaro_log(__func__, bgpcorsaro, "bgpcorsaro_per_record failed");
+      return -1;
+    }
   }
 
   if (rc < 0) {
     bgpcorsaro_log(__func__, bgpcorsaro,
-		   "bgpstream encountered an error processing records");
+                   "bgpstream encountered an error processing records");
     return 1;
   }
 
   /* free the plugin strings */
-  for(i=0;i<plugin_cnt;i++)
-    {
-      if(plugins[i] != NULL)
-	free(plugins[i]);
-    }
+  for (i = 0; i < plugin_cnt; i++) {
+    if (plugins[i] != NULL)
+      free(plugins[i]);
+  }
 
   /* free the template string */
-  if(tmpl != NULL)
+  if (tmpl != NULL)
     free(tmpl);
 
   bgpcorsaro_finalize_output(bgpcorsaro);
   bgpcorsaro = NULL;
-  if(stream != NULL)
-    {
-      bgpstream_destroy(stream);
-      stream = NULL;
-    }
+  if (stream != NULL) {
+    bgpstream_destroy(stream);
+    stream = NULL;
+  }
 
   clean();
   return 0;
 
- err:
+err:
   /* if we bail early, let us be responsible and up the memory we alloc'd */
-  for(i=0;i<plugin_cnt;i++)
-    {
-      if(plugins[i] != NULL)
-	free(plugins[i]);
-    }
+  for (i = 0; i < plugin_cnt; i++) {
+    if (plugins[i] != NULL)
+      free(plugins[i]);
+  }
 
-  if(tmpl != NULL)
+  if (tmpl != NULL)
     free(tmpl);
 
   clean();

--- a/lib/bgpdump/bgpdump_attr.h
+++ b/lib/bgpdump/bgpdump_attr.h
@@ -1,6 +1,6 @@
 /*
  Copyright (c) 2007 - 2010 RIPE NCC - All Rights Reserved
- 
+
  Permission to use, copy, modify, and distribute this software and its
  documentation for any purpose and without fee is hereby granted, provided
  that the above copyright notice appear in all copies and that both that
@@ -8,14 +8,14 @@
  documentation, and that the name of the author not be used in advertising or
  publicity pertaining to distribution of the software without specific,
  written prior permission.
- 
+
  THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
  ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS; IN NO EVENT SHALL
  AUTHOR BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY
  DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
  AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- 
+
 Parts of this code have been engineered after analiyzing GNU Zebra's
 source code and therefore might contain declarations/code from GNU
 Zebra, Copyright (C) 1999 Kunihiro Ishiguro. Zebra is a free routing
@@ -28,170 +28,162 @@ Original Author: Dan Ardelean (dan@ripe.net)
 #ifndef _BGPDUMP_ATTR_H
 #define _BGPDUMP_ATTR_H
 
-#include <sys/types.h>
 #include <netinet/in.h>
+#include <sys/types.h>
 
 /* BGP Attribute flags. */
-#define BGP_ATTR_FLAG_OPTIONAL  0x80	/* Attribute is optional. */
-#define BGP_ATTR_FLAG_TRANS     0x40	/* Attribute is transitive. */
-#define BGP_ATTR_FLAG_PARTIAL   0x20	/* Attribute is partial. */
-#define BGP_ATTR_FLAG_EXTLEN    0x10	/* Extended length flag. */
+#define BGP_ATTR_FLAG_OPTIONAL 0x80 /* Attribute is optional. */
+#define BGP_ATTR_FLAG_TRANS 0x40    /* Attribute is transitive. */
+#define BGP_ATTR_FLAG_PARTIAL 0x20  /* Attribute is partial. */
+#define BGP_ATTR_FLAG_EXTLEN 0x10   /* Extended length flag. */
 
 /* BGP attribute type codes.  */
-#define BGP_ATTR_ORIGIN                    1
-#define BGP_ATTR_AS_PATH                   2
-#define BGP_ATTR_NEXT_HOP                  3
-#define BGP_ATTR_MULTI_EXIT_DISC           4
-#define BGP_ATTR_LOCAL_PREF                5
-#define BGP_ATTR_ATOMIC_AGGREGATE          6
-#define BGP_ATTR_AGGREGATOR                7
-#define BGP_ATTR_COMMUNITIES               8
-#define BGP_ATTR_ORIGINATOR_ID             9
-#define BGP_ATTR_CLUSTER_LIST             10
-#define BGP_ATTR_DPA                      11
-#define BGP_ATTR_ADVERTISER               12
-#define BGP_ATTR_RCID_PATH                13
-#define BGP_ATTR_MP_REACH_NLRI            14
-#define BGP_ATTR_MP_UNREACH_NLRI          15
-#define BGP_ATTR_EXT_COMMUNITIES          16
-#define BGP_ATTR_NEW_AS_PATH              17
-#define BGP_ATTR_NEW_AGGREGATOR           18
+#define BGP_ATTR_ORIGIN 1
+#define BGP_ATTR_AS_PATH 2
+#define BGP_ATTR_NEXT_HOP 3
+#define BGP_ATTR_MULTI_EXIT_DISC 4
+#define BGP_ATTR_LOCAL_PREF 5
+#define BGP_ATTR_ATOMIC_AGGREGATE 6
+#define BGP_ATTR_AGGREGATOR 7
+#define BGP_ATTR_COMMUNITIES 8
+#define BGP_ATTR_ORIGINATOR_ID 9
+#define BGP_ATTR_CLUSTER_LIST 10
+#define BGP_ATTR_DPA 11
+#define BGP_ATTR_ADVERTISER 12
+#define BGP_ATTR_RCID_PATH 13
+#define BGP_ATTR_MP_REACH_NLRI 14
+#define BGP_ATTR_MP_UNREACH_NLRI 15
+#define BGP_ATTR_EXT_COMMUNITIES 16
+#define BGP_ATTR_NEW_AS_PATH 17
+#define BGP_ATTR_NEW_AGGREGATOR 18
 
 /* Flag macro */
-#define ATTR_FLAG_BIT(X)  (1 << ((X) - 1))
+#define ATTR_FLAG_BIT(X) (1 << ((X)-1))
 
 /* BGP ASPATH attribute defines */
-#define AS_HEADER_SIZE        2	 
+#define AS_HEADER_SIZE 2
 
-#define AS_SET             1
-#define AS_SEQUENCE        2
+#define AS_SET 1
+#define AS_SEQUENCE 2
 #define AS_CONFED_SEQUENCE 3
-#define AS_CONFED_SET      4
+#define AS_CONFED_SET 4
 
 #define AS_SEG_START 0
 #define AS_SEG_END 1
 
 #define ASPATH_STR_DEFAULT_LEN 32
-#define ASPATH_STR_ERROR       "! Error !"
+#define ASPATH_STR_ERROR "! Error !"
 
 /* BGP COMMUNITY attribute defines */
 
-#define COMMUNITY_NO_EXPORT             0xFFFFFF01
-#define COMMUNITY_NO_ADVERTISE          0xFFFFFF02
-#define COMMUNITY_NO_EXPORT_SUBCONFED   0xFFFFFF03
-#define COMMUNITY_LOCAL_AS              0xFFFFFF03
+#define COMMUNITY_NO_EXPORT 0xFFFFFF01
+#define COMMUNITY_NO_ADVERTISE 0xFFFFFF02
+#define COMMUNITY_NO_EXPORT_SUBCONFED 0xFFFFFF03
+#define COMMUNITY_LOCAL_AS 0xFFFFFF03
 
-#define com_nthval(X,n)  ((X)->val + (n))
+#define com_nthval(X, n) ((X)->val + (n))
 
 /* MP-BGP address families */
 #define AFI_IP 1
 #define AFI_IP6 2
 #define BGPDUMP_MAX_AFI AFI_IP6
 
-#define SAFI_UNICAST		1
-#define SAFI_MULTICAST		2
-#define SAFI_UNICAST_MULTICAST	3
+#define SAFI_UNICAST 1
+#define SAFI_MULTICAST 2
+#define SAFI_UNICAST_MULTICAST 3
 #define BGPDUMP_MAX_SAFI SAFI_UNICAST_MULTICAST
 
-struct unknown_attr
-{
-	int	flag;
-	int	type;
-	int	len;
-	u_char *raw;
+struct unknown_attr {
+  int flag;
+  int type;
+  int len;
+  u_char *raw;
 };
 
 typedef u_int32_t as_t;
 
 typedef struct attr attributes_t;
-struct attr
-{
+struct attr {
   /* Flag of attribute is set or not. */
   u_int32_t flag;
 
   /* Attributes. */
-  int                   origin;
-  struct in_addr 	nexthop;
-  u_int32_t 		med;
-  u_int32_t 		local_pref;
-  as_t 			aggregator_as;
-  struct in_addr 	aggregator_addr;
-  u_int32_t 		weight;
-  struct in_addr 	originator_id;
-  struct cluster_list	*cluster;
+  int origin;
+  struct in_addr nexthop;
+  u_int32_t med;
+  u_int32_t local_pref;
+  as_t aggregator_as;
+  struct in_addr aggregator_addr;
+  u_int32_t weight;
+  struct in_addr originator_id;
+  struct cluster_list *cluster;
 
-  struct aspath 	*aspath;
-  struct community 	*community;
-  struct ecommunity 	*ecommunity;
-  struct transit 	*transit;
-  
+  struct aspath *aspath;
+  struct community *community;
+  struct ecommunity *ecommunity;
+  struct transit *transit;
+
   /* libbgpdump additions */
-  
-  struct mp_info	*mp_info;
-  u_int16_t		len;
-  caddr_t		data;
 
-  u_int16_t		unknown_num;
-  struct unknown_attr	*unknown;
+  struct mp_info *mp_info;
+  u_int16_t len;
+  caddr_t data;
+
+  u_int16_t unknown_num;
+  struct unknown_attr *unknown;
 
   /* ASN32 support */
-  struct aspath 	*new_aspath;
-  struct aspath 	*old_aspath;
-  as_t			new_aggregator_as;
-  as_t			old_aggregator_as;
-  struct in_addr 	new_aggregator_addr;
-  struct in_addr 	old_aggregator_addr;
+  struct aspath *new_aspath;
+  struct aspath *old_aspath;
+  as_t new_aggregator_as;
+  as_t old_aggregator_as;
+  struct in_addr new_aggregator_addr;
+  struct in_addr old_aggregator_addr;
 };
 
-struct community 
-{
-  int 			size;
-  u_int32_t 		*val;
-  char			*str;
+struct community {
+  int size;
+  u_int32_t *val;
+  char *str;
 };
 
-struct cluster_list
-{
-  int			length;
-  struct in_addr 	*list;
+struct cluster_list {
+  int length;
+  struct in_addr *list;
 };
 
-struct transit
-{
-  int 			length;
-  u_char 		*val;
+struct transit {
+  int length;
+  u_char *val;
 };
 
-struct aspath 
-{
-  u_int8_t		asn_len;
-  int 			length;
-  int 			count;
-  caddr_t 		data;
-  char 			*str;
+struct aspath {
+  u_int8_t asn_len;
+  int length;
+  int count;
+  caddr_t data;
+  char *str;
 };
 
-struct assegment
-{
+struct assegment {
   u_char type;
   u_char length;
-  char   data[0];
+  char data[0];
 };
 
 struct mp_info {
   /* AFI and SAFI start from 1, so the arrays must be 1-based */
-  struct mp_nlri	*withdraw[BGPDUMP_MAX_AFI+1][BGPDUMP_MAX_SAFI+1];
-  struct mp_nlri	*announce[BGPDUMP_MAX_AFI+1][BGPDUMP_MAX_SAFI+1];
+  struct mp_nlri *withdraw[BGPDUMP_MAX_AFI + 1][BGPDUMP_MAX_SAFI + 1];
+  struct mp_nlri *announce[BGPDUMP_MAX_AFI + 1][BGPDUMP_MAX_SAFI + 1];
 };
 
 #define MP_IPV6_ANNOUNCE(m) ((m)->announce[AFI_IP6][SAFI_UNICAST])
 #define MP_IPV6_WITHDRAW(m) ((m)->withdraw[AFI_IP6][SAFI_UNICAST])
 
 typedef union union_BGPDUMP_IP_ADDRESS {
-    struct in_addr	v4_addr;
-    struct in6_addr	v6_addr;
+  struct in_addr v4_addr;
+  struct in6_addr v6_addr;
 } BGPDUMP_IP_ADDRESS;
-
 
 #define BGPDUMP_ADDRSTRLEN 46
 
@@ -201,19 +193,19 @@ typedef union union_BGPDUMP_IP_ADDRESS {
 #define AS_TRAN 23456
 
 struct prefix {
-    BGPDUMP_IP_ADDRESS	address;
-    u_char		len;
+  BGPDUMP_IP_ADDRESS address;
+  u_char len;
 };
 
 #define MAX_PREFIXES 2000
 struct mp_nlri {
-  u_char		nexthop_len;
+  u_char nexthop_len;
 
-  BGPDUMP_IP_ADDRESS	nexthop;
-  BGPDUMP_IP_ADDRESS 	nexthop_local;
+  BGPDUMP_IP_ADDRESS nexthop;
+  BGPDUMP_IP_ADDRESS nexthop_local;
 
-  u_int16_t		prefix_count;
-  struct prefix		nlri[MAX_PREFIXES];
+  u_int16_t prefix_count;
+  struct prefix nlri[MAX_PREFIXES];
 };
 
 #endif /* _BGPDUMP_ATTR_H */

--- a/lib/bgpdump/bgpdump_cfile_tools.c
+++ b/lib/bgpdump/bgpdump_cfile_tools.c
@@ -1,14 +1,14 @@
-/** 
+/**
   cfile_tools.c
- 
-  A library to deal transparently with possibly compressed files.  
+
+  A library to deal transparently with possibly compressed files.
   Documentation in the function headers and in cfile_tools.h
 
-  Copyright (C) 2004 by Arno Wagner <arno.wagner@acm.org> 
+  Copyright (C) 2004 by Arno Wagner <arno.wagner@acm.org>
   Distributed under the Gnu Public License version 2 or the modified
   BSD license (see file COPYING)
 
-  Support for gzip added by Bernhard Tellenbach <bernhard.tellenbach@gmail.com>   
+  Support for gzip added by Bernhard Tellenbach <bernhard.tellenbach@gmail.com>
 */
 
 #define _GNU_SOURCE
@@ -18,46 +18,45 @@
 //#include <bzlib.h>
 //#endif
 
+#include "bgpdump_cfile_tools.h"
+#include <assert.h>
+#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
-#include <assert.h>
-#include "bgpdump_cfile_tools.h"
 
 // Concrete formats. remember to adjust CFR_NUM_FORMATS if changed!
 // Note: 0, 1 are special entries.
 
-const char * cfr_formats[CFR_NUM_FORMATS] = {
+const char *cfr_formats[CFR_NUM_FORMATS] = {
   "not open",     //  0
   "uncompressed", //  1
 #ifndef DONT_HAVE_BZ2
-  "bzip2",         //  2
+  "bzip2", //  2
 #endif
 #ifndef DONT_HAVE_GZ
-  "gzip",         //  3
+  "gzip", //  3
 #endif
 };
 
-const char * cfr_extensions[CFR_NUM_FORMATS] = {
-  "",             //  0
-  "",             //  1
+const char *cfr_extensions[CFR_NUM_FORMATS] = {
+  "", //  0
+  "", //  1
 #ifndef DONT_HAVE_BZ2
-  ".bz2",          //  2
+  ".bz2", //  2
 #endif
 #ifndef DONT_HAVE_GZ
-  ".gz"          //  3
+  ".gz" //  3
 #endif
 };
-
 
 // Prototypes of non API functions (don't use these from outside this file)
-const char * _cfr_compressor_strerror(int format, int err);
-const char * _bz2_strerror(int err);
+const char *_cfr_compressor_strerror(int format, int err);
+const char *_bz2_strerror(int err);
 
+// API Functions
 
-// API Functions 
-
-CFRFILE *cfr_open(const char *path) {
+CFRFILE *cfr_open(const char *path)
+{
   /*******************************/
   // Analog to 'fopen'. Error in result has to be tested using
   // 'cfr_error' on the result!
@@ -66,368 +65,356 @@ CFRFILE *cfr_open(const char *path) {
   // File type is determined by file name ending
 
   int format, ext_len, name_len;
-  CFRFILE * retval = NULL;
+  CFRFILE *retval = NULL;
 
   // determine file format
   name_len = strlen(path);
-  format = 2;  // skip specials 0, 1 
+  format = 2; // skip specials 0, 1
 
   // Do action dependent on file format
-  retval = (CFRFILE *) calloc(1,sizeof(CFRFILE));
+  retval = (CFRFILE *)calloc(1, sizeof(CFRFILE));
   retval->eof = 0;
   retval->error1 = 0;
   retval->error2 = 0;
 
-
 #ifndef DONT_HAVE_GZ
-  if((path == NULL) || (strcmp(path, "-") == 0)) {
-	/* dump from stdin */
-	gzFile f;
-	while (format < CFR_NUM_FORMATS) {
-		if (strcmp(cfr_extensions[format], ".gz") == 0)
-        		break;
-    		format ++;
-  	}
-	f = gzdopen(0, "r");
-	if(f == NULL) {
-		free(retval);
-		return (NULL);
-    	}
-        retval->data2 = f;
-	retval->format = format;
-	return (retval);
+  if ((path == NULL) || (strcmp(path, "-") == 0)) {
+    /* dump from stdin */
+    gzFile f;
+    while (format < CFR_NUM_FORMATS) {
+      if (strcmp(cfr_extensions[format], ".gz") == 0)
+        break;
+      format++;
+    }
+    f = gzdopen(0, "r");
+    if (f == NULL) {
+      free(retval);
+      return (NULL);
+    }
+    retval->data2 = f;
+    retval->format = format;
+    return (retval);
   }
 #endif
   while (format < CFR_NUM_FORMATS) {
     ext_len = strlen(cfr_extensions[format]);
-    if (strncmp(cfr_extensions[format],
-                path+(name_len-ext_len),
-                ext_len) == 0
-        ) break;
-    format ++;
+    if (strncmp(cfr_extensions[format], path + (name_len - ext_len), ext_len) ==
+        0)
+      break;
+    format++;
   }
-  if (format >= CFR_NUM_FORMATS) 
-	format = 1;  // uncompressed 
+  if (format >= CFR_NUM_FORMATS)
+    format = 1; // uncompressed
   retval->format = format;
 
   switch (format) {
-  case 1:  // uncompressed
-    { 
-      FILE * in;
-      in = fopen(path,"r");
-      if (in == NULL) { 
-	free(retval);
-        return(NULL);
-      }
-      retval->data1 = in;
-      return(retval);
+  case 1: // uncompressed
+  {
+    FILE *in;
+    in = fopen(path, "r");
+    if (in == NULL) {
+      free(retval);
+      return (NULL);
     }
-    break;
+    retval->data1 = in;
+    return (retval);
+  } break;
 #ifndef DONT_HAVE_BZ2
-  case 2:  // bzip2
-    { 
-      int bzerror;
-      BZFILE * bzin;
-      FILE * in;
-      
-      retval->bz2_stream_end = 0;
-      
-      // get file
-      in = fopen(path,"r");
-      if (in == NULL) { 
-        free(retval);
-        return(NULL);
-      }
-      retval->data1 = in;
-      
-      // bzip2ify file
-      bzin = BZ2_bzReadOpen( &bzerror, in, 0, 0, NULL, 0); 
-      if (bzerror != BZ_OK) {
-        errno = bzerror;
-        BZ2_bzReadClose( &bzerror, bzin);
-        fclose(in);
-	free(retval);
-        return(NULL);
-      }
-      retval->data2 = bzin;
-      return(retval);
+  case 2: // bzip2
+  {
+    int bzerror;
+    BZFILE *bzin;
+    FILE *in;
+
+    retval->bz2_stream_end = 0;
+
+    // get file
+    in = fopen(path, "r");
+    if (in == NULL) {
+      free(retval);
+      return (NULL);
     }
-    break;
+    retval->data1 = in;
+
+    // bzip2ify file
+    bzin = BZ2_bzReadOpen(&bzerror, in, 0, 0, NULL, 0);
+    if (bzerror != BZ_OK) {
+      errno = bzerror;
+      BZ2_bzReadClose(&bzerror, bzin);
+      fclose(in);
+      free(retval);
+      return (NULL);
+    }
+    retval->data2 = bzin;
+    return (retval);
+  } break;
 #endif
 #ifndef DONT_HAVE_GZ
-  case 3:  // gzip
-    { 
-	gzFile f;
-      	// get file 
-	f = gzopen(path, "r");
-	if(f == NULL) {
-		free(retval);
-		return (NULL);
-    	}
-        retval->data2 = f;
-	return (retval);
-   }
-   break;
+  case 3: // gzip
+  {
+    gzFile f;
+    // get file
+    f = gzopen(path, "r");
+    if (f == NULL) {
+      free(retval);
+      return (NULL);
+    }
+    retval->data2 = f;
+    return (retval);
+  } break;
 #endif
-  default:  // this is an internal error, no diag yet.
-    fprintf(stderr,"illegal format '%d' in cfr_open!\n", format);
+  default: // this is an internal error, no diag yet.
+    fprintf(stderr, "illegal format '%d' in cfr_open!\n", format);
     exit(1);
   }
   return NULL;
-} 
+}
 
-
-
-int cfr_close(CFRFILE *stream) {
+int cfr_close(CFRFILE *stream)
+{
   /**************************/
   // Analog to 'fclose'.
   // FIXME - why is stream->* set, then freed?
   if (stream == NULL || stream->closed) {
-      errno = EBADF;
-      return -1;
+    errno = EBADF;
+    return -1;
   }
-    
+
   int retval = -1;
-  
+
   switch (stream->format) {
-  case 1:  // uncompressed
-      retval = fclose((FILE *)(stream->data1));
-      stream->error1 = retval;
-      break;
+  case 1: // uncompressed
+    retval = fclose((FILE *)(stream->data1));
+    stream->error1 = retval;
+    break;
   case 2: // bzip2
-      #ifndef DONT_HAVE_BZ2
-      BZ2_bzReadClose( &stream->error2, (BZFILE *)stream->data2);
-      stream->error1 = retval = fclose((FILE *)(stream->data1));
-      break;
-      #endif
-  case 3:  // gzip
-      #ifndef DONT_HAVE_GZ
-      if(stream->data2!=NULL)
-          retval = gzclose(stream->data2);
-      stream->error2 = retval;
-      break;
-      #endif
-    default:  // internal error
-          assert("illegal stream->format" && 0);
+#ifndef DONT_HAVE_BZ2
+    BZ2_bzReadClose(&stream->error2, (BZFILE *)stream->data2);
+    stream->error1 = retval = fclose((FILE *)(stream->data1));
+    break;
+#endif
+  case 3: // gzip
+#ifndef DONT_HAVE_GZ
+    if (stream->data2 != NULL)
+      retval = gzclose(stream->data2);
+    stream->error2 = retval;
+    break;
+#endif
+  default: // internal error
+    assert("illegal stream->format" && 0);
   }
   free(stream);
-  return(retval);
+  return (retval);
 }
 
-size_t cfr_read_n(CFRFILE *stream, void *ptr, size_t bytes) {
+size_t cfr_read_n(CFRFILE *stream, void *ptr, size_t bytes)
+{
   /******************************************************************/
-  // Wrapper, will return either 'bytes' (the number of bytes to read) or 0 
-  return(cfr_read(ptr, bytes, 1, stream)*bytes);
+  // Wrapper, will return either 'bytes' (the number of bytes to read) or 0
+  return (cfr_read(ptr, bytes, 1, stream) * bytes);
 }
 
-size_t cfr_read(void *ptr, size_t size, size_t nmemb, CFRFILE *stream) {
+size_t cfr_read(void *ptr, size_t size, size_t nmemb, CFRFILE *stream)
+{
   /******************************************************************/
   // Analog to 'fread'. Will not return with partial elements, only
   // full ones. Hence calling this function with one large element
   // size will result in a complete or no read.
-  
+
   size_t retval = 0;
-  if (stream == NULL) return(0);
+  if (stream == NULL)
+    return (0);
 
   // shortcut
-  if (stream->eof) return(0);
+  if (stream->eof)
+    return (0);
 
   switch (stream->format) {
-  case 1:  // uncompressed
-    { 
-      FILE * in;
-      in = (FILE *)(stream->data1);
-      retval = fread(ptr, size, nmemb, in);
-      if (retval != nmemb) {
-        // fprintf(stderr,"short read!!!\n");
-        stream->eof = feof(in);
-        stream->error1 = ferror(in);
-	retval = 0;
-      }
-      return (retval);
+  case 1: // uncompressed
+  {
+    FILE *in;
+    in = (FILE *)(stream->data1);
+    retval = fread(ptr, size, nmemb, in);
+    if (retval != nmemb) {
+      // fprintf(stderr,"short read!!!\n");
+      stream->eof = feof(in);
+      stream->error1 = ferror(in);
+      retval = 0;
     }
-    break;
-#ifndef DONT_HAVE_BZ2    
-   case 2:  // bzip2
-    { 
-      BZFILE * bzin; 
-      int bzerror;
-      int buffsize;
+    return (retval);
+  } break;
+#ifndef DONT_HAVE_BZ2
+  case 2: // bzip2
+  {
+    BZFILE *bzin;
+    int bzerror;
+    int buffsize;
 
-      if (stream->bz2_stream_end == 1) {
-        // feof-behaviour: Last read did consume last byte but not more
-        stream->eof = 1;
-        return(0);
-      }
+    if (stream->bz2_stream_end == 1) {
+      // feof-behaviour: Last read did consume last byte but not more
+      stream->eof = 1;
+      return (0);
+    }
 
-      bzerror = BZ_OK;
-      bzin = (BZFILE *) (stream->data2);
-      buffsize = size * nmemb;
+    bzerror = BZ_OK;
+    bzin = (BZFILE *)(stream->data2);
+    buffsize = size * nmemb;
 
-      retval = BZ2_bzRead(&bzerror, bzin, ptr, buffsize);
+    retval = BZ2_bzRead(&bzerror, bzin, ptr, buffsize);
 
-      if (bzerror == BZ_STREAM_END ) {
-        stream->bz2_stream_end = 1;
-        stream->error2 = bzerror;
-        if (retval == buffsize) {
-          // feof-behaviour: no eof yet
-        } else {
-          // feof-behaviour: read past end, set eof
-          stream->eof = 1;
-	  retval = 0;
-        }
-        return(retval/size);
-      }
-      if (bzerror == BZ_OK) {
-        // Normal case, no error.
-        // A short read here is an error, so catch it
-        if (retval == buffsize) {
-          return(retval/size);
-        }
-      }
-
-      // Other error...
+    if (bzerror == BZ_STREAM_END) {
+      stream->bz2_stream_end = 1;
       stream->error2 = bzerror;
-      BZ2_bzReadClose( &bzerror, bzin );
-      if (bzerror != BZ_OK) {
-        stream->error2 = bzerror;
+      if (retval == buffsize) {
+        // feof-behaviour: no eof yet
+      } else {
+        // feof-behaviour: read past end, set eof
+        stream->eof = 1;
+        retval = 0;
       }
-      retval = fclose((FILE *)(stream->data1));
-      stream->error1 = retval;
-      stream->closed = 1;
-      return(0);
+      return (retval / size);
     }
-    break;
-#endif    
-#ifndef DONT_HAVE_GZ
-  case 3:  // gzip
-    { 
-      gzFile in;
-      in = (gzFile)(stream->data2);
-      retval = gzread(in, ptr, size*nmemb);
-      if (retval != nmemb*size) {
-        // fprintf(stderr,"short read!!!\n");
-        stream->eof = gzeof(in);
-        stream->error2 = errno;
-	retval = 0;
+    if (bzerror == BZ_OK) {
+      // Normal case, no error.
+      // A short read here is an error, so catch it
+      if (retval == buffsize) {
+        return (retval / size);
       }
-      return (retval/size);
     }
-    break;
+
+    // Other error...
+    stream->error2 = bzerror;
+    BZ2_bzReadClose(&bzerror, bzin);
+    if (bzerror != BZ_OK) {
+      stream->error2 = bzerror;
+    }
+    retval = fclose((FILE *)(stream->data1));
+    stream->error1 = retval;
+    stream->closed = 1;
+    return (0);
+  } break;
 #endif
-  default:  // this is an internal error, no diag yet.
-    fprintf(stderr,"illegal format '%d' in cfr_read!\n",stream->format);
+#ifndef DONT_HAVE_GZ
+  case 3: // gzip
+  {
+    gzFile in;
+    in = (gzFile)(stream->data2);
+    retval = gzread(in, ptr, size * nmemb);
+    if (retval != nmemb * size) {
+      // fprintf(stderr,"short read!!!\n");
+      stream->eof = gzeof(in);
+      stream->error2 = errno;
+      retval = 0;
+    }
+    return (retval / size);
+  } break;
+#endif
+  default: // this is an internal error, no diag yet.
+    fprintf(stderr, "illegal format '%d' in cfr_read!\n", stream->format);
     exit(1);
   }
-} 
+}
 
-
-
-
-
-ssize_t cfr_getline(char **lineptr, size_t *n, CFRFILE *stream) {
+ssize_t cfr_getline(char **lineptr, size_t *n, CFRFILE *stream)
+{
   /************************************************************/
   // May not be very efficient, since it uses single-char reads
   // for formats where there is no native getline in the library.
   // For bzip2 the speedup for additional buffering was only 5%
   // so I dropped it.
   // Returns -1 in case of an error.
-  
-  if (stream == NULL) return(-1);  
+
+  if (stream == NULL)
+    return (-1);
 
   switch (stream->format) {
-  case 1:  // uncompressed
-    { 
-      if (fgets(*lineptr, *n, (FILE *)(stream->data1)) == NULL) {
-        stream->error1 = errno;
-	return -1;
-      }
-      return 0;
+  case 1: // uncompressed
+  {
+    if (fgets(*lineptr, *n, (FILE *)(stream->data1)) == NULL) {
+      stream->error1 = errno;
+      return -1;
     }
-    break;
+    return 0;
+  } break;
 
 #ifndef DONT_HAVE_BZ2
-  case 2:  // bzip2  
-    {                
-      size_t count;
-      char c;
-      size_t ret;
+  case 2: // bzip2
+  {
+    size_t count;
+    char c;
+    size_t ret;
 
-	  //bzin = (BZFILE *) (stream->data2);
+    // bzin = (BZFILE *) (stream->data2);
 
-      // allocate initial buffer if none was passed or size was zero
-      if (*lineptr == NULL) {
-        *lineptr = (char *) calloc(120, 1);
-        *n = 120;
-      }
-      if (*n == 0) {
-        *n = 120;
-        *lineptr = (char *) realloc(*lineptr, *n); // to avoid memory-leaks
-      }
-
-      count = 0;
-      // read until '\n'
-      do {
-        ret = cfr_read(&c, 1, 1, stream);
-        if (ret != 1) {
-          return(-1);
-        }
-        count ++;
-        if (count >= *n) {
-          *n = 2 * *n;
-          *lineptr = (char *) realloc(*lineptr, *n);
-          if (*lineptr == NULL) {
-            stream->error1 = errno;
-            return(-1);
-          }
-        }
-        (*lineptr)[count-1] = c;
-      } while (c != '\n');
-      (*lineptr)[count] = 0;
-      return(count);
+    // allocate initial buffer if none was passed or size was zero
+    if (*lineptr == NULL) {
+      *lineptr = (char *)calloc(120, 1);
+      *n = 120;
     }
-    break;
+    if (*n == 0) {
+      *n = 120;
+      *lineptr = (char *)realloc(*lineptr, *n); // to avoid memory-leaks
+    }
+
+    count = 0;
+    // read until '\n'
+    do {
+      ret = cfr_read(&c, 1, 1, stream);
+      if (ret != 1) {
+        return (-1);
+      }
+      count++;
+      if (count >= *n) {
+        *n = 2 * *n;
+        *lineptr = (char *)realloc(*lineptr, *n);
+        if (*lineptr == NULL) {
+          stream->error1 = errno;
+          return (-1);
+        }
+      }
+      (*lineptr)[count - 1] = c;
+    } while (c != '\n');
+    (*lineptr)[count] = 0;
+    return (count);
+  } break;
 #endif
 #ifndef DONT_HAVE_GZ
-  case 3:  // gzip
-    { 
-      char * return_ptr = gzgets((gzFile)(stream->data2), *lineptr, *n );
-      if (return_ptr == Z_NULL) {
-        stream->error2 = errno;
-        return(-1);
-      }
-      return *n;
-  
+  case 3: // gzip
+  {
+    char *return_ptr = gzgets((gzFile)(stream->data2), *lineptr, *n);
+    if (return_ptr == Z_NULL) {
+      stream->error2 = errno;
+      return (-1);
     }
-    break;
+    return *n;
+
+  } break;
 #endif
-  default:  // this is an internal error, no diag yet.
-    fprintf(stderr,"illegal format '%d' in cfr_getline!\n",stream->format);
+  default: // this is an internal error, no diag yet.
+    fprintf(stderr, "illegal format '%d' in cfr_getline!\n", stream->format);
     exit(1);
-    return(-1);
-  }     
+    return (-1);
+  }
 }
 
-
-
-int cfr_eof(CFRFILE *stream) {
+int cfr_eof(CFRFILE *stream)
+{
   // Returns true on end of file/end of compressed data.
   // The end of the compressed data is regarded as end of file
-  // in this library, embedded or multiple compressed data per 
+  // in this library, embedded or multiple compressed data per
   // file is not supported by this library.
   //
   // Note: The sematics is that cfr_eof is true only after
   // the first byte after the end of file was read. Some compressors
-  // report EOF already when the last availale character has been 
+  // report EOF already when the last availale character has been
   // read (far more sensible IMO), but for consistency we follow the
   // convention of the standard c library here.
 
-  return(stream->eof);
+  return (stream->eof);
 }
 
-
-
-int cfr_error(CFRFILE *stream) {
+int cfr_error(CFRFILE *stream)
+{
   // Returns true on error.
   // Errors can be ordinary errors from fopen.fclose/fread
   // or can originate from the underlying compression.
@@ -437,115 +424,125 @@ int cfr_error(CFRFILE *stream) {
   // come up with a description of the whole situation.
   // For numeric details, more query functions would need to be
   // implemented.
-  
-  if (stream == NULL) return(1);
-  return(stream->error1 || stream->error2);
+
+  if (stream == NULL)
+    return (1);
+  return (stream->error1 || stream->error2);
 }
 
-
-char * cfr_strerror(CFRFILE *stream) {
+char *cfr_strerror(CFRFILE *stream)
+{
   // Result is "stream-i/o: <stream-error> <compressor>[: <compressor error>]"
-  // Do not modify result. 
+  // Do not modify result.
   // Result may change on subsequent call to this function.
 
   static char res[120];
-  char * msg, * msg2;
+  char *msg, *msg2;
 
   if (stream == NULL) {
-    asprintf(&msg,"Error: stream is NULL, i.e. not opened");
-    return(msg);
+    asprintf(&msg, "Error: stream is NULL, i.e. not opened");
+    return (msg);
   }
 
-  asprintf(&msg,
-           "stream-i/o: %s, %s  [%s]",
-           stream->eof?"EOF":"",
-           strerror(stream->error1),
-           cfr_compressor_str(stream));
+  asprintf(&msg, "stream-i/o: %s, %s  [%s]", stream->eof ? "EOF" : "",
+           strerror(stream->error1), cfr_compressor_str(stream));
   if (stream->format == 2) {
-    asprintf(&msg2, 
-             "%s: %s",
-             msg, 
+    asprintf(&msg2, "%s: %s", msg,
              _cfr_compressor_strerror(stream->format, stream->error2));
     free(msg);
     msg = msg2;
-  } 
+  }
   if (stream->format == 3) {
-    asprintf(&msg2, 
-             "%s: %s",
-             msg, 
+    asprintf(&msg2, "%s: %s", msg,
              gzerror((gzFile)(stream->data2), &(stream->error2)));
     free(msg);
     msg = msg2;
   }
   snprintf(res, 120, "%s", msg);
   res[119] = 0;
-  free(msg); 
-  return(res);
+  free(msg);
+  return (res);
 }
 
-const char * cfr_compressor_str(CFRFILE *stream) {
+const char *cfr_compressor_str(CFRFILE *stream)
+{
   // Returns the name of the compressor used
 
   if ((stream->format < 0) || (stream->format >= CFR_NUM_FORMATS)) {
-    return("undefined compression type");
+    return ("undefined compression type");
   } else {
     return (cfr_formats[stream->format]);
   }
 }
 
-
-// Utility functions for compressor errors. 
+// Utility functions for compressor errors.
 // * Not part of the API, do not call directly as they may change! *
 
-const char * _cfr_compressor_strerror(int format, int err) {
+const char *_cfr_compressor_strerror(int format, int err)
+{
   // Transforms error code to string for all compressors
-  
+
   switch (format) {
-  case 0: 
-    return("file not open");
+  case 0:
+    return ("file not open");
     break;
 
   case 1:
-    return("file not compressed");
+    return ("file not compressed");
     break;
-    
+
 #ifndef DONT_HAVE_BZ2
   case 2:
-    return(_bz2_strerror(err));
+    return (_bz2_strerror(err));
     break;
-#endif          
+#endif
 #ifndef DONT_HAVE_GZ
   case 3:
     return NULL;
     break;
-#endif          
+#endif
   default:
-    return("unknowen compressor code");
-  }  
+    return ("unknowen compressor code");
+  }
 }
-    
+
 #ifndef DONT_HAVE_BZ2
-const char * _bz2_strerror(int err) {
+const char *_bz2_strerror(int err)
+{
   // Since bzlib does not have strerror, we do it here manually.
   // This works for version 1.0 of 21 March 2000 of bzlib.h
-  
+
   switch (err) {
-  case BZ_OK: return("BZ_OK");
-  case BZ_RUN_OK: return("BZ_RUN_OK");
-  case BZ_FLUSH_OK: return("BZ_FLUSH_OK");
-  case BZ_FINISH_OK: return("BZ_FINISH_OK");
-  case BZ_STREAM_END: return("BZ_STREAM_END");
-  case BZ_SEQUENCE_ERROR: return("BZ_SEQUENCE_ERROR");
-  case BZ_PARAM_ERROR: return("BZ_PARAM_ERROR");
-  case BZ_MEM_ERROR: return("BZ_MEM_ERROR");
-  case BZ_DATA_ERROR: return("BZ_DATA_ERROR");
-  case BZ_DATA_ERROR_MAGIC: return("BZ_DATA_ERROR_MAGIC");
-  case BZ_IO_ERROR: return("BZ_IO_ERROR");
-  case BZ_UNEXPECTED_EOF: return("BZ_UNEXPECTED_EOF");
-  case BZ_OUTBUFF_FULL: return("BZ_OUTBUFF_FULL");
-  case BZ_CONFIG_ERROR: return("BZ_CONFIG_ERROR");
-  default: return("unknowen bzip2 error code");
+  case BZ_OK:
+    return ("BZ_OK");
+  case BZ_RUN_OK:
+    return ("BZ_RUN_OK");
+  case BZ_FLUSH_OK:
+    return ("BZ_FLUSH_OK");
+  case BZ_FINISH_OK:
+    return ("BZ_FINISH_OK");
+  case BZ_STREAM_END:
+    return ("BZ_STREAM_END");
+  case BZ_SEQUENCE_ERROR:
+    return ("BZ_SEQUENCE_ERROR");
+  case BZ_PARAM_ERROR:
+    return ("BZ_PARAM_ERROR");
+  case BZ_MEM_ERROR:
+    return ("BZ_MEM_ERROR");
+  case BZ_DATA_ERROR:
+    return ("BZ_DATA_ERROR");
+  case BZ_DATA_ERROR_MAGIC:
+    return ("BZ_DATA_ERROR_MAGIC");
+  case BZ_IO_ERROR:
+    return ("BZ_IO_ERROR");
+  case BZ_UNEXPECTED_EOF:
+    return ("BZ_UNEXPECTED_EOF");
+  case BZ_OUTBUFF_FULL:
+    return ("BZ_OUTBUFF_FULL");
+  case BZ_CONFIG_ERROR:
+    return ("BZ_CONFIG_ERROR");
+  default:
+    return ("unknowen bzip2 error code");
   }
 }
 #endif
-    

--- a/lib/bgpdump/bgpdump_cfile_tools.h
+++ b/lib/bgpdump/bgpdump_cfile_tools.h
@@ -1,4 +1,4 @@
-/** 
+/**
   cfile_tools.h
   A small library containing tools for dealing with files
   that are compressed with different compressors or not compressed
@@ -7,21 +7,21 @@
   but not both. Reading and writing is by different function classes.
   Access is sequential only.
 
-  Copyright (C) 2004 by Arno Wagner <arno.wagner@acm.org> 
+  Copyright (C) 2004 by Arno Wagner <arno.wagner@acm.org>
   Distributed under the Gnu Public License version 2 or the modified
   BSD license (see file COPYING)
 
   Support for gzip added by Bernhard Tellenbach <bernhard.tellenbach@gmail.com>
 
-  Function prefixes are: 
-     cfr_ = compressed file read   
+  Function prefixes are:
+     cfr_ = compressed file read
 
   Supported:
-  Reading: 
-  - type recognition from file name extension 
+  Reading:
+  - type recognition from file name extension
   - standard input (filename: '-' )
   - no compression
-  - bzip2  
+  - bzip2
   - gzip
 */
 
@@ -34,25 +34,24 @@
 // Types
 
 struct _CFRFILE {
-  int format;       // 0 = not open, 1 = uncompressed, 2 = bzip2, 3 = gzip
-  int eof;          // 0 = not eof 
-  int closed;       // indicates whether fclose has been called, 0 = not yet
-  int error1;       // errors from the sytem, 0 = no error
-  int error2;       // for error messages from the compressor
-  FILE * data1;     // for filehandle of the system 
-  void * data2;     // addtional handle(s) of the compressor
-  // compressor specific stuff 
+  int format;  // 0 = not open, 1 = uncompressed, 2 = bzip2, 3 = gzip
+  int eof;     // 0 = not eof
+  int closed;  // indicates whether fclose has been called, 0 = not yet
+  int error1;  // errors from the sytem, 0 = no error
+  int error2;  // for error messages from the compressor
+  FILE *data1; // for filehandle of the system
+  void *data2; // addtional handle(s) of the compressor
+  // compressor specific stuff
   int bz2_stream_end; // True when a bz2 stream has ended. Needed since
                       // further reading returns error and not eof.
 };
 
 typedef struct _CFRFILE CFRFILE;
 
-
 // Functions
 
-CFRFILE    * cfr_open(const char *path); 
-int          cfr_close(CFRFILE *stream);
-size_t       cfr_read_n(CFRFILE *stream, void *ptr, size_t bytes);
+CFRFILE *cfr_open(const char *path);
+int cfr_close(CFRFILE *stream);
+size_t cfr_read_n(CFRFILE *stream, void *ptr, size_t bytes);
 
 #endif

--- a/lib/bgpdump/bgpdump_cfile_tools_wandio.c
+++ b/lib/bgpdump/bgpdump_cfile_tools_wandio.c
@@ -6,39 +6,39 @@
  * 2014-08-14
  */
 
+#include "bgpdump_cfile_tools.h"
 #include "config.h"
+#include <assert.h>
+#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
-#include <assert.h>
 #include <wandio.h>
-#include "bgpdump_cfile_tools.h"
 
-#define WFILE(x) ((io_t*)(x)->data2)
+#define WFILE(x) ((io_t *)(x)->data2)
 
 // API Functions
 
-CFRFILE *cfr_open(const char *path) {
+CFRFILE *cfr_open(const char *path)
+{
   CFRFILE *cfr = NULL;
 
-  if((cfr = malloc(sizeof(CFRFILE))) == NULL)
-    {
-      return NULL;
-    }
+  if ((cfr = malloc(sizeof(CFRFILE))) == NULL) {
+    return NULL;
+  }
   memset(cfr, 0, sizeof(CFRFILE));
 
   /* sweet hax */
-  if((cfr->data2 = wandio_create(path)) == NULL)
-    {
-      free(cfr);
-      return NULL;
-    }
+  if ((cfr->data2 = wandio_create(path)) == NULL) {
+    free(cfr);
+    return NULL;
+  }
 
   return cfr;
 }
 
-int cfr_close(CFRFILE *stream) {
-  if(stream == NULL) {
+int cfr_close(CFRFILE *stream)
+{
+  if (stream == NULL) {
     return 0;
   }
 
@@ -49,6 +49,7 @@ int cfr_close(CFRFILE *stream) {
   return 0;
 }
 
-size_t cfr_read_n(CFRFILE *stream, void *ptr, size_t bytes) {
+size_t cfr_read_n(CFRFILE *stream, void *ptr, size_t bytes)
+{
   return wandio_read(WFILE(stream), ptr, bytes);
 }

--- a/lib/bgpdump/bgpdump_formats.h
+++ b/lib/bgpdump/bgpdump_formats.h
@@ -1,6 +1,6 @@
 /*
  Copyright (c) 2007 - 2010 RIPE NCC - All Rights Reserved
- 
+
  Permission to use, copy, modify, and distribute this software and its
  documentation for any purpose and without fee is hereby granted, provided
  that the above copyright notice appear in all copies and that both that
@@ -8,7 +8,7 @@
  documentation, and that the name of the author not be used in advertising or
  publicity pertaining to distribution of the software without specific,
  written prior permission.
- 
+
  THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
  ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS; IN NO EVENT SHALL
  AUTHOR BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY
@@ -30,221 +30,218 @@ Original Author: Dan Ardelean (dan@ripe.net)
 
 #include "bgpdump_attr.h"
 
-#include <stdio.h>
-#include <sys/types.h>
-#include <string.h>
 #include <netinet/in.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
 
 /* type and subtypes values */
-#define BGPDUMP_TYPE_MRTD_BGP			5
-#define BGPDUMP_SUBTYPE_MRTD_BGP_NULL		0
-#define BGPDUMP_SUBTYPE_MRTD_BGP_PREFUPDATE	1
-#define BGPDUMP_SUBTYPE_MRTD_BGP_UPDATE		2
-#define BGPDUMP_SUBTYPE_MRTD_BGP_STATE_CHANGE	3
-#define BGPDUMP_SUBTYPE_MRTD_BGP_SYNC		4
-#define BGPDUMP_SUBTYPE_MRTD_BGP_OPEN		129
-#define BGPDUMP_SUBTYPE_MRTD_BGP_NOTIFICATION	131
-#define BGPDUMP_SUBTYPE_MRTD_BGP_KEEPALIVE	132
-#define BGPDUMP_SUBTYPE_MRTD_BGP_ROUT_REFRESH	133
+#define BGPDUMP_TYPE_MRTD_BGP 5
+#define BGPDUMP_SUBTYPE_MRTD_BGP_NULL 0
+#define BGPDUMP_SUBTYPE_MRTD_BGP_PREFUPDATE 1
+#define BGPDUMP_SUBTYPE_MRTD_BGP_UPDATE 2
+#define BGPDUMP_SUBTYPE_MRTD_BGP_STATE_CHANGE 3
+#define BGPDUMP_SUBTYPE_MRTD_BGP_SYNC 4
+#define BGPDUMP_SUBTYPE_MRTD_BGP_OPEN 129
+#define BGPDUMP_SUBTYPE_MRTD_BGP_NOTIFICATION 131
+#define BGPDUMP_SUBTYPE_MRTD_BGP_KEEPALIVE 132
+#define BGPDUMP_SUBTYPE_MRTD_BGP_ROUT_REFRESH 133
 
-#define BGPDUMP_TYPE_MRTD_TABLE_DUMP				12
-#define BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP			1
-#define BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP6			2
-#define BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP_32BIT_AS		3
-#define BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP6_32BIT_AS	4
+#define BGPDUMP_TYPE_MRTD_TABLE_DUMP 12
+#define BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP 1
+#define BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP6 2
+#define BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP_32BIT_AS 3
+#define BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP6_32BIT_AS 4
 
-#define BGPDUMP_TYPE_TABLE_DUMP_V2                       13
-#define BGPDUMP_SUBTYPE_TABLE_DUMP_V2_PEER_INDEX_TABLE    1
-#define BGPDUMP_SUBTYPE_TABLE_DUMP_V2_RIB_IPV4_UNICAST    2
-#define BGPDUMP_SUBTYPE_TABLE_DUMP_V2_RIB_IPV4_MULTICAST  3
-#define BGPDUMP_SUBTYPE_TABLE_DUMP_V2_RIB_IPV6_UNICAST    4
-#define BGPDUMP_SUBTYPE_TABLE_DUMP_V2_RIB_IPV6_MULTICAST  5
-#define BGPDUMP_SUBTYPE_TABLE_DUMP_V2_RIB_GENERIC         6
-#define BGPDUMP_PEERTYPE_TABLE_DUMP_V2_AFI_IP             0
-#define BGPDUMP_PEERTYPE_TABLE_DUMP_V2_AFI_IP6            1
-#define BGPDUMP_PEERTYPE_TABLE_DUMP_V2_AS2                0
-#define BGPDUMP_PEERTYPE_TABLE_DUMP_V2_AS4                2
-#define BGPDUMP_TYPE_TABLE_DUMP_V2_MAX_VIEWNAME_LEN     255
+#define BGPDUMP_TYPE_TABLE_DUMP_V2 13
+#define BGPDUMP_SUBTYPE_TABLE_DUMP_V2_PEER_INDEX_TABLE 1
+#define BGPDUMP_SUBTYPE_TABLE_DUMP_V2_RIB_IPV4_UNICAST 2
+#define BGPDUMP_SUBTYPE_TABLE_DUMP_V2_RIB_IPV4_MULTICAST 3
+#define BGPDUMP_SUBTYPE_TABLE_DUMP_V2_RIB_IPV6_UNICAST 4
+#define BGPDUMP_SUBTYPE_TABLE_DUMP_V2_RIB_IPV6_MULTICAST 5
+#define BGPDUMP_SUBTYPE_TABLE_DUMP_V2_RIB_GENERIC 6
+#define BGPDUMP_PEERTYPE_TABLE_DUMP_V2_AFI_IP 0
+#define BGPDUMP_PEERTYPE_TABLE_DUMP_V2_AFI_IP6 1
+#define BGPDUMP_PEERTYPE_TABLE_DUMP_V2_AS2 0
+#define BGPDUMP_PEERTYPE_TABLE_DUMP_V2_AS4 2
+#define BGPDUMP_TYPE_TABLE_DUMP_V2_MAX_VIEWNAME_LEN 255
 
 /* Zebra record types */
-#define BGPDUMP_TYPE_ZEBRA_BGP			16 /* MSG_PROTOCOL_BGP4MP */
-#define BGPDUMP_SUBTYPE_ZEBRA_BGP_STATE_CHANGE	0  /* BGP4MP_STATE_CHANGE */
-#define BGPDUMP_SUBTYPE_ZEBRA_BGP_MESSAGE	1  /* BGP4MP_MESSAGE */
-#define BGPDUMP_SUBTYPE_ZEBRA_BGP_ENTRY		2  /* BGP4MP_ENTRY */
-#define BGPDUMP_SUBTYPE_ZEBRA_BGP_SNAPSHOT	3  /* BGP4MP_SNAPSHOT */
-#define BGPDUMP_SUBTYPE_ZEBRA_BGP_MESSAGE_AS4	4  /* BGP4MP_MESSAGE_AS4 */
-#define BGPDUMP_SUBTYPE_ZEBRA_BGP_STATE_CHANGE_AS4	5  /* BGP4MP_STATE_CHANGE_AS4 */
+#define BGPDUMP_TYPE_ZEBRA_BGP 16                /* MSG_PROTOCOL_BGP4MP */
+#define BGPDUMP_SUBTYPE_ZEBRA_BGP_STATE_CHANGE 0 /* BGP4MP_STATE_CHANGE */
+#define BGPDUMP_SUBTYPE_ZEBRA_BGP_MESSAGE 1      /* BGP4MP_MESSAGE */
+#define BGPDUMP_SUBTYPE_ZEBRA_BGP_ENTRY 2        /* BGP4MP_ENTRY */
+#define BGPDUMP_SUBTYPE_ZEBRA_BGP_SNAPSHOT 3     /* BGP4MP_SNAPSHOT */
+#define BGPDUMP_SUBTYPE_ZEBRA_BGP_MESSAGE_AS4 4  /* BGP4MP_MESSAGE_AS4 */
+#define BGPDUMP_SUBTYPE_ZEBRA_BGP_STATE_CHANGE_AS4                             \
+  5 /* BGP4MP_STATE_CHANGE_AS4 */
 
 /* BGP state - defined in RFC1771 */
-#define BGP_STATE_IDLE		1
-#define BGP_STATE_CONNECT	2
-#define BGP_STATE_ACTIVE	3
-#define BGP_STATE_OPENSENT	4
-#define BGP_STATE_OPENCONFIRM	5
-#define BGP_STATE_ESTABLISHED	6
+#define BGP_STATE_IDLE 1
+#define BGP_STATE_CONNECT 2
+#define BGP_STATE_ACTIVE 3
+#define BGP_STATE_OPENSENT 4
+#define BGP_STATE_OPENCONFIRM 5
+#define BGP_STATE_ESTABLISHED 6
 
 /* BGP message types */
-#define	BGP_MSG_OPEN		           1
-#define	BGP_MSG_UPDATE		           2
-#define	BGP_MSG_NOTIFY		           3
-#define	BGP_MSG_KEEPALIVE	           4
-#define BGP_MSG_ROUTE_REFRESH_01           5
-#define BGP_MSG_ROUTE_REFRESH	         128
+#define BGP_MSG_OPEN 1
+#define BGP_MSG_UPDATE 2
+#define BGP_MSG_NOTIFY 3
+#define BGP_MSG_KEEPALIVE 4
+#define BGP_MSG_ROUTE_REFRESH_01 5
+#define BGP_MSG_ROUTE_REFRESH 128
 
 typedef struct struct_BGPDUMP_MRTD_MESSAGE {
-    u_int16_t		source_as;
-    struct in_addr	source_ip;
-    u_int16_t		destination_as;
-    struct in_addr	destination_ip;
-    u_char		*bgp_message;
+  u_int16_t source_as;
+  struct in_addr source_ip;
+  u_int16_t destination_as;
+  struct in_addr destination_ip;
+  u_char *bgp_message;
 } BGPDUMP_MRTD_MESSAGE;
 
 typedef struct struct_BGPDUMP_MRTD_TABLE_DUMP {
-    u_int16_t		view;
-    u_int16_t		sequence;
-    BGPDUMP_IP_ADDRESS	prefix;
-    u_char		mask;
-    u_char		status;
-    time_t		uptime;
-    BGPDUMP_IP_ADDRESS	peer_ip;
-    as_t		peer_as;
-    u_int16_t		attr_len;
+  u_int16_t view;
+  u_int16_t sequence;
+  BGPDUMP_IP_ADDRESS prefix;
+  u_char mask;
+  u_char status;
+  time_t uptime;
+  BGPDUMP_IP_ADDRESS peer_ip;
+  as_t peer_as;
+  u_int16_t attr_len;
 } BGPDUMP_MRTD_TABLE_DUMP;
 
-
 typedef struct struct_BGPDUMP_TABLE_DUMP_V2_PEER_INDEX_TABLE_ENTRY {
-	u_char              afi;
-	BGPDUMP_IP_ADDRESS  peer_ip;
-	struct in_addr      peer_bgp_id;
-	as_t                peer_as;
+  u_char afi;
+  BGPDUMP_IP_ADDRESS peer_ip;
+  struct in_addr peer_bgp_id;
+  as_t peer_as;
 } BGPDUMP_TABLE_DUMP_V2_PEER_INDEX_TABLE_ENTRY;
 
 typedef struct struct_BGPDUMP_TABLE_DUMP_V2_PEER_INDEX_TABLE {
-	struct in_addr      local_bgp_id;
-	char                view_name[BGPDUMP_TYPE_TABLE_DUMP_V2_MAX_VIEWNAME_LEN];
-	uint16_t            peer_count;
-	BGPDUMP_TABLE_DUMP_V2_PEER_INDEX_TABLE_ENTRY  *entries;
+  struct in_addr local_bgp_id;
+  char view_name[BGPDUMP_TYPE_TABLE_DUMP_V2_MAX_VIEWNAME_LEN];
+  uint16_t peer_count;
+  BGPDUMP_TABLE_DUMP_V2_PEER_INDEX_TABLE_ENTRY *entries;
 } BGPDUMP_TABLE_DUMP_V2_PEER_INDEX_TABLE;
 
 typedef struct struct_BGPDUMP_TABLE_DUMP_V2_ROUTE_ENTRY {
-	uint16_t            peer_index;
-	uint32_t            originated_time;
-	BGPDUMP_TABLE_DUMP_V2_PEER_INDEX_TABLE_ENTRY peer;
-        attributes_t        *attr;
+  uint16_t peer_index;
+  uint32_t originated_time;
+  BGPDUMP_TABLE_DUMP_V2_PEER_INDEX_TABLE_ENTRY peer;
+  attributes_t *attr;
 } BGPDUMP_TABLE_DUMP_V2_ROUTE_ENTRY;
 
 typedef struct struct_BGPDUMP_TABLE_DUMP_V2_PREFIX {
-	uint32_t            seq;
-	uint16_t            afi;
-	uint8_t             safi;
-	u_char              prefix_length;
-	BGPDUMP_IP_ADDRESS  prefix;
-	uint16_t            entry_count;
-	BGPDUMP_TABLE_DUMP_V2_ROUTE_ENTRY *entries;
+  uint32_t seq;
+  uint16_t afi;
+  uint8_t safi;
+  u_char prefix_length;
+  BGPDUMP_IP_ADDRESS prefix;
+  uint16_t entry_count;
+  BGPDUMP_TABLE_DUMP_V2_ROUTE_ENTRY *entries;
 } BGPDUMP_TABLE_DUMP_V2_PREFIX;
-
-
 
 /* For Zebra BGP4MP_STATE_CHANGE */
 typedef struct struct_BGPDUMP_ZEBRA_STATE_CHANGE {
-    as_t		source_as;
-    as_t		destination_as;
-    u_int16_t		interface_index;
-    u_int16_t		address_family;
-    BGPDUMP_IP_ADDRESS	source_ip;
-    BGPDUMP_IP_ADDRESS	destination_ip;
-    u_int16_t		old_state;
-    u_int16_t		new_state;
+  as_t source_as;
+  as_t destination_as;
+  u_int16_t interface_index;
+  u_int16_t address_family;
+  BGPDUMP_IP_ADDRESS source_ip;
+  BGPDUMP_IP_ADDRESS destination_ip;
+  u_int16_t old_state;
+  u_int16_t new_state;
 } BGPDUMP_ZEBRA_STATE_CHANGE;
 
 struct zebra_incomplete {
-    u_int16_t afi;
-    u_int8_t orig_len;
-    struct prefix prefix;
+  u_int16_t afi;
+  u_int8_t orig_len;
+  struct prefix prefix;
 };
 
 /* For Zebra BGP4MP_MESSAGE */
 typedef struct struct_BGPDUMP_ZEBRA_MESSAGE {
-    /* Zebra header */
-    as_t		source_as;
-    as_t		destination_as;
-    u_int16_t		interface_index;
-    u_int16_t		address_family;
-    BGPDUMP_IP_ADDRESS	source_ip;
-    BGPDUMP_IP_ADDRESS	destination_ip;
+  /* Zebra header */
+  as_t source_as;
+  as_t destination_as;
+  u_int16_t interface_index;
+  u_int16_t address_family;
+  BGPDUMP_IP_ADDRESS source_ip;
+  BGPDUMP_IP_ADDRESS destination_ip;
 
-    /* BGP packet header fields */
-    u_int16_t		size;
-    u_char		type;
+  /* BGP packet header fields */
+  u_int16_t size;
+  u_char type;
 
-    /* For OPEN packets */
-    u_char	version;
-    as_t	my_as;
-    u_int16_t	hold_time;
-    struct	in_addr bgp_id;
-    u_char	opt_len;
-    u_char	*opt_data;
+  /* For OPEN packets */
+  u_char version;
+  as_t my_as;
+  u_int16_t hold_time;
+  struct in_addr bgp_id;
+  u_char opt_len;
+  u_char *opt_data;
 
-    /* For UPDATE packets */
-    u_int16_t		withdraw_count;
-    u_int16_t		announce_count;
-    struct prefix	withdraw[MAX_PREFIXES];
-    struct prefix	announce[MAX_PREFIXES];
+  /* For UPDATE packets */
+  u_int16_t withdraw_count;
+  u_int16_t announce_count;
+  struct prefix withdraw[MAX_PREFIXES];
+  struct prefix announce[MAX_PREFIXES];
 
-    /* For corrupt update dumps */
-    u_int16_t cut_bytes;
-    struct zebra_incomplete incomplete;
+  /* For corrupt update dumps */
+  u_int16_t cut_bytes;
+  struct zebra_incomplete incomplete;
 
-    /* For NOTIFY packets */
-    u_char error_code;
-    u_char sub_error_code;
-    u_int16_t notify_len;
-    u_char *notify_data;
+  /* For NOTIFY packets */
+  u_char error_code;
+  u_char sub_error_code;
+  u_int16_t notify_len;
+  u_char *notify_data;
 
 } BGPDUMP_ZEBRA_MESSAGE;
 
 /* For Zebra BGP4MP_ENTRY */
 typedef struct struct_BGPDUMP_ZEBRA_ENTRY {
-    u_int16_t	view;
-    u_int16_t	status;
-    time_t	time_last_change;
-    u_int16_t	address_family;
-    u_char	SAFI;
-    u_char	next_hop_len;
-    u_char	prefix_length;
-    u_char	*address_prefix;
-    u_int16_t	empty;
-    u_char	*bgp_atribute;
+  u_int16_t view;
+  u_int16_t status;
+  time_t time_last_change;
+  u_int16_t address_family;
+  u_char SAFI;
+  u_char next_hop_len;
+  u_char prefix_length;
+  u_char *address_prefix;
+  u_int16_t empty;
+  u_char *bgp_atribute;
 } BGPDUMP_ZEBRA_ENTRY;
 
 /* For Zebra BGP4MP_SNAPSHOT */
 typedef struct struct_BGPDUMP_ZEBRA_SNAPSHOT {
-    u_int16_t	view;
-    u_int16_t	file;
+  u_int16_t view;
+  u_int16_t file;
 } BGPDUMP_ZEBRA_SNAPSHOT;
 
 typedef union union_BGPDUMP_BODY {
-	BGPDUMP_MRTD_MESSAGE		mrtd_message;
-	BGPDUMP_MRTD_TABLE_DUMP		mrtd_table_dump;
-	BGPDUMP_TABLE_DUMP_V2_PEER_INDEX_TABLE		mrtd_table_dump_v2_peer_table;
-	BGPDUMP_TABLE_DUMP_V2_PREFIX		mrtd_table_dump_v2_prefix;
-	BGPDUMP_ZEBRA_STATE_CHANGE	zebra_state_change;
-	BGPDUMP_ZEBRA_MESSAGE		zebra_message;
-	BGPDUMP_ZEBRA_ENTRY		zebra_entry;
-	BGPDUMP_ZEBRA_SNAPSHOT		zebra_snapshot;
+  BGPDUMP_MRTD_MESSAGE mrtd_message;
+  BGPDUMP_MRTD_TABLE_DUMP mrtd_table_dump;
+  BGPDUMP_TABLE_DUMP_V2_PEER_INDEX_TABLE mrtd_table_dump_v2_peer_table;
+  BGPDUMP_TABLE_DUMP_V2_PREFIX mrtd_table_dump_v2_prefix;
+  BGPDUMP_ZEBRA_STATE_CHANGE zebra_state_change;
+  BGPDUMP_ZEBRA_MESSAGE zebra_message;
+  BGPDUMP_ZEBRA_ENTRY zebra_entry;
+  BGPDUMP_ZEBRA_SNAPSHOT zebra_snapshot;
 } BGPDUMP_BODY;
-
 
 /* The MRT header. Common to all records. */
 typedef struct struct_BGPDUMP_ENTRY {
-  time_t		time;
-  u_int16_t		type;
-  u_int16_t		subtype;
-  u_int32_t		length;
-  attributes_t       *attr;
-  BGPDUMP_BODY 	body;
+  time_t time;
+  u_int16_t type;
+  u_int16_t subtype;
+  u_int32_t length;
+  attributes_t *attr;
+  BGPDUMP_BODY body;
   // link to the current bgpdump structure, or NULL
-  struct struct_BGPDUMP * dump;
+  struct struct_BGPDUMP *dump;
 } BGPDUMP_ENTRY;
 
 #endif

--- a/lib/bgpdump/bgpdump_lib.c
+++ b/lib/bgpdump/bgpdump_lib.c
@@ -1,6 +1,6 @@
 /*
   Copyright (c) 2007 - 2010 RIPE NCC - All Rights Reserved
- 
+
   Permission to use, copy, modify, and distribute this software and its
   documentation for any purpose and without fee is hereby granted, provided
   that the above copyright notice appear in all copies and that both that
@@ -8,14 +8,14 @@
   documentation, and that the name of the author not be used in advertising or
   publicity pertaining to distribution of the software without specific,
   written prior permission.
- 
+
   THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
   ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS; IN NO EVENT SHALL
   AUTHOR BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY
   DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
   AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
   OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- 
+
   Parts of this code have been engineered after analiyzing GNU Zebra's
   source code and therefore might contain declarations/code from GNU
   Zebra, Copyright (C) 1999 Kunihiro Ishiguro. Zebra is a free routing
@@ -30,100 +30,119 @@
 #include "bgpdump_mstream.h"
 #include "bgpdump_util.h"
 
-#include <sys/stat.h>
-#include <stdlib.h>
-#include <unistd.h>
 #include <stdbool.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
+#include <arpa/inet.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
-#include <arpa/inet.h>
 
-#include <zlib.h>
 #include <assert.h>
+#include <zlib.h>
 
-void	  bgpdump_free_attr(attributes_t *attr);
-static    int process_mrtd_table_dump(struct mstream *s,BGPDUMP_ENTRY *entry);
-static    int process_mrtd_table_dump_v2(struct mstream *s,BGPDUMP_ENTRY *entry);
-static    int process_mrtd_table_dump_v2_peer_index_table(struct mstream *s,BGPDUMP_ENTRY *entry);
-static    int process_mrtd_table_dump_v2_ipv4_unicast(struct mstream *s,BGPDUMP_ENTRY *entry);
-static    int process_mrtd_table_dump_v2_ipv6_unicast(struct mstream *s,BGPDUMP_ENTRY *entry);
-static    int process_zebra_bgp(struct mstream *s,BGPDUMP_ENTRY *entry);
-static    int process_zebra_bgp_state_change(struct mstream *s,BGPDUMP_ENTRY *entry, u_int8_t asn_len);
+void bgpdump_free_attr(attributes_t *attr);
+static int process_mrtd_table_dump(struct mstream *s, BGPDUMP_ENTRY *entry);
+static int process_mrtd_table_dump_v2(struct mstream *s, BGPDUMP_ENTRY *entry);
+static int process_mrtd_table_dump_v2_peer_index_table(struct mstream *s,
+                                                       BGPDUMP_ENTRY *entry);
+static int process_mrtd_table_dump_v2_ipv4_unicast(struct mstream *s,
+                                                   BGPDUMP_ENTRY *entry);
+static int process_mrtd_table_dump_v2_ipv6_unicast(struct mstream *s,
+                                                   BGPDUMP_ENTRY *entry);
+static int process_zebra_bgp(struct mstream *s, BGPDUMP_ENTRY *entry);
+static int process_zebra_bgp_state_change(struct mstream *s,
+                                          BGPDUMP_ENTRY *entry,
+                                          u_int8_t asn_len);
 
-static    int process_zebra_bgp_message(struct mstream *s,BGPDUMP_ENTRY *entry, u_int8_t asn_len);
-static    int process_zebra_bgp_message_update(struct mstream *s,BGPDUMP_ENTRY *entry, u_int8_t asn_len);
-static    int process_zebra_bgp_message_open(struct mstream *s,BGPDUMP_ENTRY *entry, u_int8_t asn_len);
-static    int process_zebra_bgp_message_notify(struct mstream *s,BGPDUMP_ENTRY *entry);
+static int process_zebra_bgp_message(struct mstream *s, BGPDUMP_ENTRY *entry,
+                                     u_int8_t asn_len);
+static int process_zebra_bgp_message_update(struct mstream *s,
+                                            BGPDUMP_ENTRY *entry,
+                                            u_int8_t asn_len);
+static int process_zebra_bgp_message_open(struct mstream *s,
+                                          BGPDUMP_ENTRY *entry,
+                                          u_int8_t asn_len);
+static int process_zebra_bgp_message_notify(struct mstream *s,
+                                            BGPDUMP_ENTRY *entry);
 
-static    int process_zebra_bgp_entry(struct mstream *s,BGPDUMP_ENTRY *entry);
-static    int process_zebra_bgp_snapshot(struct mstream *s,BGPDUMP_ENTRY *entry);
+static int process_zebra_bgp_entry(struct mstream *s, BGPDUMP_ENTRY *entry);
+static int process_zebra_bgp_snapshot(struct mstream *s, BGPDUMP_ENTRY *entry);
 
-static    attributes_t *process_attributes(struct mstream *s, u_int8_t asn_len, struct zebra_incomplete *incomplete);
+static attributes_t *process_attributes(struct mstream *s, u_int8_t asn_len,
+                                        struct zebra_incomplete *incomplete);
 
-static    char aspath_delimiter_char (u_char type, u_char which);
+static char aspath_delimiter_char(u_char type, u_char which);
 
-static    void process_mp_announce(struct mstream *s, struct mp_info *info, struct zebra_incomplete *incomplete);
-static    void process_mp_withdraw(struct mstream *s, struct mp_info *info, struct zebra_incomplete *incomplete);
-static    int read_prefix_list(struct mstream *s, u_int16_t af, struct prefix *prefixes, struct zebra_incomplete *incomplete);
+static void process_mp_announce(struct mstream *s, struct mp_info *info,
+                                struct zebra_incomplete *incomplete);
+static void process_mp_withdraw(struct mstream *s, struct mp_info *info,
+                                struct zebra_incomplete *incomplete);
+static int read_prefix_list(struct mstream *s, u_int16_t af,
+                            struct prefix *prefixes,
+                            struct zebra_incomplete *incomplete);
 
-static    as_t read_asn(struct mstream *s, as_t *asn, u_int8_t len);
-static    struct aspath *create_aspath(u_int16_t len, u_int8_t asn_len);
-static    void aspath_error(struct aspath *as);
-static    int check_new_aspath(struct aspath *aspath);
-static    void process_asn32_trans(attributes_t *attr, u_int8_t asn_len);
-static    struct aspath *asn32_merge_paths(struct aspath *path, struct aspath *newpath);
-static    void asn32_expand_16_to_32(char *dst, char *src, int len);
+static as_t read_asn(struct mstream *s, as_t *asn, u_int8_t len);
+static struct aspath *create_aspath(u_int16_t len, u_int8_t asn_len);
+static void aspath_error(struct aspath *as);
+static int check_new_aspath(struct aspath *aspath);
+static void process_asn32_trans(attributes_t *attr, u_int8_t asn_len);
+static struct aspath *asn32_merge_paths(struct aspath *path,
+                                        struct aspath *newpath);
+static void asn32_expand_16_to_32(char *dst, char *src, int len);
 
 // comments here
-//BGPDUMP_TABLE_DUMP_V2_PEER_INDEX_TABLE *table_dump_v2_peer_index_table = NULL;
+// BGPDUMP_TABLE_DUMP_V2_PEER_INDEX_TABLE *table_dump_v2_peer_index_table =
+// NULL;
 
 #if defined(linux)
 static size_t strlcat(char *dst, const char *src, size_t size);
 #endif
 
-char *bgpdump_version(void) {
+char *bgpdump_version(void)
+{
   return PACKAGE_VERSION;
 }
 
-
-BGPDUMP *bgpdump_open_dump(const char *filename) {
+BGPDUMP *bgpdump_open_dump(const char *filename)
+{
 
   CFRFILE *f = cfr_open(filename);
-  if(! f) {
+  if (!f) {
     fprintf(stderr, "Cannot open dumpfile %s: ", filename);
     perror("");
     return NULL;
   }
-    
+
   BGPDUMP *this_dump = malloc(sizeof(BGPDUMP));
   strcpy(this_dump->filename, "[STDIN]");
-  if(filename && strcmp(filename, "-")) {
+  if (filename && strcmp(filename, "-")) {
     strcpy(this_dump->filename, filename);
   }
 
   this_dump->f = f;
-  this_dump->eof=0;
+  this_dump->eof = 0;
   this_dump->parsed = 0;
   this_dump->parsed_ok = 0;
   this_dump->corrupted_read = false;
-  
+
   // peer index table shared among entries
   this_dump->table_dump_v2_peer_index_table = NULL;
 
   return this_dump;
 }
 
+void bgpdump_close_dump(BGPDUMP *dump)
+{
 
-void bgpdump_close_dump(BGPDUMP *dump) {
-
-  if(dump == NULL) {
+  if (dump == NULL) {
     return;
   }
 
   // destroy current index table, if any
-  if(dump->table_dump_v2_peer_index_table){
-    if(dump->table_dump_v2_peer_index_table->entries) {
+  if (dump->table_dump_v2_peer_index_table) {
+    if (dump->table_dump_v2_peer_index_table->entries) {
       free(dump->table_dump_v2_peer_index_table->entries);
       dump->table_dump_v2_peer_index_table->entries = NULL;
     }
@@ -134,95 +153,97 @@ void bgpdump_close_dump(BGPDUMP *dump) {
   free(dump);
 }
 
-
-BGPDUMP_ENTRY* bgpdump_entry_create(BGPDUMP *dump){
+BGPDUMP_ENTRY *bgpdump_entry_create(BGPDUMP *dump)
+{
   BGPDUMP_ENTRY *this_entry = malloc(sizeof(BGPDUMP_ENTRY));
   memset(this_entry, 0, sizeof(BGPDUMP_ENTRY));
   this_entry->dump = dump;
   return this_entry;
 }
 
-
-BGPDUMP_ENTRY*	bgpdump_read_next(BGPDUMP *dump) {
+BGPDUMP_ENTRY *bgpdump_read_next(BGPDUMP *dump)
+{
 
   assert(dump);
 
   struct mstream s;
   u_char *buffer;
-  int ok=0;
+  int ok = 0;
   u_int32_t bytes_read;
 
   BGPDUMP_ENTRY *this_entry = bgpdump_entry_create(dump);
-  
+
   // initialize corrupted_read
   dump->corrupted_read = false;
 
   assert(this_entry);
-  
+
   bytes_read = cfr_read_n(dump->f, &(this_entry->time), 4);
   bytes_read += cfr_read_n(dump->f, &(this_entry->type), 2);
   bytes_read += cfr_read_n(dump->f, &(this_entry->subtype), 2);
   bytes_read += cfr_read_n(dump->f, &(this_entry->length), 4);
-  if(bytes_read != 12) {
-    if(bytes_read > 0) {
+  if (bytes_read != 12) {
+    if (bytes_read > 0) {
       /* Malformed record */
       dump->parsed++;
-      bgpdump_err("bgpdump_read_next: %s incomplete MRT header (%d bytes read, expecting 12)",
-		  dump->filename, bytes_read);	    
+      bgpdump_err("bgpdump_read_next: %s incomplete MRT header (%d bytes read, "
+                  "expecting 12)",
+                  dump->filename, bytes_read);
       dump->corrupted_read = true;
     }
     /* Nothing more to read, quit */
     bgpdump_free_mem(this_entry);
     this_entry = NULL;
-    dump->eof=1;
-    //printf("case 1\n");
-    return(NULL);
+    dump->eof = 1;
+    // printf("case 1\n");
+    return (NULL);
   }
 
   dump->parsed++;
 
   /* Intel byte ordering stuff ... */
-  this_entry->type=ntohs(this_entry->type);
-  this_entry->subtype=ntohs(this_entry->subtype);
-  this_entry->time=ntohl(this_entry->time);
-  this_entry->length=ntohl(this_entry->length);
-  this_entry->attr=NULL;
+  this_entry->type = ntohs(this_entry->type);
+  this_entry->subtype = ntohs(this_entry->subtype);
+  this_entry->time = ntohl(this_entry->time);
+  this_entry->length = ntohl(this_entry->length);
+  this_entry->attr = NULL;
   buffer = malloc(this_entry->length);
   bytes_read = cfr_read_n(dump->f, buffer, this_entry->length);
-  if(bytes_read != this_entry->length) {
-    bgpdump_err("bgpdump_read_next: %s incomplete dump record (%d bytes read, expecting %d)",
-		dump->filename, bytes_read, this_entry->length);
+  if (bytes_read != this_entry->length) {
+    bgpdump_err("bgpdump_read_next: %s incomplete dump record (%d bytes read, "
+                "expecting %d)",
+                dump->filename, bytes_read, this_entry->length);
     dump->corrupted_read = true;
-    //printf("case 2\n");
+    // printf("case 2\n");
     bgpdump_free_mem(this_entry);
     this_entry = NULL;
     free(buffer);
-    dump->eof=1;
-    return(NULL);
+    dump->eof = 1;
+    return (NULL);
   }
 
-  ok=0;
-  mstream_init(&s,buffer,this_entry->length);
+  ok = 0;
+  mstream_init(&s, buffer, this_entry->length);
 
-  switch(this_entry->type) {
+  switch (this_entry->type) {
   case BGPDUMP_TYPE_MRTD_BGP:
     break;
   case BGPDUMP_TYPE_MRTD_TABLE_DUMP:
-    ok = process_mrtd_table_dump(&s,this_entry);
+    ok = process_mrtd_table_dump(&s, this_entry);
     break;
   case BGPDUMP_TYPE_ZEBRA_BGP:
-    ok = process_zebra_bgp(&s,this_entry);
+    ok = process_zebra_bgp(&s, this_entry);
     break;
   case BGPDUMP_TYPE_TABLE_DUMP_V2:
-    ok = process_mrtd_table_dump_v2(&s,this_entry);
+    ok = process_mrtd_table_dump_v2(&s, this_entry);
     break;
   }
 
   free(buffer);
-  if(ok) {
+  if (ok) {
     dump->parsed_ok++;
   } else {
-    //printf("case 3 - not corrupted, just empty beginning\n");
+    // printf("case 3 - not corrupted, just empty beginning\n");
     bgpdump_free_mem(this_entry);
     this_entry = NULL;
     return NULL;
@@ -230,19 +251,19 @@ BGPDUMP_ENTRY*	bgpdump_read_next(BGPDUMP *dump) {
   return this_entry;
 }
 
-
-static void bgpdump_free_mp_info(struct mp_info *info) {
+static void bgpdump_free_mp_info(struct mp_info *info)
+{
   u_int16_t afi;
   u_int8_t safi;
 
-  for(afi = 1; afi <= BGPDUMP_MAX_AFI; afi++) {
-    for(safi = 1; safi < BGPDUMP_MAX_SAFI; safi++) {
-      if(info->announce[afi][safi])
-	free(info->announce[afi][safi]);
+  for (afi = 1; afi <= BGPDUMP_MAX_AFI; afi++) {
+    for (safi = 1; safi < BGPDUMP_MAX_SAFI; safi++) {
+      if (info->announce[afi][safi])
+        free(info->announce[afi][safi]);
       info->announce[afi][safi] = NULL;
-      if(info->withdraw[afi][safi]) {
-	free(info->withdraw[afi][safi]);
-	info->withdraw[afi][safi] = NULL;
+      if (info->withdraw[afi][safi]) {
+        free(info->withdraw[afi][safi]);
+        info->withdraw[afi][safi] = NULL;
       }
     }
   }
@@ -250,42 +271,42 @@ static void bgpdump_free_mp_info(struct mp_info *info) {
   free(info);
 }
 
+void bgpdump_free_mem(BGPDUMP_ENTRY *entry)
+{
 
-void bgpdump_free_mem(BGPDUMP_ENTRY *entry) {
-
-  if(entry!=NULL) {
+  if (entry != NULL) {
     bgpdump_free_attr(entry->attr);
     entry->attr = NULL;
-    switch(entry->type) {
+    switch (entry->type) {
     case BGPDUMP_TYPE_ZEBRA_BGP:
-      switch(entry->subtype) {
+      switch (entry->subtype) {
       case BGPDUMP_SUBTYPE_ZEBRA_BGP_MESSAGE:
-	switch(entry->body.zebra_message.type) {
-	case BGP_MSG_NOTIFY:
-	  if(entry->body.zebra_message.notify_data)
-	    free(entry->body.zebra_message.notify_data);
-	  break;
-	case BGP_MSG_OPEN:
-	  if(entry->body.zebra_message.opt_data)
-	    free(entry->body.zebra_message.opt_data);
-	  break;
-	}
-	break;
+        switch (entry->body.zebra_message.type) {
+        case BGP_MSG_NOTIFY:
+          if (entry->body.zebra_message.notify_data)
+            free(entry->body.zebra_message.notify_data);
+          break;
+        case BGP_MSG_OPEN:
+          if (entry->body.zebra_message.opt_data)
+            free(entry->body.zebra_message.opt_data);
+          break;
+        }
+        break;
       }
       break;
     case BGPDUMP_TYPE_TABLE_DUMP_V2:
-      if(entry->subtype == BGPDUMP_SUBTYPE_TABLE_DUMP_V2_RIB_IPV4_UNICAST ||
-	 entry->subtype == BGPDUMP_SUBTYPE_TABLE_DUMP_V2_RIB_IPV6_UNICAST ){
+      if (entry->subtype == BGPDUMP_SUBTYPE_TABLE_DUMP_V2_RIB_IPV4_UNICAST ||
+          entry->subtype == BGPDUMP_SUBTYPE_TABLE_DUMP_V2_RIB_IPV6_UNICAST) {
 
-	BGPDUMP_TABLE_DUMP_V2_PREFIX *e;
-	e = &entry->body.mrtd_table_dump_v2_prefix;
-	int i;
+        BGPDUMP_TABLE_DUMP_V2_PREFIX *e;
+        e = &entry->body.mrtd_table_dump_v2_prefix;
+        int i;
 
-	for(i = 0; i < e->entry_count; i++){
-	  bgpdump_free_attr(e->entries[i].attr);
+        for (i = 0; i < e->entry_count; i++) {
+          bgpdump_free_attr(e->entries[i].attr);
           e->entries[i].attr = NULL;
-	}
-	free(e->entries);
+        }
+        free(e->entries);
       }
       break;
     }
@@ -295,54 +316,53 @@ void bgpdump_free_mem(BGPDUMP_ENTRY *entry) {
   }
 }
 
-
-void bgpdump_free_attr(attributes_t *attr){
-  if(attr != NULL) {  
+void bgpdump_free_attr(attributes_t *attr)
+{
+  if (attr != NULL) {
     u_int16_t i;
-    struct aspath *path, *pathstofree[3] = { attr->aspath, attr->old_aspath, attr->new_aspath };
-    for(i = 0; i < (sizeof(pathstofree) / sizeof(pathstofree[0])); i++) {
+    struct aspath *path,
+      *pathstofree[3] = {attr->aspath, attr->old_aspath, attr->new_aspath};
+    for (i = 0; i < (sizeof(pathstofree) / sizeof(pathstofree[0])); i++) {
       path = pathstofree[i];
-      if(path) {
-	if(path->data)
-	  free(path->data);
-	if(path->str) {
-	  free(path->str);
-	}
-	free(path);
+      if (path) {
+        if (path->data)
+          free(path->data);
+        if (path->str) {
+          free(path->str);
+        }
+        free(path);
       }
     }
 
-    if(attr->community != NULL) {
-      if(attr->community->val != NULL)
-        {
-          free(attr->community->val);
-          attr->community->val = NULL;
-        }
+    if (attr->community != NULL) {
+      if (attr->community->val != NULL) {
+        free(attr->community->val);
+        attr->community->val = NULL;
+      }
 
-      if(attr->community->str != NULL)
-        {
-          free(attr->community->str);
-          attr->community->str = NULL;
-        }
+      if (attr->community->str != NULL) {
+        free(attr->community->str);
+        attr->community->str = NULL;
+      }
 
       free(attr->community);
       attr->community = NULL;
     }
 
-    if(attr->data != NULL)
+    if (attr->data != NULL)
       free(attr->data);
 
-    if(attr->mp_info != NULL)
+    if (attr->mp_info != NULL)
       bgpdump_free_mp_info(attr->mp_info);
 
-    if(attr->cluster != NULL) {
+    if (attr->cluster != NULL) {
       free(attr->cluster->list);
       free(attr->cluster);
     }
 
     if (attr->unknown_num) {
       for (i = 0; i < attr->unknown_num; i++)
-	free(attr->unknown[i].raw);
+        free(attr->unknown[i].raw);
       free(attr->unknown);
     }
 
@@ -350,13 +370,14 @@ void bgpdump_free_attr(attributes_t *attr){
   }
 }
 
-int process_mrtd_table_dump(struct mstream *s,BGPDUMP_ENTRY *entry) {
+int process_mrtd_table_dump(struct mstream *s, BGPDUMP_ENTRY *entry)
+{
   int afi = entry->subtype;
   u_int8_t asn_len;
   u_int32_t temp_time = 0;
-  mstream_getw(s,&entry->body.mrtd_table_dump.view);
-  mstream_getw(s,&entry->body.mrtd_table_dump.sequence);
-  switch(afi) {
+  mstream_getw(s, &entry->body.mrtd_table_dump.view);
+  mstream_getw(s, &entry->body.mrtd_table_dump.sequence);
+  switch (afi) {
   case BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP:
   case BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP_32BIT_AS:
     entry->body.mrtd_table_dump.prefix.v4_addr = mstream_get_ipv4(s);
@@ -366,16 +387,16 @@ int process_mrtd_table_dump(struct mstream *s,BGPDUMP_ENTRY *entry) {
     mstream_get(s, &entry->body.mrtd_table_dump.prefix.v6_addr.s6_addr, 16);
     break;
   default:
-    bgpdump_warn("process_mrtd_table_dump: unknown AFI %d",  afi);
+    bgpdump_warn("process_mrtd_table_dump: unknown AFI %d", afi);
     mstream_get(s, NULL, mstream_can_read(s));
     return 0;
   }
-  mstream_getc(s,&entry->body.mrtd_table_dump.mask);
-  mstream_getc(s,&entry->body.mrtd_table_dump.status);
-  mstream_getl(s,&temp_time);
+  mstream_getc(s, &entry->body.mrtd_table_dump.mask);
+  mstream_getc(s, &entry->body.mrtd_table_dump.status);
+  mstream_getl(s, &temp_time);
   (entry->body).mrtd_table_dump.uptime = temp_time;
 
-  switch(afi) {
+  switch (afi) {
   case BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP:
   case BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP_32BIT_AS:
     entry->body.mrtd_table_dump.peer_ip.v4_addr = mstream_get_ipv4(s);
@@ -386,7 +407,7 @@ int process_mrtd_table_dump(struct mstream *s,BGPDUMP_ENTRY *entry) {
     break;
   }
 
-  switch(afi) {
+  switch (afi) {
   case BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP:
   case BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP6:
     asn_len = ASN16_LEN;
@@ -400,17 +421,17 @@ int process_mrtd_table_dump(struct mstream *s,BGPDUMP_ENTRY *entry) {
     return 0;
   }
 
-  read_asn(s,&entry->body.mrtd_table_dump.peer_as, asn_len);
+  read_asn(s, &entry->body.mrtd_table_dump.peer_as, asn_len);
 
   entry->attr = process_attributes(s, asn_len, NULL);
 
   return 1;
 }
 
+int process_mrtd_table_dump_v2(struct mstream *s, BGPDUMP_ENTRY *entry)
+{
 
-int process_mrtd_table_dump_v2(struct mstream *s,BGPDUMP_ENTRY *entry) {
-
-  switch(entry->subtype){
+  switch (entry->subtype) {
   case BGPDUMP_SUBTYPE_TABLE_DUMP_V2_PEER_INDEX_TABLE:
     return process_mrtd_table_dump_v2_peer_index_table(s, entry);
     break;
@@ -421,14 +442,16 @@ int process_mrtd_table_dump_v2(struct mstream *s,BGPDUMP_ENTRY *entry) {
     return process_mrtd_table_dump_v2_ipv6_unicast(s, entry);
     break;
   case BGPDUMP_SUBTYPE_TABLE_DUMP_V2_RIB_GENERIC:
-    //return process_mrtd_table_dump_v2_generic(s, entry);
+    // return process_mrtd_table_dump_v2_generic(s, entry);
     break;
   }
 
   return 0;
 }
 
-int process_mrtd_table_dump_v2_peer_index_table(struct mstream *s,BGPDUMP_ENTRY *entry) {
+int process_mrtd_table_dump_v2_peer_index_table(struct mstream *s,
+                                                BGPDUMP_ENTRY *entry)
+{
 
   assert(entry->dump);
 
@@ -437,62 +460,66 @@ int process_mrtd_table_dump_v2_peer_index_table(struct mstream *s,BGPDUMP_ENTRY 
   uint8_t peertype;
   uint16_t view_name_len;
 
-  if(entry->dump->table_dump_v2_peer_index_table){
-    if(entry->dump->table_dump_v2_peer_index_table->entries)
+  if (entry->dump->table_dump_v2_peer_index_table) {
+    if (entry->dump->table_dump_v2_peer_index_table->entries)
       free(entry->dump->table_dump_v2_peer_index_table->entries);
     free(entry->dump->table_dump_v2_peer_index_table);
   }
 
-  entry->dump->table_dump_v2_peer_index_table = malloc(sizeof(BGPDUMP_TABLE_DUMP_V2_PEER_INDEX_TABLE));
+  entry->dump->table_dump_v2_peer_index_table =
+    malloc(sizeof(BGPDUMP_TABLE_DUMP_V2_PEER_INDEX_TABLE));
   t = entry->dump->table_dump_v2_peer_index_table;
   t->entries = NULL;
 
   t->local_bgp_id = mstream_get_ipv4(s);
 
-  mstream_getw(s,&view_name_len);
+  mstream_getw(s, &view_name_len);
   strcpy(t->view_name, "");
 
   // view_name_len is without trailing \0
-  if(view_name_len+1 > BGPDUMP_TYPE_TABLE_DUMP_V2_MAX_VIEWNAME_LEN) {
-    bgpdump_warn("process_mrtd_table_dump_v2_peer_index_table: view name length more than maximum length (%d), ignoring view name", BGPDUMP_TYPE_TABLE_DUMP_V2_MAX_VIEWNAME_LEN);
+  if (view_name_len + 1 > BGPDUMP_TYPE_TABLE_DUMP_V2_MAX_VIEWNAME_LEN) {
+    bgpdump_warn("process_mrtd_table_dump_v2_peer_index_table: view name "
+                 "length more than maximum length (%d), ignoring view name",
+                 BGPDUMP_TYPE_TABLE_DUMP_V2_MAX_VIEWNAME_LEN);
   } else {
     mstream_get(s, t->view_name, view_name_len);
     t->view_name[view_name_len] = 0;
   }
 
-  mstream_getw(s,&t->peer_count);
+  mstream_getw(s, &t->peer_count);
 
-  t->entries = malloc(sizeof(BGPDUMP_TABLE_DUMP_V2_PEER_INDEX_TABLE_ENTRY) * t->peer_count);
-  if(t->entries == NULL){
-    bgpdump_err("process_mrtd_table_dump_v2_peer_index_table: failed to allocate memory for index table");
+  t->entries = malloc(sizeof(BGPDUMP_TABLE_DUMP_V2_PEER_INDEX_TABLE_ENTRY) *
+                      t->peer_count);
+  if (t->entries == NULL) {
+    bgpdump_err("process_mrtd_table_dump_v2_peer_index_table: failed to "
+                "allocate memory for index table");
     return 0;
   }
 
-  for(i=0; i < t->peer_count; i++) {
-    mstream_getc(s,&peertype);
+  for (i = 0; i < t->peer_count; i++) {
+    mstream_getc(s, &peertype);
     t->entries[i].afi = AFI_IP;
-    if(peertype & BGPDUMP_PEERTYPE_TABLE_DUMP_V2_AFI_IP6)
+    if (peertype & BGPDUMP_PEERTYPE_TABLE_DUMP_V2_AFI_IP6)
       t->entries[i].afi = AFI_IP6;
-    
+
     t->entries[i].peer_bgp_id = mstream_get_ipv4(s);
 
-    if(t->entries[i].afi == AFI_IP)
+    if (t->entries[i].afi == AFI_IP)
       t->entries[i].peer_ip.v4_addr = mstream_get_ipv4(s);
     else
       mstream_get(s, &t->entries[i].peer_ip.v6_addr.s6_addr, 16);
 
-
-    if(peertype & BGPDUMP_PEERTYPE_TABLE_DUMP_V2_AS4)
+    if (peertype & BGPDUMP_PEERTYPE_TABLE_DUMP_V2_AS4)
       read_asn(s, &t->entries[i].peer_as, 4);
     else
       read_asn(s, &t->entries[i].peer_as, 2);
-
   }
   return 0;
 }
 
-
-int process_mrtd_table_dump_v2_ipv4_unicast(struct mstream *s, BGPDUMP_ENTRY *entry){
+int process_mrtd_table_dump_v2_ipv4_unicast(struct mstream *s,
+                                            BGPDUMP_ENTRY *entry)
+{
   BGPDUMP_TABLE_DUMP_V2_PREFIX *prefixdata;
   prefixdata = &entry->body.mrtd_table_dump_v2_prefix;
   uint16_t i;
@@ -503,31 +530,36 @@ int process_mrtd_table_dump_v2_ipv4_unicast(struct mstream *s, BGPDUMP_ENTRY *en
   mstream_getl(s, &prefixdata->seq);
   mstream_getc(s, &prefixdata->prefix_length);
   bzero(&prefixdata->prefix.v4_addr.s_addr, 4);
-  mstream_get(s, &prefixdata->prefix.v4_addr.s_addr, (prefixdata->prefix_length+7)/8);
+  mstream_get(s, &prefixdata->prefix.v4_addr.s_addr,
+              (prefixdata->prefix_length + 7) / 8);
   mstream_getw(s, &prefixdata->entry_count);
 
-  prefixdata->entries = malloc(sizeof(BGPDUMP_TABLE_DUMP_V2_ROUTE_ENTRY) * prefixdata->entry_count);
-  if(prefixdata->entries == NULL){
-    bgpdump_err("process_mrtd_table_dump_v2_ipv4_unicast: failed to allocate memory for entry table");
+  prefixdata->entries =
+    malloc(sizeof(BGPDUMP_TABLE_DUMP_V2_ROUTE_ENTRY) * prefixdata->entry_count);
+  if (prefixdata->entries == NULL) {
+    bgpdump_err("process_mrtd_table_dump_v2_ipv4_unicast: failed to allocate "
+                "memory for entry table");
     return 0;
   }
 
-  for(i=0; i < prefixdata->entry_count; i++){
+  for (i = 0; i < prefixdata->entry_count; i++) {
     BGPDUMP_TABLE_DUMP_V2_ROUTE_ENTRY *e;
     e = &prefixdata->entries[i];
 
     mstream_getw(s, &e->peer_index);
-    e->peer = entry->dump->table_dump_v2_peer_index_table->entries[e->peer_index];
+    e->peer =
+      entry->dump->table_dump_v2_peer_index_table->entries[e->peer_index];
     mstream_getl(s, &e->originated_time);
-            
+
     e->attr = process_attributes(s, 4, NULL);
   }
 
   return 1;
 }
 
-
-int process_mrtd_table_dump_v2_ipv6_unicast(struct mstream *s, BGPDUMP_ENTRY *entry){
+int process_mrtd_table_dump_v2_ipv6_unicast(struct mstream *s,
+                                            BGPDUMP_ENTRY *entry)
+{
   BGPDUMP_TABLE_DUMP_V2_PREFIX *prefixdata;
   prefixdata = &entry->body.mrtd_table_dump_v2_prefix;
   uint16_t i;
@@ -539,22 +571,26 @@ int process_mrtd_table_dump_v2_ipv6_unicast(struct mstream *s, BGPDUMP_ENTRY *en
 
   mstream_getc(s, &prefixdata->prefix_length);
   bzero(&prefixdata->prefix.v6_addr.s6_addr, 16);
-  mstream_get(s, &prefixdata->prefix.v6_addr.s6_addr, (prefixdata->prefix_length+7)/8);
+  mstream_get(s, &prefixdata->prefix.v6_addr.s6_addr,
+              (prefixdata->prefix_length + 7) / 8);
 
   mstream_getw(s, &prefixdata->entry_count);
 
-  prefixdata->entries = malloc(sizeof(BGPDUMP_TABLE_DUMP_V2_ROUTE_ENTRY) * prefixdata->entry_count);
-  if(prefixdata->entries == NULL){
-    bgpdump_err("process_mrtd_table_dump_v2_ipv6_unicast: failed to allocate memory for entry table");
+  prefixdata->entries =
+    malloc(sizeof(BGPDUMP_TABLE_DUMP_V2_ROUTE_ENTRY) * prefixdata->entry_count);
+  if (prefixdata->entries == NULL) {
+    bgpdump_err("process_mrtd_table_dump_v2_ipv6_unicast: failed to allocate "
+                "memory for entry table");
     return 0;
   }
 
-  for(i=0; i < prefixdata->entry_count; i++){
+  for (i = 0; i < prefixdata->entry_count; i++) {
     BGPDUMP_TABLE_DUMP_V2_ROUTE_ENTRY *e;
     e = &prefixdata->entries[i];
 
     mstream_getw(s, &e->peer_index);
-    e->peer = entry->dump->table_dump_v2_peer_index_table->entries[e->peer_index];
+    e->peer =
+      entry->dump->table_dump_v2_peer_index_table->entries[e->peer_index];
     mstream_getl(s, &e->originated_time);
 
     e->attr = process_attributes(s, 4, NULL);
@@ -563,8 +599,9 @@ int process_mrtd_table_dump_v2_ipv6_unicast(struct mstream *s, BGPDUMP_ENTRY *en
   return 1;
 }
 
-int process_zebra_bgp(struct mstream *s,BGPDUMP_ENTRY *entry) {
-  switch(entry->subtype) {
+int process_zebra_bgp(struct mstream *s, BGPDUMP_ENTRY *entry)
+{
+  switch (entry->subtype) {
   case BGPDUMP_SUBTYPE_ZEBRA_BGP_STATE_CHANGE:
     return process_zebra_bgp_state_change(s, entry, ASN16_LEN);
   case BGPDUMP_SUBTYPE_ZEBRA_BGP_STATE_CHANGE_AS4:
@@ -574,7 +611,7 @@ int process_zebra_bgp(struct mstream *s,BGPDUMP_ENTRY *entry) {
   case BGPDUMP_SUBTYPE_ZEBRA_BGP_MESSAGE_AS4:
     return process_zebra_bgp_message(s, entry, ASN32_LEN);
   case BGPDUMP_SUBTYPE_ZEBRA_BGP_ENTRY:
-    return process_zebra_bgp_entry(s,entry);
+    return process_zebra_bgp_entry(s, entry);
   case BGPDUMP_SUBTYPE_ZEBRA_BGP_SNAPSHOT:
     return process_zebra_bgp_snapshot(s, entry);
   default:
@@ -583,17 +620,20 @@ int process_zebra_bgp(struct mstream *s,BGPDUMP_ENTRY *entry) {
   }
 }
 
-int process_zebra_bgp_state_change(struct mstream *s,BGPDUMP_ENTRY *entry, u_int8_t asn_len) {
+int process_zebra_bgp_state_change(struct mstream *s, BGPDUMP_ENTRY *entry,
+                                   u_int8_t asn_len)
+{
   read_asn(s, &entry->body.zebra_state_change.source_as, asn_len);
   read_asn(s, &entry->body.zebra_state_change.destination_as, asn_len);
 
   /* Work around Zebra dump corruption.
    * N.B. I don't see this in quagga 0.96.4 any more. Is it fixed? */
   if (entry->length == 8) {
-    bgpdump_warn("process_zebra_bgp_state_change: 8-byte state change (zebra bug?)");
+    bgpdump_warn(
+      "process_zebra_bgp_state_change: 8-byte state change (zebra bug?)");
 
-    mstream_getw(s,&entry->body.zebra_state_change.old_state);
-    mstream_getw(s,&entry->body.zebra_state_change.new_state);
+    mstream_getw(s, &entry->body.zebra_state_change.old_state);
+    mstream_getw(s, &entry->body.zebra_state_change.new_state);
 
     /* Fill in with dummy values */
     entry->body.zebra_state_change.interface_index = 0;
@@ -604,15 +644,15 @@ int process_zebra_bgp_state_change(struct mstream *s,BGPDUMP_ENTRY *entry, u_int
     return 1;
   }
 
-  mstream_getw(s,&entry->body.zebra_state_change.interface_index);
-  mstream_getw(s,&entry->body.zebra_state_change.address_family);
+  mstream_getw(s, &entry->body.zebra_state_change.interface_index);
+  mstream_getw(s, &entry->body.zebra_state_change.address_family);
 
-  switch(entry->body.zebra_state_change.address_family) {
+  switch (entry->body.zebra_state_change.address_family) {
   case AFI_IP:
     // length could be 20 or 24 (asn16 vs asn32)
-    if(entry->length != 20 && entry->length != 24) {
+    if (entry->length != 20 && entry->length != 24) {
       bgpdump_warn("process_zebra_bgp_state_change: bad length %d",
-	   entry->length);
+                   entry->length);
       return 0;
     }
 
@@ -621,89 +661,102 @@ int process_zebra_bgp_state_change(struct mstream *s,BGPDUMP_ENTRY *entry, u_int
     break;
   case AFI_IP6:
     // length could be 44 or 48 (asn16 vs asn32)
-    if(entry->length != 44 && entry->length != 48) {
+    if (entry->length != 44 && entry->length != 48) {
       bgpdump_warn("process_zebra_bgp_state_change: bad length %d",
-	   entry->length);
+                   entry->length);
       return 0;
     }
 
-    mstream_get(s, &entry->body.zebra_state_change.source_ip.v6_addr.s6_addr, 16);
-    mstream_get(s, &entry->body.zebra_state_change.destination_ip.v6_addr.s6_addr, 16);
+    mstream_get(s, &entry->body.zebra_state_change.source_ip.v6_addr.s6_addr,
+                16);
+    mstream_get(
+      s, &entry->body.zebra_state_change.destination_ip.v6_addr.s6_addr, 16);
     break;
   default:
     bgpdump_warn("process_zebra_bgp_state_change: unknown AFI %d",
-	 entry->body.zebra_state_change.address_family);
+                 entry->body.zebra_state_change.address_family);
     return 0;
   }
-  mstream_getw(s,&entry->body.zebra_state_change.old_state);
-  mstream_getw(s,&entry->body.zebra_state_change.new_state);
+  mstream_getw(s, &entry->body.zebra_state_change.old_state);
+  mstream_getw(s, &entry->body.zebra_state_change.new_state);
 
   return 1;
 }
 
-int process_zebra_bgp_message(struct mstream *s,BGPDUMP_ENTRY *entry, u_int8_t asn_len) {
+int process_zebra_bgp_message(struct mstream *s, BGPDUMP_ENTRY *entry,
+                              u_int8_t asn_len)
+{
   u_char marker[16]; /* BGP marker */
 
   read_asn(s, &entry->body.zebra_message.source_as, asn_len);
   read_asn(s, &entry->body.zebra_message.destination_as, asn_len);
-  mstream_getw(s,&entry->body.zebra_message.interface_index);
-  mstream_getw(s,&entry->body.zebra_message.address_family);
+  mstream_getw(s, &entry->body.zebra_message.interface_index);
+  mstream_getw(s, &entry->body.zebra_message.address_family);
 
   entry->body.zebra_message.opt_len = 0;
   entry->body.zebra_message.opt_data = NULL;
   entry->body.zebra_message.notify_len = 0;
   entry->body.zebra_message.notify_data = NULL;
 
-  switch(entry->body.zebra_message.address_family) {
+  switch (entry->body.zebra_message.address_family) {
   case AFI_IP:
     entry->body.zebra_message.source_ip.v4_addr = mstream_get_ipv4(s);
     entry->body.zebra_message.destination_ip.v4_addr = mstream_get_ipv4(s);
-    mstream_get (s, marker, 16);
+    mstream_get(s, marker, 16);
     break;
   case AFI_IP6:
-    mstream_get(s,&entry->body.zebra_message.source_ip.v6_addr.s6_addr, 16);
-    mstream_get(s,&entry->body.zebra_message.destination_ip.v6_addr.s6_addr, 16);
-    mstream_get (s, marker, 16);
+    mstream_get(s, &entry->body.zebra_message.source_ip.v6_addr.s6_addr, 16);
+    mstream_get(s, &entry->body.zebra_message.destination_ip.v6_addr.s6_addr,
+                16);
+    mstream_get(s, marker, 16);
     break;
   case 0xFFFF:
     /* Zebra doesn't dump ifindex or src/dest IPs in OPEN
      * messages. Work around it. */
     if (entry->body.zebra_message.interface_index == 0xFFFF) {
       memset(marker, 0xFF, 4);
-      mstream_get (s, marker + 4, 12);
+      mstream_get(s, marker + 4, 12);
       entry->body.zebra_message.interface_index = 0;
       entry->body.zebra_message.address_family = AFI_IP;
       entry->body.zebra_message.source_ip.v4_addr.s_addr = 0;
       entry->body.zebra_message.destination_ip.v4_addr.s_addr = 0;
       break;
     }
-    /* Note fall through! If we don't recognize this type of data corruption, we say
-     * the address family is unsupported (since FFFF is not a valid address family) */
+  /* Note fall through! If we don't recognize this type of data corruption, we
+   * say
+   * the address family is unsupported (since FFFF is not a valid address
+   * family) */
   default:
     /* unsupported address family */
     bgpdump_warn("process_zebra_bgp_message: unsupported AFI %d",
-	 entry->body.zebra_message.address_family);
+                 entry->body.zebra_message.address_family);
     return 0;
   }
 
-  if(memcmp(marker, "\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", 16) != 0) {
+  if (memcmp(marker,
+             "\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377",
+             16) != 0) {
     /* bad marker... ignore packet */
-    bgpdump_warn(
-	 "bgp_message: bad marker: %02x.%02x.%02x.%02x.%02x.%02x.%02x.%02x.%02x.%02x.%02x.%02x.%02x.%02x.%02x.%02x",
-	 marker[0],marker[1],marker[2],marker[3],marker[4],marker[5],marker[6],marker[7],
-	 marker[8],marker[9],marker[10],marker[11],marker[12],marker[13],marker[14],marker[15]);
+    bgpdump_warn("bgp_message: bad marker: "
+                 "%02x.%02x.%02x.%02x.%02x.%02x.%02x.%02x.%02x.%02x.%02x.%02x.%"
+                 "02x.%02x.%02x.%02x",
+                 marker[0], marker[1], marker[2], marker[3], marker[4],
+                 marker[5], marker[6], marker[7], marker[8], marker[9],
+                 marker[10], marker[11], marker[12], marker[13], marker[14],
+                 marker[15]);
     return 0;
   }
 
-  mstream_getw(s,&entry->body.zebra_message.size);
-    
-  int expected = entry->body.zebra_message.size - sizeof(marker) - sizeof(u_int16_t);
-    
+  mstream_getw(s, &entry->body.zebra_message.size);
+
+  int expected =
+    entry->body.zebra_message.size - sizeof(marker) - sizeof(u_int16_t);
+
   mstream_t copy = mstream_copy(s, expected);
-    
+
   entry->body.zebra_message.cut_bytes = expected - mstream_can_read(&copy);
 
-  switch(mstream_getc (&copy, &entry->body.zebra_message.type)) {
+  switch (mstream_getc(&copy, &entry->body.zebra_message.type)) {
   case BGP_MSG_OPEN:
     return process_zebra_bgp_message_open(&copy, entry, asn_len);
   case BGP_MSG_UPDATE:
@@ -723,143 +776,160 @@ int process_zebra_bgp_message(struct mstream *s,BGPDUMP_ENTRY *entry, u_int8_t a
     return 0;
   default:
     bgpdump_warn("bgp_message: unknown BGP message type %d",
-		 entry->body.zebra_message.type);
+                 entry->body.zebra_message.type);
     return 0;
   }
 }
 
-int process_zebra_bgp_message_notify(struct mstream *s, BGPDUMP_ENTRY *entry) {
+int process_zebra_bgp_message_notify(struct mstream *s, BGPDUMP_ENTRY *entry)
+{
   mstream_getc(s, &entry->body.zebra_message.error_code);
   mstream_getc(s, &entry->body.zebra_message.sub_error_code);
   entry->body.zebra_message.notify_len = entry->body.zebra_message.size - 21;
 
-  if(entry->body.zebra_message.notify_len > 0) {
-    entry->body.zebra_message.notify_data = malloc(entry->body.zebra_message.notify_len);
-    mstream_get(s, entry->body.zebra_message.notify_data, entry->body.zebra_message.notify_len);
+  if (entry->body.zebra_message.notify_len > 0) {
+    entry->body.zebra_message.notify_data =
+      malloc(entry->body.zebra_message.notify_len);
+    mstream_get(s, entry->body.zebra_message.notify_data,
+                entry->body.zebra_message.notify_len);
   }
 
   return 1;
 }
 
-int process_zebra_bgp_message_open(struct mstream *s, BGPDUMP_ENTRY *entry, u_int8_t asn_len) {
+int process_zebra_bgp_message_open(struct mstream *s, BGPDUMP_ENTRY *entry,
+                                   u_int8_t asn_len)
+{
   mstream_getc(s, &entry->body.zebra_message.version);
   read_asn(s, &entry->body.zebra_message.my_as, asn_len);
   mstream_getw(s, &entry->body.zebra_message.hold_time);
   entry->body.zebra_message.bgp_id = mstream_get_ipv4(s);
   mstream_getc(s, &entry->body.zebra_message.opt_len);
 
-  if(entry->body.zebra_message.opt_len) {
-    entry->body.zebra_message.opt_data = malloc(entry->body.zebra_message.opt_len);
-    mstream_get(s, entry->body.zebra_message.opt_data, entry->body.zebra_message.opt_len);
+  if (entry->body.zebra_message.opt_len) {
+    entry->body.zebra_message.opt_data =
+      malloc(entry->body.zebra_message.opt_len);
+    mstream_get(s, entry->body.zebra_message.opt_data,
+                entry->body.zebra_message.opt_len);
   }
 
   return 1;
 }
 
-int process_zebra_bgp_message_update(struct mstream *s, BGPDUMP_ENTRY *entry, u_int8_t asn_len) {
+int process_zebra_bgp_message_update(struct mstream *s, BGPDUMP_ENTRY *entry,
+                                     u_int8_t asn_len)
+{
   entry->body.zebra_message.incomplete.orig_len = 0;
 
   mstream_t withdraw_stream = mstream_copy(s, mstream_getw(s, NULL));
-  entry->body.zebra_message.withdraw_count = read_prefix_list(&withdraw_stream, AFI_IP,
-							      entry->body.zebra_message.withdraw,
-							      &entry->body.zebra_message.incomplete);
+  entry->body.zebra_message.withdraw_count = read_prefix_list(
+    &withdraw_stream, AFI_IP, entry->body.zebra_message.withdraw,
+    &entry->body.zebra_message.incomplete);
 
-  entry->attr = process_attributes(s, asn_len, &entry->body.zebra_message.incomplete);
+  entry->attr =
+    process_attributes(s, asn_len, &entry->body.zebra_message.incomplete);
 
-  entry->body.zebra_message.announce_count = read_prefix_list(s, AFI_IP, 
-							      entry->body.zebra_message.announce,
-							      &entry->body.zebra_message.incomplete);
+  entry->body.zebra_message.announce_count =
+    read_prefix_list(s, AFI_IP, entry->body.zebra_message.announce,
+                     &entry->body.zebra_message.incomplete);
 
   return 1;
 }
 
-int process_zebra_bgp_entry(struct mstream *s, BGPDUMP_ENTRY *entry) {
+int process_zebra_bgp_entry(struct mstream *s, BGPDUMP_ENTRY *entry)
+{
   bgpdump_warn("process_zebra_bgp_entry: record type not implemented yet");
   return 0;
 }
 
-int process_zebra_bgp_snapshot(struct mstream *s, BGPDUMP_ENTRY *entry) {
+int process_zebra_bgp_snapshot(struct mstream *s, BGPDUMP_ENTRY *entry)
+{
   bgpdump_warn("process_zebra_bgp_snapshot: record type not implemented yet");
   return 0;
 }
 
-static attributes_t *attr_init(struct mstream *s, int len) {
+static attributes_t *attr_init(struct mstream *s, int len)
+{
 
   attributes_t *attr = malloc(sizeof(struct attr));
-    
-  attr->data=malloc(len);
+
+  attr->data = malloc(len);
   memcpy(attr->data, &s->start[s->position], len);
-    
+
   attr->len = len;
-  attr->flag			= 0;
-  attr->origin		= -1;
-  attr->nexthop.s_addr	= INADDR_NONE;
-  attr->med			= -1;
-  attr->local_pref		= -1;
-  attr->aggregator_as		= -1;
+  attr->flag = 0;
+  attr->origin = -1;
+  attr->nexthop.s_addr = INADDR_NONE;
+  attr->med = -1;
+  attr->local_pref = -1;
+  attr->aggregator_as = -1;
   attr->aggregator_addr.s_addr = INADDR_NONE;
-  attr->weight		= -1;
+  attr->weight = -1;
 
-  attr->originator_id.s_addr	= -1;
-  attr->cluster		= NULL;
+  attr->originator_id.s_addr = -1;
+  attr->cluster = NULL;
 
-  attr->aspath			= NULL;
-  attr->community		= NULL;
-  attr->transit		= NULL;
-  attr->mp_info		= calloc(1, sizeof(struct mp_info));;
+  attr->aspath = NULL;
+  attr->community = NULL;
+  attr->transit = NULL;
+  attr->mp_info = calloc(1, sizeof(struct mp_info));
+  ;
 
   attr->unknown_num = 0;
   attr->unknown = NULL;
 
-  attr->new_aspath		= NULL;
-  attr->old_aspath		= NULL;
-  attr->new_aggregator_as	= -1;
+  attr->new_aspath = NULL;
+  attr->old_aspath = NULL;
+  attr->new_aggregator_as = -1;
   attr->new_aggregator_addr.s_addr = INADDR_NONE;
-    
+
   return attr;
 }
 
-static void process_unknown_attr(struct mstream *s, attributes_t *attr, int flag, int type, int len) {
+static void process_unknown_attr(struct mstream *s, attributes_t *attr,
+                                 int flag, int type, int len)
+{
   /* Unknown attribute. Save as is */
   attr->unknown_num++;
-  attr->unknown = realloc(attr->unknown, attr->unknown_num * sizeof(struct unknown_attr));
-    
+  attr->unknown =
+    realloc(attr->unknown, attr->unknown_num * sizeof(struct unknown_attr));
+
   /* Pointer to the unknown attribute we want to fill in */
   struct unknown_attr unknown = {
-    .flag = flag,
-    .type = type,
-    .len = len,
-    .raw = malloc(len)
-  };
-    
+    .flag = flag, .type = type, .len = len, .raw = malloc(len)};
+
   attr->unknown[attr->unknown_num - 1] = unknown;
-    
+
   mstream_get(s, unknown.raw, len);
 }
 
-static void process_one_attr(struct mstream *outer_stream, attributes_t *attr, u_int8_t asn_len, struct zebra_incomplete *incomplete) {
+static void process_one_attr(struct mstream *outer_stream, attributes_t *attr,
+                             u_int8_t asn_len,
+                             struct zebra_incomplete *incomplete)
+{
   int flag = mstream_getc(outer_stream, NULL);
   int type = mstream_getc(outer_stream, NULL);
   int len;
-    
-  if(flag & BGP_ATTR_FLAG_EXTLEN)
-    len = mstream_getw(outer_stream,NULL);
-  else
-    len = mstream_getc(outer_stream,NULL);    
 
-  //info("flag:%-2i type:%-2i length:%i", flag, type, len);
+  if (flag & BGP_ATTR_FLAG_EXTLEN)
+    len = mstream_getw(outer_stream, NULL);
+  else
+    len = mstream_getc(outer_stream, NULL);
+
+  // info("flag:%-2i type:%-2i length:%i", flag, type, len);
 
   mstream_t ms = mstream_copy(outer_stream, len), *s = &ms;
-  if(mstream_can_read(s) != len) {
-    bgpdump_warn("ERROR attribute is truncated: expected=%u remaining=%u\n", len, mstream_can_read(s));
+  if (mstream_can_read(s) != len) {
+    bgpdump_warn("ERROR attribute is truncated: expected=%u remaining=%u\n",
+                 len, mstream_can_read(s));
     return;
   }
-    
+
   /* Take note of all attributes, including unknown ones */
-  if(type <= sizeof(attr->flag) * 8)
+  if (type <= sizeof(attr->flag) * 8)
     attr->flag |= ATTR_FLAG_BIT(type);
-        
-  switch(type) {
+
+  switch (type) {
   case BGP_ATTR_MP_REACH_NLRI:
     process_mp_announce(s, attr->mp_info, incomplete);
     break;
@@ -871,7 +941,7 @@ static void process_one_attr(struct mstream *outer_stream, attributes_t *attr, u
     attr->origin = mstream_getc(s, NULL);
     break;
   case BGP_ATTR_AS_PATH:
-    assert(! attr->aspath);
+    assert(!attr->aspath);
     attr->aspath = create_aspath(len, asn_len);
     mstream_get(s, attr->aspath->data, len);
     /*process_attr_aspath_string(attr->aspath);*/
@@ -882,33 +952,33 @@ static void process_one_attr(struct mstream *outer_stream, attributes_t *attr, u
     break;
   case BGP_ATTR_MULTI_EXIT_DISC:
     assert(-1 == attr->med);
-    mstream_getl(s,&attr->med);
+    mstream_getl(s, &attr->med);
     break;
   case BGP_ATTR_LOCAL_PREF:
     assert(-1 == attr->local_pref);
-    mstream_getl(s,&attr->local_pref);
+    mstream_getl(s, &attr->local_pref);
     break;
   case BGP_ATTR_ATOMIC_AGGREGATE:
     break;
   case BGP_ATTR_AGGREGATOR:
     // wrong aggregator as was checked here
-    assert(-1 == attr->aggregator_as);    
+    assert(-1 == attr->aggregator_as);
     read_asn(s, &attr->aggregator_as, asn_len);
     attr->aggregator_addr = mstream_get_ipv4(s);
     break;
   case BGP_ATTR_COMMUNITIES:
-    assert(! attr->community);
-    attr->community		= malloc(sizeof(struct community));
-    attr->community->size	= len / 4;
-    attr->community->val	= malloc(len);
-    mstream_get(s,attr->community->val,len);
-    attr->community->str	= NULL;
+    assert(!attr->community);
+    attr->community = malloc(sizeof(struct community));
+    attr->community->size = len / 4;
+    attr->community->val = malloc(len);
+    mstream_get(s, attr->community->val, len);
+    attr->community->str = NULL;
     /*process_attr_community_string(attr->community);*/
     break;
   case BGP_ATTR_NEW_AS_PATH:
-    assert(! attr->new_aspath);
+    assert(!attr->new_aspath);
     attr->new_aspath = create_aspath(len, ASN32_LEN);
-    mstream_get(s,attr->new_aspath->data, len);
+    mstream_get(s, attr->new_aspath->data, len);
     /*process_attr_aspath_string(attr->new_aspath);*/
     /* AS_CONFED_SEQUENCE and AS_CONFED_SET segments invalid in NEW_AS_PATH */
     check_new_aspath(attr->new_aspath);
@@ -923,57 +993,63 @@ static void process_one_attr(struct mstream *outer_stream, attributes_t *attr, u
     attr->originator_id = mstream_get_ipv4(s);
     break;
   case BGP_ATTR_CLUSTER_LIST:
-    assert(! attr->cluster);
-    attr->cluster		= malloc(sizeof(struct cluster_list));
-    attr->cluster->length	= len/4;
-    attr->cluster->list = malloc((attr->cluster->length) * sizeof(struct in_addr));
-            
+    assert(!attr->cluster);
+    attr->cluster = malloc(sizeof(struct cluster_list));
+    attr->cluster->length = len / 4;
+    attr->cluster->list =
+      malloc((attr->cluster->length) * sizeof(struct in_addr));
+
     int i; // cluster index
     for (i = 0; i < attr->cluster->length; i++)
       attr->cluster->list[i] = mstream_get_ipv4(s);
     break;
   default:
     process_unknown_attr(s, attr, flag, type, len);
-  }    
+  }
 }
 
-attributes_t *process_attributes(struct mstream *s, u_int8_t asn_len, struct zebra_incomplete *incomplete) {
-  int	total = mstream_getw(s, NULL);
-    
+attributes_t *process_attributes(struct mstream *s, u_int8_t asn_len,
+                                 struct zebra_incomplete *incomplete)
+{
+  int total = mstream_getw(s, NULL);
+
   attributes_t *attr = attr_init(s, total);
   mstream_t copy = mstream_copy(s, total);
 
-  if(mstream_can_read(&copy) != total)
-    bgpdump_warn("entry is truncated: expected=%u remaining=%u", total, mstream_can_read(&copy));
-    
-  while(mstream_can_read(&copy))
+  if (mstream_can_read(&copy) != total)
+    bgpdump_warn("entry is truncated: expected=%u remaining=%u", total,
+                 mstream_can_read(&copy));
+
+  while (mstream_can_read(&copy))
     process_one_attr(&copy, attr, asn_len, incomplete);
-    
+
   // Once all attributes have been read, take care of ASN32 transition
   process_asn32_trans(attr, asn_len);
-    
+
   return attr;
 }
 
-struct aspath *create_aspath(u_int16_t len, u_int8_t asn_len) {
+struct aspath *create_aspath(u_int16_t len, u_int8_t asn_len)
+{
   struct aspath *aspath = malloc(sizeof(struct aspath));
-  if(aspath) {
-    aspath->asn_len	= asn_len;
-    aspath->length	= len;
-    aspath->count	= 0;
-    aspath->str		= NULL;
-    if(len > 0)
-      aspath->data	= malloc(len);
+  if (aspath) {
+    aspath->asn_len = asn_len;
+    aspath->length = len;
+    aspath->count = 0;
+    aspath->str = NULL;
+    if (len > 0)
+      aspath->data = malloc(len);
     else
-      aspath->data	= NULL;
+      aspath->data = NULL;
   }
   return aspath;
 }
 
-void aspath_error(struct aspath *as) {
+void aspath_error(struct aspath *as)
+{
   as->count = 0;
 
-  if(as->str) {
+  if (as->str) {
     free(as->str);
     as->str = NULL;
   }
@@ -984,7 +1060,8 @@ void aspath_error(struct aspath *as) {
 
 /* AK adds buildstring flag as this func is used by bgpdump just to get the
    number of hops (as->count) */
-void process_attr_aspath_string(struct aspath *as, int buildstring) {
+void process_attr_aspath_string(struct aspath *as, int buildstring)
+{
 
   const int MAX_ASPATH_LEN = 8000;
 
@@ -1003,7 +1080,7 @@ void process_attr_aspath_string(struct aspath *as, int buildstring) {
   int space = 0;
   u_char type = AS_SEQUENCE;
   int pos = 0;
-    
+
   /* Set initial pointer. */
   caddr_t pnt = as->data;
   caddr_t end = pnt + as->length;
@@ -1011,49 +1088,45 @@ void process_attr_aspath_string(struct aspath *as, int buildstring) {
 
   u_int16_t tmp16;
   u_int32_t tmp32;
-    
+
   int i;
   while (pnt < end) {
-    
-    /* For fetch value. */
-    segment = (struct assegment *) pnt;
 
-    
+    /* For fetch value. */
+    segment = (struct assegment *)pnt;
+
     /* Check AS type validity. */
-    if ((segment->type != AS_SET) &&
-	(segment->type != AS_SEQUENCE) &&
-	(segment->type != AS_CONFED_SET) &&
-	(segment->type != AS_CONFED_SEQUENCE))
-      {
-	aspath_error(as);
-	return;
-      }
+    if ((segment->type != AS_SET) && (segment->type != AS_SEQUENCE) &&
+        (segment->type != AS_CONFED_SET) &&
+        (segment->type != AS_CONFED_SEQUENCE)) {
+      aspath_error(as);
+      return;
+    }
 
     /* Check AS length. */
-    if ((pnt + (segment->length * as->asn_len) + AS_HEADER_SIZE) > end)
-      {
-	aspath_error(as);
-	return;
-      }
+    if ((pnt + (segment->length * as->asn_len) + AS_HEADER_SIZE) > end) {
+      aspath_error(as);
+      return;
+    }
 
     if (buildstring) {
       /* If segment type is changed, print previous type's end
          character. */
       if (type != AS_SEQUENCE)
-        as->str[pos++] = aspath_delimiter_char (type, AS_SEG_END);
+        as->str[pos++] = aspath_delimiter_char(type, AS_SEG_END);
 
       if (space)
         as->str[pos++] = ' ';
 
       if (segment->type != AS_SEQUENCE)
-        as->str[pos++] = aspath_delimiter_char (segment->type, AS_SEG_START);
+        as->str[pos++] = aspath_delimiter_char(segment->type, AS_SEG_START);
 
       space = 0;
     }
 
     /* Increment as->count - NOT ignoring CONFED_SETS/SEQUENCES any more.
        I doubt anybody was relying on this behaviour anyway. */
-    switch(segment->type) {
+    switch (segment->type) {
     case AS_SEQUENCE:
     case AS_CONFED_SEQUENCE:
       as->count += segment->length;
@@ -1065,42 +1138,38 @@ void process_attr_aspath_string(struct aspath *as, int buildstring) {
     }
 
     if (buildstring) {
-      for (i = 0; i < segment->length; i++)
-        {
-          as_t asn;
+      for (i = 0; i < segment->length; i++) {
+        as_t asn;
 
-          if (space)
-            {
-              if (segment->type == AS_SET
-                  || segment->type == AS_CONFED_SET)
-                as->str[pos++] = ',';
-              else
-                as->str[pos++] = ' ';
-            }
+        if (space) {
+          if (segment->type == AS_SET || segment->type == AS_CONFED_SET)
+            as->str[pos++] = ',';
           else
-            space = 1;
+            as->str[pos++] = ' ';
+        } else
+          space = 1;
 
-          int asn_pos = i * as->asn_len;
-          switch(as->asn_len) {
-          case ASN16_LEN:
-            memcpy(&tmp16, segment->data+asn_pos, sizeof(u_int16_t));
-            asn = ntohs (tmp16);
-            break;
-          case ASN32_LEN:
-            memcpy(&tmp32, segment->data+asn_pos, sizeof(u_int32_t));
-            asn = ntohl (tmp32);
-            break;
-          default:
-            assert("invalid asn_len" && false);
-            return;
-          }
-
-          pos += bgpdump_int2str(asn, as->str + pos);
-          if(pos > MAX_ASPATH_LEN - 100) {
-            strcpy(as->str + pos, "...");
-            return;
-          };
+        int asn_pos = i * as->asn_len;
+        switch (as->asn_len) {
+        case ASN16_LEN:
+          memcpy(&tmp16, segment->data + asn_pos, sizeof(u_int16_t));
+          asn = ntohs(tmp16);
+          break;
+        case ASN32_LEN:
+          memcpy(&tmp32, segment->data + asn_pos, sizeof(u_int32_t));
+          asn = ntohl(tmp32);
+          break;
+        default:
+          assert("invalid asn_len" && false);
+          return;
         }
+
+        pos += bgpdump_int2str(asn, as->str + pos);
+        if (pos > MAX_ASPATH_LEN - 100) {
+          strcpy(as->str + pos, "...");
+          return;
+        };
+      }
     }
 
     type = segment->type;
@@ -1109,44 +1178,39 @@ void process_attr_aspath_string(struct aspath *as, int buildstring) {
 
   if (buildstring) {
     if (segment && segment->type != AS_SEQUENCE)
-      as->str[pos++] = aspath_delimiter_char (segment->type, AS_SEG_END);
+      as->str[pos++] = aspath_delimiter_char(segment->type, AS_SEG_END);
 
     as->str[pos] = '\0';
   }
 }
 
-char aspath_delimiter_char (u_char type, u_char which) {
+char aspath_delimiter_char(u_char type, u_char which)
+{
   int i;
-  struct
-  {
+  struct {
     int type;
     char start;
     char end;
-  } aspath_delim_char [] =
-      {
-	{ AS_SET,             '{', '}' },
-	{ AS_SEQUENCE,        ' ', ' ' },
-	{ AS_CONFED_SET,      '[', ']' },
-	{ AS_CONFED_SEQUENCE, '(', ')' },
-	{ 0, '\0', '\0' }
-      };
+  } aspath_delim_char[] = {{AS_SET, '{', '}'},
+                           {AS_SEQUENCE, ' ', ' '},
+                           {AS_CONFED_SET, '[', ']'},
+                           {AS_CONFED_SEQUENCE, '(', ')'},
+                           {0, '\0', '\0'}};
 
-  for (i = 0; aspath_delim_char[i].type != 0; i++)
-    {
-      if (aspath_delim_char[i].type == type)
-	{
-	  if (which == AS_SEG_START)
-	    return aspath_delim_char[i].start;
-	  else if (which == AS_SEG_END)
-	    return aspath_delim_char[i].end;
-	}
+  for (i = 0; aspath_delim_char[i].type != 0; i++) {
+    if (aspath_delim_char[i].type == type) {
+      if (which == AS_SEG_START)
+        return aspath_delim_char[i].start;
+      else if (which == AS_SEG_END)
+        return aspath_delim_char[i].end;
     }
+  }
   return ' ';
 }
 
-
-void process_attr_community_string(struct community *com) {
-  if(com == NULL) {
+void process_attr_community_string(struct community *com)
+{
+  if (com == NULL) {
     return;
   }
 
@@ -1156,82 +1220,86 @@ void process_attr_community_string(struct community *com) {
   u_int16_t as;
   u_int16_t val;
 
-  memset (buf, 0, BUFSIZ);
+  memset(buf, 0, BUFSIZ);
 
-  for (i = 0; i < com->size; i++)
-    {
-      memcpy (&comval, com_nthval (com, i), sizeof (u_int32_t));
-      comval = ntohl (comval);
-      switch (comval)
-	{
-	case COMMUNITY_NO_EXPORT:
-	  strlcat (buf, " no-export", BUFSIZ);
-	  break;
-	case COMMUNITY_NO_ADVERTISE:
-	  strlcat (buf, " no-advertise", BUFSIZ);
-	  break;
-	case COMMUNITY_LOCAL_AS:
-	  strlcat (buf, " local-AS", BUFSIZ);
-	  break;
-	default:
-	  as = (comval >> 16) & 0xFFFF;
-	  val = comval & 0xFFFF;
-	  snprintf (buf + strlen (buf), BUFSIZ - strlen (buf),
-		    " %d:%d", as, val);
-	  break;
-	}
+  for (i = 0; i < com->size; i++) {
+    memcpy(&comval, com_nthval(com, i), sizeof(u_int32_t));
+    comval = ntohl(comval);
+    switch (comval) {
+    case COMMUNITY_NO_EXPORT:
+      strlcat(buf, " no-export", BUFSIZ);
+      break;
+    case COMMUNITY_NO_ADVERTISE:
+      strlcat(buf, " no-advertise", BUFSIZ);
+      break;
+    case COMMUNITY_LOCAL_AS:
+      strlcat(buf, " local-AS", BUFSIZ);
+      break;
+    default:
+      as = (comval >> 16) & 0xFFFF;
+      val = comval & 0xFFFF;
+      snprintf(buf + strlen(buf), BUFSIZ - strlen(buf), " %d:%d", as, val);
+      break;
     }
+  }
 
-  com->str = malloc(strlen(buf)+1);
+  com->str = malloc(strlen(buf) + 1);
   strcpy(com->str, buf);
 }
 
-static struct mp_nlri *get_nexthop(struct mstream *s, u_int16_t afi) {
+static struct mp_nlri *get_nexthop(struct mstream *s, u_int16_t afi)
+{
   struct mp_nlri *nlri = calloc(1, sizeof(struct mp_nlri));
-    
+
   nlri->nexthop_len = mstream_getc(s, NULL);
-    
+
   // sometimes nexthop_len is 0 - not sure what this means (see IS-626)
   // if(mp_nlri->nexthop_len == 0)
   //    return len;
 
-  if(afi == AFI_IP) {
+  if (afi == AFI_IP) {
     assert(nlri->nexthop_len == 4);
     nlri->nexthop.v4_addr = mstream_get_ipv4(s);
     return nlri;
   }
   assert(afi == AFI_IP6);
   mstream_get(s, &nlri->nexthop.v6_addr, 16);
-  if(nlri->nexthop_len == 32) {
+  if (nlri->nexthop_len == 32) {
     /* Is there also a link-local address? */
     mstream_get(s, &nlri->nexthop_local.v6_addr.s6_addr, 16);
-  } else if(nlri->nexthop_len != 16) {
-    bgpdump_warn("process_mp_announce: unknown MP nexthop length %d", nlri->nexthop_len);
+  } else if (nlri->nexthop_len != 16) {
+    bgpdump_warn("process_mp_announce: unknown MP nexthop length %d",
+                 nlri->nexthop_len);
   }
   return nlri;
 }
 
-void process_mp_announce(struct mstream *s, struct mp_info *info, struct zebra_incomplete *incomplete) {
+void process_mp_announce(struct mstream *s, struct mp_info *info,
+                         struct zebra_incomplete *incomplete)
+{
   u_int16_t afi;
   u_int8_t safi;
 
   // look for MRT abbreviated MP_NLRI packets
-  if(s->start[s->position] != 0) {
+  if (s->start[s->position] != 0) {
     assert(info->announce[AFI_IP6][SAFI_UNICAST] == NULL);
     info->announce[AFI_IP6][SAFI_UNICAST] = get_nexthop(s, AFI_IP6);
     return;
   }
-    
+
   mstream_getw(s, &afi);
   mstream_getc(s, &safi);
-        
-  if(afi > BGPDUMP_MAX_AFI || safi > BGPDUMP_MAX_SAFI) {
-    bgpdump_warn("process_mp_announce: unknown protocol(AFI=%d, SAFI=%d)!", afi, safi);
+
+  if (afi > BGPDUMP_MAX_AFI || safi > BGPDUMP_MAX_SAFI) {
+    bgpdump_warn("process_mp_announce: unknown protocol(AFI=%d, SAFI=%d)!", afi,
+                 safi);
     return;
   }
 
-  if(info->announce[afi][safi] != NULL) {
-    bgpdump_warn("process_mp_announce: two MP_NLRI for the same protocol(%d, %d)!", afi, safi);
+  if (info->announce[afi][safi] != NULL) {
+    bgpdump_warn(
+      "process_mp_announce: two MP_NLRI for the same protocol(%d, %d)!", afi,
+      safi);
     return;
   }
 
@@ -1239,16 +1307,19 @@ void process_mp_announce(struct mstream *s, struct mp_info *info, struct zebra_i
 
   // SNPA is defunct and num_snpa should always be 0
   u_int8_t num_snpa;
-  if(mstream_getc(s, &num_snpa))
+  if (mstream_getc(s, &num_snpa))
     bgpdump_warn("process_mp_announce: MP_NLRI contains SNPAs, skipping");
-  for(; num_snpa > 0; --num_snpa) {
+  for (; num_snpa > 0; --num_snpa) {
     mstream_get(s, NULL, mstream_getc(s, NULL));
   }
 
-  info->announce[afi][safi]->prefix_count = read_prefix_list(s, afi, info->announce[afi][safi]->nlri, incomplete);
+  info->announce[afi][safi]->prefix_count =
+    read_prefix_list(s, afi, info->announce[afi][safi]->nlri, incomplete);
 }
 
-void process_mp_withdraw(struct mstream *s, struct mp_info *info, struct zebra_incomplete *incomplete) {
+void process_mp_withdraw(struct mstream *s, struct mp_info *info,
+                         struct zebra_incomplete *incomplete)
+{
   u_int16_t afi;
   u_int8_t safi;
   struct mp_nlri *mp_nlri;
@@ -1257,14 +1328,16 @@ void process_mp_withdraw(struct mstream *s, struct mp_info *info, struct zebra_i
   mstream_getc(s, &safi);
 
   /* Do we know about this address family? */
-  if(afi > BGPDUMP_MAX_AFI || safi > BGPDUMP_MAX_SAFI) {
+  if (afi > BGPDUMP_MAX_AFI || safi > BGPDUMP_MAX_SAFI) {
     bgpdump_warn("process_mp_withdraw: unknown AFI,SAFI %d,%d!", afi, safi);
     return;
   }
 
   /* If there are 2 NLRI's for the same protocol, fail but don't burn and die */
-  if(info->withdraw[afi][safi] != NULL) {
-    bgpdump_warn("process_mp_withdraw: update contains more than one MP_NLRI with AFI,SAFI %d,%d!", afi, safi);
+  if (info->withdraw[afi][safi] != NULL) {
+    bgpdump_warn("process_mp_withdraw: update contains more than one MP_NLRI "
+                 "with AFI,SAFI %d,%d!",
+                 afi, safi);
     return;
   }
 
@@ -1276,56 +1349,58 @@ void process_mp_withdraw(struct mstream *s, struct mp_info *info, struct zebra_i
   mp_nlri->prefix_count = read_prefix_list(s, afi, mp_nlri->nlri, incomplete);
 }
 
-static int read_prefix_list(struct mstream *s, u_int16_t afi, struct prefix *prefixes, struct zebra_incomplete *incomplete) {
+static int read_prefix_list(struct mstream *s, u_int16_t afi,
+                            struct prefix *prefixes,
+                            struct zebra_incomplete *incomplete)
+{
   int count = 0;
-    
-  while(mstream_can_read(s)) {
-    u_int8_t p_len = mstream_getc(s,NULL); // length in bits
+
+  while (mstream_can_read(s)) {
+    u_int8_t p_len = mstream_getc(s, NULL); // length in bits
     u_int8_t p_bytes = (p_len + 7) / 8;
-        
+
     /* Truncated prefix list? */
-    if(mstream_can_read(s) < p_bytes) {
-      if(! incomplete)
-	break;
-            
+    if (mstream_can_read(s) < p_bytes) {
+      if (!incomplete)
+        break;
+
       /* Put prefix in incomplete structure */
       incomplete->afi = afi;
       incomplete->orig_len = p_len;
-      incomplete->prefix = (struct prefix) {
-	.len = mstream_can_read(s) * 8
-      };
+      incomplete->prefix = (struct prefix){.len = mstream_can_read(s) * 8};
       mstream_get(s, &incomplete->prefix.address, p_bytes);
       break;
     }
-        
+
     struct prefix *prefix = prefixes + count;
-        
-    if(count++ > MAX_PREFIXES)
+
+    if (count++ > MAX_PREFIXES)
       continue;
 
-    *prefix = (struct prefix) { .len = p_len };
+    *prefix = (struct prefix){.len = p_len};
     mstream_get(s, &prefix->address, p_bytes);
   }
-    
-  if(count > MAX_PREFIXES) {
+
+  if (count > MAX_PREFIXES) {
     bgpdump_err("too many prefixes (%i > %i)", count, MAX_PREFIXES);
     assert(0); // AK adds to force a fatal error
     return MAX_PREFIXES;
   }
-    
+
   return count;
 }
 
-static as_t read_asn(struct mstream *s, as_t *asn, u_int8_t len) {
+static as_t read_asn(struct mstream *s, as_t *asn, u_int8_t len)
+{
   u_int16_t asn16;
 
   assert(len == sizeof(u_int32_t) || len == sizeof(u_int16_t));
-  switch(len) {
+  switch (len) {
   case sizeof(u_int32_t):
     return mstream_getl(s, asn);
   case sizeof(u_int16_t):
     mstream_getw(s, &asn16);
-    if(asn)
+    if (asn)
       *asn = asn16;
     return asn16;
   default:
@@ -1334,38 +1409,44 @@ static as_t read_asn(struct mstream *s, as_t *asn, u_int8_t len) {
   }
 }
 
-int check_new_aspath(struct aspath *aspath) {
+int check_new_aspath(struct aspath *aspath)
+{
   struct assegment *segment;
-  for(segment = (struct assegment *) aspath->data;
-      segment < (struct assegment *) (aspath->data + aspath->length);
-      segment = (struct assegment *) ((char *) segment + sizeof(*segment) + segment->length * ASN32_LEN)) {
-    if(segment->type == AS_CONFED_SEQUENCE || segment->type == AS_CONFED_SET) {
-      bgpdump_warn("check_new_aspath: invalid segment of type AS_CONFED_%s in NEW_AS_PATH",
-		   segment->type == AS_CONFED_SET ? "SET" : "SEQUENCE");
+  for (segment = (struct assegment *)aspath->data;
+       segment < (struct assegment *)(aspath->data + aspath->length);
+       segment = (struct assegment *)((char *)segment + sizeof(*segment) +
+                                      segment->length * ASN32_LEN)) {
+    if (segment->type == AS_CONFED_SEQUENCE || segment->type == AS_CONFED_SET) {
+      bgpdump_warn(
+        "check_new_aspath: invalid segment of type AS_CONFED_%s in NEW_AS_PATH",
+        segment->type == AS_CONFED_SET ? "SET" : "SEQUENCE");
       return 0;
     }
   }
   return 1;
 }
 
-void process_asn32_trans(attributes_t *attr, u_int8_t asn_len) {
-  if(asn_len == ASN32_LEN) {
+void process_asn32_trans(attributes_t *attr, u_int8_t asn_len)
+{
+  if (asn_len == ASN32_LEN) {
     /* These attributes "SHOULD NOT" be used with ASN32. */
-    if(attr->flag & ATTR_FLAG_BIT(BGP_ATTR_NEW_AS_PATH))
-      bgpdump_warn("process_asn32_trans: ASN32 message contains NEW_AS_PATH attribute");
+    if (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_NEW_AS_PATH))
+      bgpdump_warn(
+        "process_asn32_trans: ASN32 message contains NEW_AS_PATH attribute");
 
-    if(attr->flag & ATTR_FLAG_BIT(BGP_ATTR_NEW_AGGREGATOR))
-      bgpdump_warn("process_asn32_trans: ASN32 message contains NEW_AGGREGATOR attribute");
+    if (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_NEW_AGGREGATOR))
+      bgpdump_warn(
+        "process_asn32_trans: ASN32 message contains NEW_AGGREGATOR attribute");
 
     /* Don't compute anything, just leave AS_PATH and AGGREGATOR as they are */
     return;
   }
 
   /* Process NEW_AGGREGATOR */
-  if(attr->flag & ATTR_FLAG_BIT(BGP_ATTR_AGGREGATOR) &&
-     attr->flag & ATTR_FLAG_BIT(BGP_ATTR_NEW_AGGREGATOR)) {
+  if (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_AGGREGATOR) &&
+      attr->flag & ATTR_FLAG_BIT(BGP_ATTR_NEW_AGGREGATOR)) {
     /* Both AGGREGATOR and NEW_AGGREGATOR present, merge */
-    if(attr->aggregator_as != AS_TRAN) {
+    if (attr->aggregator_as != AS_TRAN) {
       /* Don't do anything */
       return;
     } else {
@@ -1377,7 +1458,7 @@ void process_asn32_trans(attributes_t *attr, u_int8_t asn_len) {
   }
 
   /* Process NEW_AS_PATH */
-  if(! (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_NEW_AS_PATH)))
+  if (!(attr->flag & ATTR_FLAG_BIT(BGP_ATTR_NEW_AS_PATH)))
     return;
 
   // AK HAX: This code requries the aspath->count field to be populated. This is
@@ -1387,33 +1468,37 @@ void process_asn32_trans(attributes_t *attr, u_int8_t asn_len) {
   process_attr_aspath_string(attr->new_aspath, 0);
 
   // attr->aspath may be NULL, at least in case of MP_UNREACH_NLRI
-  if(attr->aspath == NULL) return;
-  if(attr->aspath->count < attr->new_aspath->count) {
+  if (attr->aspath == NULL)
+    return;
+  if (attr->aspath->count < attr->new_aspath->count) {
     return;
   }
 
   /* Merge paths */
   attr->old_aspath = attr->aspath;
   attr->aspath = asn32_merge_paths(attr->old_aspath, attr->new_aspath);
-  //if(attr->aspath) {
+  // if(attr->aspath) {
   //  process_attr_aspath_string(attr->aspath);
   //}
 }
 
-struct aspath *asn32_merge_paths(struct aspath *path, struct aspath *newpath) {
+struct aspath *asn32_merge_paths(struct aspath *path, struct aspath *newpath)
+{
   struct aspath *mergedpath = create_aspath(0, ASN32_LEN);
   struct assegment *segment, *mergedsegment;
   int newlen;
 
-  /* Keep copying segments from AS_PATH until our path is as long as AS_PATH - NEW_AS_PATH. */
-  segment = (struct assegment *) (path->data);
-  while(mergedpath->count < (path->count - newpath->count)) {
+  /* Keep copying segments from AS_PATH until our path is as long as AS_PATH -
+   * NEW_AS_PATH. */
+  segment = (struct assegment *)(path->data);
+  while (mergedpath->count < (path->count - newpath->count)) {
     /* Make room */
-    newlen = mergedpath->length + sizeof(struct assegment) + segment->length * ASN32_LEN;
+    newlen = mergedpath->length + sizeof(struct assegment) +
+             segment->length * ASN32_LEN;
     mergedpath->data = realloc(mergedpath->data, newlen);
 
     /* Create a new AS-path segment */
-    mergedsegment = (struct assegment *) (mergedpath->data + mergedpath->length);
+    mergedsegment = (struct assegment *)(mergedpath->data + mergedpath->length);
 
     /* Copy segment over. AS_PATH contains 16-bit ASes, so expand */
     mergedsegment->type = segment->type;
@@ -1422,42 +1507,47 @@ struct aspath *asn32_merge_paths(struct aspath *path, struct aspath *newpath) {
 
     /* Update length */
     mergedpath->length = newlen;
-    if(segment->type == AS_SET || segment->type == AS_CONFED_SET) {
+    if (segment->type == AS_SET || segment->type == AS_CONFED_SET) {
       mergedpath->count += 1;
     } else {
       mergedpath->count += segment->length;
       /* Did we copy too many ASes over? */
-      if(mergedpath->count > path->count - newpath->count) {
-	mergedsegment->length -= mergedpath->count - (path->count - newpath->count);
-	mergedpath->length -= (mergedpath->count - (path->count - newpath->count)) * ASN32_LEN;
+      if (mergedpath->count > path->count - newpath->count) {
+        mergedsegment->length -=
+          mergedpath->count - (path->count - newpath->count);
+        mergedpath->length -=
+          (mergedpath->count - (path->count - newpath->count)) * ASN32_LEN;
       }
     }
   }
 
   /* Append NEW_AS_PATH to merged path */
-  mergedpath->data = realloc(mergedpath->data, mergedpath->length + newpath->length);
+  mergedpath->data =
+    realloc(mergedpath->data, mergedpath->length + newpath->length);
   memcpy(mergedpath->data + mergedpath->length, newpath->data, newpath->length);
   mergedpath->length += newpath->length;
 
   return mergedpath;
 }
 
-void asn32_expand_16_to_32(char *dst, char *src, int len) {
-  u_int32_t *dstarray = (u_int32_t *) dst;
-  u_int16_t *srcarray = (u_int16_t *) src;
+void asn32_expand_16_to_32(char *dst, char *src, int len)
+{
+  u_int32_t *dstarray = (u_int32_t *)dst;
+  u_int16_t *srcarray = (u_int16_t *)src;
   int i;
 
-  for(i = 0; i < len; i++) {
+  for (i = 0; i < len; i++) {
     dstarray[i] = htonl(ntohs(srcarray[i]));
   }
 }
 
 #if defined(linux)
-size_t strlcat(char *dst, const char *src, size_t size) {
-  if (strlen (dst) + strlen (src) >= size)
+size_t strlcat(char *dst, const char *src, size_t size)
+{
+  if (strlen(dst) + strlen(src) >= size)
     return -1;
 
-  strcat (dst, src);
+  strcat(dst, src);
 
   return (strlen(dst));
 }

--- a/lib/bgpdump/bgpdump_lib.h
+++ b/lib/bgpdump/bgpdump_lib.h
@@ -1,6 +1,6 @@
 /*
  Copyright (c) 2007 - 2010 RIPE NCC - All Rights Reserved
- 
+
  Permission to use, copy, modify, and distribute this software and its
  documentation for any purpose and without fee is hereby granted, provided
  that the above copyright notice appear in all copies and that both that
@@ -8,14 +8,14 @@
  documentation, and that the name of the author not be used in advertising or
  publicity pertaining to distribution of the software without specific,
  written prior permission.
- 
+
  THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
  ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS; IN NO EVENT SHALL
  AUTHOR BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY
  DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
  AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- 
+
 Parts of this code have been engineered after analiyzing GNU Zebra's
 source code and therefore might contain declarations/code from GNU
 Zebra, Copyright (C) 1999 Kunihiro Ishiguro. Zebra is a free routing
@@ -28,15 +28,14 @@ Original Author: Dan Ardelean (dan@ripe.net)
 #ifndef _BGPDUMP_LIB_H
 #define _BGPDUMP_LIB_H
 
-#include <stdio.h>
 #include <stdbool.h>
-
+#include <stdio.h>
 
 #include "bgpdump_attr.h"
 #include "bgpdump_formats.h"
 
-#define BGPDUMP_MAX_FILE_LEN	1024
-#define BGPDUMP_MAX_AS_PATH_LEN	2000
+#define BGPDUMP_MAX_FILE_LEN 1024
+#define BGPDUMP_MAX_AS_PATH_LEN 2000
 
 // if you include cfile_tools.h, include it first
 #ifndef _CFILE_TOOLS_DEFINES
@@ -44,17 +43,17 @@ typedef struct _CFRFILE CFRFILE;
 #endif
 
 typedef struct struct_BGPDUMP {
-    CFRFILE	*f;
-    int		f_type;
-    int		eof;
-    char	filename[BGPDUMP_MAX_FILE_LEN];
-    int		parsed;
-    int		parsed_ok;
-    // corrupted read signals a corrupted entry found in file
-    // when a corrupted read is set eof is 1 and entry is NULL
-    bool        corrupted_read;
-  // this object used to be a global variable, now it is part of 
-  // BGPDUMP so that multiple BGPDUMP objects can be used simultaneously 
+  CFRFILE *f;
+  int f_type;
+  int eof;
+  char filename[BGPDUMP_MAX_FILE_LEN];
+  int parsed;
+  int parsed_ok;
+  // corrupted read signals a corrupted entry found in file
+  // when a corrupted read is set eof is 1 and entry is NULL
+  bool corrupted_read;
+  // this object used to be a global variable, now it is part of
+  // BGPDUMP so that multiple BGPDUMP objects can be used simultaneously
   // without collisions
   BGPDUMP_TABLE_DUMP_V2_PEER_INDEX_TABLE *table_dump_v2_peer_index_table;
 } BGPDUMP;
@@ -62,9 +61,9 @@ typedef struct struct_BGPDUMP {
 /* prototypes */
 
 BGPDUMP *bgpdump_open_dump(const char *filename);
-void	bgpdump_close_dump(BGPDUMP *dump);
-BGPDUMP_ENTRY*	bgpdump_read_next(BGPDUMP *dump);
-void	bgpdump_free_mem(BGPDUMP_ENTRY *entry);
+void bgpdump_close_dump(BGPDUMP *dump);
+BGPDUMP_ENTRY *bgpdump_read_next(BGPDUMP *dump);
+void bgpdump_free_mem(BGPDUMP_ENTRY *entry);
 
 void process_attr_aspath_string(struct aspath *as, int buildstring);
 void process_attr_community_string(struct community *com);

--- a/lib/bgpdump/bgpdump_mstream.c
+++ b/lib/bgpdump/bgpdump_mstream.c
@@ -1,6 +1,6 @@
 /*
  Copyright (c) 2007 - 2010 RIPE NCC - All Rights Reserved
- 
+
  Permission to use, copy, modify, and distribute this software and its
  documentation for any purpose and without fee is hereby granted, provided
  that the above copyright notice appear in all copies and that both that
@@ -8,14 +8,14 @@
  documentation, and that the name of the author not be used in advertising or
  publicity pertaining to distribution of the software without specific,
  written prior permission.
- 
+
  THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
  ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS; IN NO EVENT SHALL
  AUTHOR BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY
  DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
  AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- 
+
 Parts of this code have been engineered after analiyzing GNU Zebra's
 source code and therefore might contain declarations/code from GNU
 Zebra, Copyright (C) 1999 Kunihiro Ishiguro. Zebra is a free routing
@@ -25,79 +25,91 @@ this license is included with libbgpdump.
 Original Author: Dan Ardelean (dan@ripe.net)
 */
 
-#include "config.h"
 #include "bgpdump_mstream.h"
+#include "config.h"
 
+#include <netinet/in.h>
 #include <stdio.h>
 #include <string.h>
-#include <netinet/in.h>
 
-void mstream_init(struct mstream *s, u_char *buffer, u_int32_t len) {
-    s->start=buffer;
-    s->position=0;
-    s->len=len;
+void mstream_init(struct mstream *s, u_char *buffer, u_int32_t len)
+{
+  s->start = buffer;
+  s->position = 0;
+  s->len = len;
 }
 
-u_char mstream_getc(struct mstream *s, u_char *d) {
-    u_char data;
+u_char mstream_getc(struct mstream *s, u_char *d)
+{
+  u_char data;
 
-    mstream_get(s, &data, sizeof(data));
-    if(d!=NULL) memcpy(d,&data,sizeof(data));
-    return data;
+  mstream_get(s, &data, sizeof(data));
+  if (d != NULL)
+    memcpy(d, &data, sizeof(data));
+  return data;
 }
 
-u_int16_t mstream_getw(struct mstream *s, u_int16_t *d) {
-    u_int16_t data;
+u_int16_t mstream_getw(struct mstream *s, u_int16_t *d)
+{
+  u_int16_t data;
 
-    mstream_get(s, &data, sizeof(data));
-    data=ntohs(data);
-    if(d!=NULL) memcpy(d,&data,sizeof(data));
-    return data;
+  mstream_get(s, &data, sizeof(data));
+  data = ntohs(data);
+  if (d != NULL)
+    memcpy(d, &data, sizeof(data));
+  return data;
 }
 
-u_int32_t mstream_getl(struct mstream *s, u_int32_t *d) {
-    u_int32_t data;
+u_int32_t mstream_getl(struct mstream *s, u_int32_t *d)
+{
+  u_int32_t data;
 
-    mstream_get(s, &data, sizeof(data));
-    data=ntohl(data);
-    if(d!=NULL) memcpy(d,&data,sizeof(data));
-    return data;
+  mstream_get(s, &data, sizeof(data));
+  data = ntohl(data);
+  if (d != NULL)
+    memcpy(d, &data, sizeof(data));
+  return data;
 }
 
-struct in_addr mstream_get_ipv4(struct mstream *s) {
-    struct in_addr addr;
+struct in_addr mstream_get_ipv4(struct mstream *s)
+{
+  struct in_addr addr;
 
-    mstream_get(s, &addr.s_addr, 4);
-    return addr;
+  mstream_get(s, &addr.s_addr, 4);
+  return addr;
 }
 
-u_int32_t mstream_can_read(struct mstream *s) {
-    return s->len - s->position;
+u_int32_t mstream_can_read(struct mstream *s)
+{
+  return s->len - s->position;
 }
 
 // construct a partial mstream
-mstream_t mstream_copy(mstream_t *s, int len) {
-    mstream_t copy = {0};
-    copy.start = s->start + s->position;
-    copy.len = mstream_get(s, NULL, len);
-    return copy;
+mstream_t mstream_copy(mstream_t *s, int len)
+{
+  mstream_t copy = {0};
+  copy.start = s->start + s->position;
+  copy.len = mstream_get(s, NULL, len);
+  return copy;
 }
 
-u_int32_t mstream_get (struct mstream *s, void *d, u_int32_t len) {
-    int room = mstream_can_read(s);
+u_int32_t mstream_get(struct mstream *s, void *d, u_int32_t len)
+{
+  int room = mstream_can_read(s);
 
-    if(room >= len) {
-	if(d) memcpy(d, s->start + s->position, len);
-	s->position += len;
-	return len;
-    } else {
-	/* Reading past end of buffer!
-	   Zero out extra bytes and set position to end of buffer */
-	if(d) {
-	    memcpy(d, s->start + s->position, room);
-	    memset((char *)d + room, 0, len - room);
-	}
-	s->position = s->len;
-	return room;
+  if (room >= len) {
+    if (d)
+      memcpy(d, s->start + s->position, len);
+    s->position += len;
+    return len;
+  } else {
+    /* Reading past end of buffer!
+       Zero out extra bytes and set position to end of buffer */
+    if (d) {
+      memcpy(d, s->start + s->position, room);
+      memset((char *)d + room, 0, len - room);
     }
+    s->position = s->len;
+    return room;
+  }
 }

--- a/lib/bgpdump/bgpdump_mstream.h
+++ b/lib/bgpdump/bgpdump_mstream.h
@@ -1,6 +1,6 @@
 /*
  Copyright (c) 2007 - 2010 RIPE NCC - All Rights Reserved
- 
+
  Permission to use, copy, modify, and distribute this software and its
  documentation for any purpose and without fee is hereby granted, provided
  that the above copyright notice appear in all copies and that both that
@@ -8,14 +8,14 @@
  documentation, and that the name of the author not be used in advertising or
  publicity pertaining to distribution of the software without specific,
  written prior permission.
- 
+
  THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
  ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS; IN NO EVENT SHALL
  AUTHOR BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY
  DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
  AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- 
+
 Parts of this code have been engineered after analiyzing GNU Zebra's
 source code and therefore might contain declarations/code from GNU
 Zebra, Copyright (C) 1999 Kunihiro Ishiguro. Zebra is a free routing
@@ -28,22 +28,22 @@ Original Author: Dan Ardelean (dan@ripe.net)
 #ifndef _BGPDUMP_MSTREAM_H
 #define _BGPDUMP_MSTREAM_H
 
-#include <sys/types.h>
 #include <netinet/in.h>
+#include <sys/types.h>
 
 typedef struct mstream {
-    u_char	*start;
-    u_int16_t	position;
-    u_int32_t	len;
+  u_char *start;
+  u_int16_t position;
+  u_int32_t len;
 } mstream_t;
 
-void      mstream_init(struct mstream *s, u_char *buffer,u_int32_t len);
-u_char    mstream_getc(struct mstream *s, u_char *d);
+void mstream_init(struct mstream *s, u_char *buffer, u_int32_t len);
+u_char mstream_getc(struct mstream *s, u_char *d);
 u_int16_t mstream_getw(struct mstream *s, u_int16_t *d);
 u_int32_t mstream_getl(struct mstream *s, u_int32_t *d);
 struct in_addr mstream_get_ipv4(struct mstream *s);
 u_int32_t mstream_can_read(struct mstream *s);
-u_int32_t mstream_get (struct mstream *s, void *d, u_int32_t len);
+u_int32_t mstream_get(struct mstream *s, void *d, u_int32_t len);
 mstream_t mstream_copy(mstream_t *s, int len);
 
 #endif

--- a/lib/bgpdump/bgpdump_process.c
+++ b/lib/bgpdump/bgpdump_process.c
@@ -1,6 +1,6 @@
 /*
   Copyright (c) 2007 - 2010 RIPE NCC - All Rights Reserved
- 
+
   Permission to use, copy, modify, and distribute this software and its
   documentation for any purpose and without fee is hereby granted, provided
   that the above copyright notice appear in all copies and that both that
@@ -8,21 +8,21 @@
   documentation, and that the name of the author not be used in advertising or
   publicity pertaining to distribution of the software without specific,
   written prior permission.
- 
+
   THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
   ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS; IN NO EVENT SHALL
   AUTHOR BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY
   DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
   AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
   OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- 
+
   Parts of this code have been engineered after analiyzing GNU Zebra's
   source code and therefore might contain declarations/code from GNU
   Zebra, Copyright (C) 1999 Kunihiro Ishiguro. Zebra is a free routing
   software, distributed under the GNU General Public License. A copy of
   this license is included with libbgpdump.
 
-  Original Author: Shufu Mao(msf98@mails.tsinghua.edu.cn) 
+  Original Author: Shufu Mao(msf98@mails.tsinghua.edu.cn)
 */
 
 #include "config.h"
@@ -30,33 +30,41 @@
 #include "bgpdump_lib.h"
 #include "bgpdump_util.h"
 
+#include <arpa/inet.h>
+#include <assert.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <sys/socket.h>
 #include <time.h>
 #include <unistd.h>
-#include <fcntl.h>
-#include <stdlib.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <arpa/inet.h>
-#include <stdbool.h>
-#include <assert.h>
 
 static void show_attr(attributes_t *attr);
-static void show_prefixes(int count,struct prefix *prefix);
-static void table_line_announce_1(struct mp_nlri *prefix,int count,BGPDUMP_ENTRY *entry,char *time_str);
-static void table_line_announce(struct prefix *prefix,int count,BGPDUMP_ENTRY *entry,char *time_str);
-static void table_line_withdraw(struct prefix *prefix,int count,BGPDUMP_ENTRY *entry,char *time_str);
-static void table_line_mrtd_route(BGPDUMP_MRTD_TABLE_DUMP *route,BGPDUMP_ENTRY *entry);
-static void table_line_dump_v2_prefix(BGPDUMP_TABLE_DUMP_V2_PREFIX *e,BGPDUMP_ENTRY *entry);
+static void show_prefixes(int count, struct prefix *prefix);
+static void table_line_announce_1(struct mp_nlri *prefix, int count,
+                                  BGPDUMP_ENTRY *entry, char *time_str);
+static void table_line_announce(struct prefix *prefix, int count,
+                                BGPDUMP_ENTRY *entry, char *time_str);
+static void table_line_withdraw(struct prefix *prefix, int count,
+                                BGPDUMP_ENTRY *entry, char *time_str);
+static void table_line_mrtd_route(BGPDUMP_MRTD_TABLE_DUMP *route,
+                                  BGPDUMP_ENTRY *entry);
+static void table_line_dump_v2_prefix(BGPDUMP_TABLE_DUMP_V2_PREFIX *e,
+                                      BGPDUMP_ENTRY *entry);
 
-void show_prefixes6(int count,struct prefix *prefix);
-static void table_line_withdraw6(struct prefix *prefix,int count,BGPDUMP_ENTRY *entry,char *time_str);
-static void table_line_announce6(struct mp_nlri *prefix,int count,BGPDUMP_ENTRY *entry,char *time_str);
+void show_prefixes6(int count, struct prefix *prefix);
+static void table_line_withdraw6(struct prefix *prefix, int count,
+                                 BGPDUMP_ENTRY *entry, char *time_str);
+static void table_line_announce6(struct mp_nlri *prefix, int count,
+                                 BGPDUMP_ENTRY *entry, char *time_str);
 
 /* If no aspath was present as a string in the packet, return an empty string
  * so everything stays machine parsable */
-static char *attr_aspath(attributes_t *a) {
-  if(a->flag & ATTR_FLAG_BIT(BGP_ATTR_AS_PATH) && a->aspath) {
-    if(!a->aspath->str) {
+static char *attr_aspath(attributes_t *a)
+{
+  if (a->flag & ATTR_FLAG_BIT(BGP_ATTR_AS_PATH) && a->aspath) {
+    if (!a->aspath->str) {
       process_attr_aspath_string(a->aspath, 1);
     }
     return a->aspath->str;
@@ -64,21 +72,15 @@ static char *attr_aspath(attributes_t *a) {
   return "";
 }
 
-static int mode=1;     // m option - H = 0, m =1, M =2
-static int timetype=0; // dump = 0 [default], change = 1
+static int mode = 1;     // m option - H = 0, m =1, M =2
+static int timetype = 0; // dump = 0 [default], change = 1
 
-const char *bgp_state_name[] = {
-  "Unknown",
-  "Idle",
-  "Connect",
-  "Active",
-  "Opensent",
-  "Openconfirm",
-  "Established",
-  NULL
-};
+const char *bgp_state_name[] = {"Unknown",     "Idle",     "Connect",
+                                "Active",      "Opensent", "Openconfirm",
+                                "Established", NULL};
 
-void bgpdump_print_entry(BGPDUMP_ENTRY *entry) {
+void bgpdump_print_entry(BGPDUMP_ENTRY *entry)
+{
 
   assert(entry);
   bgpdump_log_to_stderr();
@@ -87,1180 +89,1322 @@ void bgpdump_print_entry(BGPDUMP_ENTRY *entry) {
   char time_str[128];
   char time_str2[128];
   char time_str_fixed[128];
-  char prefix[BGPDUMP_ADDRSTRLEN];  
-	
-  date=gmtime(&entry->time);
-  bgpdump_time2str(date,time_str);	
-  bgpdump_time2str(date,time_str_fixed);	
-  if (mode==0)
-    {
-      printf("TIME: %s\n", time_str);
-    }	
-  //printf("TIME: %s",asctime(gmtime(&entry->time)));
-  //printf("LENGTH          : %u\n", entry->length);
-  switch(entry->type) {
+  char prefix[BGPDUMP_ADDRSTRLEN];
+
+  date = gmtime(&entry->time);
+  bgpdump_time2str(date, time_str);
+  bgpdump_time2str(date, time_str_fixed);
+  if (mode == 0) {
+    printf("TIME: %s\n", time_str);
+  }
+  // printf("TIME: %s",asctime(gmtime(&entry->time)));
+  // printf("LENGTH          : %u\n", entry->length);
+  switch (entry->type) {
   case BGPDUMP_TYPE_MRTD_TABLE_DUMP:
-    if(mode==0){
+    if (mode == 0) {
       const char *prefix_str = NULL;
-      switch(entry->subtype){
+      switch (entry->subtype) {
       case BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP6:
-	printf("TYPE: TABLE_DUMP/INET6\n");
-	prefix_str = bgpdump_fmt_ipv6(entry->body.mrtd_table_dump.prefix,prefix);
-	break;
+        printf("TYPE: TABLE_DUMP/INET6\n");
+        prefix_str =
+          bgpdump_fmt_ipv6(entry->body.mrtd_table_dump.prefix, prefix);
+        break;
 
       case BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP6_32BIT_AS:
-	printf("TYPE: TABLE_DUMP/INET6_32BIT_AS\n");
-	prefix_str = bgpdump_fmt_ipv6(entry->body.mrtd_table_dump.prefix,prefix);
-	break;
+        printf("TYPE: TABLE_DUMP/INET6_32BIT_AS\n");
+        prefix_str =
+          bgpdump_fmt_ipv6(entry->body.mrtd_table_dump.prefix, prefix);
+        break;
       case BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP:
-	printf("TYPE: TABLE_DUMP/INET\n");
-	prefix_str = inet_ntoa(entry->body.mrtd_table_dump.prefix.v4_addr);
-	break;
+        printf("TYPE: TABLE_DUMP/INET\n");
+        prefix_str = inet_ntoa(entry->body.mrtd_table_dump.prefix.v4_addr);
+        break;
 
       case BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP_32BIT_AS:
-	printf("TYPE: TABLE_DUMP/INET_32BIT_AS\n");
-	prefix_str = inet_ntoa(entry->body.mrtd_table_dump.prefix.v4_addr);
-	break;
+        printf("TYPE: TABLE_DUMP/INET_32BIT_AS\n");
+        prefix_str = inet_ntoa(entry->body.mrtd_table_dump.prefix.v4_addr);
+        break;
 
       default:
-	printf("Error: unknown table type %d\n", entry->subtype);
-	return;
-
+        printf("Error: unknown table type %d\n", entry->subtype);
+        return;
       }
-      printf("VIEW: %d\n",entry->body.mrtd_table_dump.view);
-      printf("SEQUENCE: %d\n",entry->body.mrtd_table_dump.sequence);
-      printf("PREFIX: %s/%d\n",prefix_str,entry->body.mrtd_table_dump.mask);
+      printf("VIEW: %d\n", entry->body.mrtd_table_dump.view);
+      printf("SEQUENCE: %d\n", entry->body.mrtd_table_dump.sequence);
+      printf("PREFIX: %s/%d\n", prefix_str, entry->body.mrtd_table_dump.mask);
       printf("FROM:");
-      switch(entry->subtype)
-	{
-	case BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP6:
-	case BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP6_32BIT_AS:
+      switch (entry->subtype) {
+      case BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP6:
+      case BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP6_32BIT_AS:
 
-	  bgpdump_fmt_ipv6(entry->body.mrtd_table_dump.peer_ip,prefix);
-	  printf("%s ",prefix);
-	  break;
-	case BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP:
-	case BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP_32BIT_AS:
-	  if (entry->body.mrtd_table_dump.peer_ip.v4_addr.s_addr != 0x00000000L)
-	    printf("%s ",inet_ntoa(entry->body.mrtd_table_dump.peer_ip.v4_addr));
-	  else
-	    printf("N/A ");
-
-	}
-      printf("AS%u\n",entry->body.mrtd_table_dump.peer_as);
-
-      //printf("FROM: %s AS%d\n",inet_ntoa(entry->body.mrtd_table_dump.peer_ip.v4_addr),entry->body.mrtd_table_dump.peer_as);
-      //time2str(localtime(&entry->body.mrtd_table_dump.uptime),time_str2);
-      bgpdump_time2str(gmtime(&entry->body.mrtd_table_dump.uptime),time_str2);
-      printf("ORIGINATED: %s\n",time_str2); 	
-      if (entry->attr && entry->attr->len)
-	show_attr(entry->attr);
-
-      printf("STATUS: 0x%x\n",entry->body.mrtd_table_dump.status);
-	    
-		
-      //printf("    UPTIME      : %s",asctime(gmtime(&entry->body.mrtd_table_dump.uptime)));
-      //printf("    PEER IP     : %s\n",inet_ntoa(entry->body.mrtd_table_dump.peer_ip));
-      //printf("    PEER IP     : %s\n",inet_ntoa(entry->body.mrtd_table_dump.peer_ip.v4_addr));
-      //printf("    PEER AS     : %d\n",entry->body.mrtd_table_dump.peer_as);
-    }
-    else if (mode ==1 || mode ==2) // -m -M
-      {
-	table_line_mrtd_route(&entry->body.mrtd_table_dump,entry);	     
+        bgpdump_fmt_ipv6(entry->body.mrtd_table_dump.peer_ip, prefix);
+        printf("%s ", prefix);
+        break;
+      case BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP:
+      case BGPDUMP_SUBTYPE_MRTD_TABLE_DUMP_AFI_IP_32BIT_AS:
+        if (entry->body.mrtd_table_dump.peer_ip.v4_addr.s_addr != 0x00000000L)
+          printf("%s ", inet_ntoa(entry->body.mrtd_table_dump.peer_ip.v4_addr));
+        else
+          printf("N/A ");
       }
+      printf("AS%u\n", entry->body.mrtd_table_dump.peer_as);
+
+      // printf("FROM: %s
+      // AS%d\n",inet_ntoa(entry->body.mrtd_table_dump.peer_ip.v4_addr),entry->body.mrtd_table_dump.peer_as);
+      // time2str(localtime(&entry->body.mrtd_table_dump.uptime),time_str2);
+      bgpdump_time2str(gmtime(&entry->body.mrtd_table_dump.uptime), time_str2);
+      printf("ORIGINATED: %s\n", time_str2);
+      if (entry->attr && entry->attr->len)
+        show_attr(entry->attr);
+
+      printf("STATUS: 0x%x\n", entry->body.mrtd_table_dump.status);
+
+      // printf("    UPTIME      :
+      // %s",asctime(gmtime(&entry->body.mrtd_table_dump.uptime)));
+      // printf("    PEER IP     :
+      // %s\n",inet_ntoa(entry->body.mrtd_table_dump.peer_ip));
+      // printf("    PEER IP     :
+      // %s\n",inet_ntoa(entry->body.mrtd_table_dump.peer_ip.v4_addr));
+      // printf("    PEER AS     : %d\n",entry->body.mrtd_table_dump.peer_as);
+    } else if (mode == 1 || mode == 2) // -m -M
+    {
+      table_line_mrtd_route(&entry->body.mrtd_table_dump, entry);
+    }
     break;
 
   case BGPDUMP_TYPE_TABLE_DUMP_V2:
-    if(mode == 0){
+    if (mode == 0) {
       char peer_ip[BGPDUMP_ADDRSTRLEN];
-      //char time_str[30];
+      // char time_str[30];
       int i;
 
       BGPDUMP_TABLE_DUMP_V2_PREFIX *e;
       e = &entry->body.mrtd_table_dump_v2_prefix;
 
-      if(e->afi == AFI_IP){
-	strncpy(prefix, inet_ntoa(e->prefix.v4_addr), BGPDUMP_ADDRSTRLEN);
-      } else if(e->afi == AFI_IP6){
-	bgpdump_fmt_ipv6(e->prefix, prefix);
+      if (e->afi == AFI_IP) {
+        strncpy(prefix, inet_ntoa(e->prefix.v4_addr), BGPDUMP_ADDRSTRLEN);
+      } else if (e->afi == AFI_IP6) {
+        bgpdump_fmt_ipv6(e->prefix, prefix);
       }
 
-      for(i = 0; i < e->entry_count; i++){
-	// This is slightly nasty - as we want to print multiple entries
-	// for multiple peers, we may need to print another TIME ourselves
-	if(i) printf("\nTIME: %s\n",time_str_fixed);
-	if(e->afi == AFI_IP){
-	  printf("TYPE: TABLE_DUMP_V2/IPV4_UNICAST\n");
-	} else if(e->afi == AFI_IP6){
-	  printf("TYPE: TABLE_DUMP_V2/IPV6_UNICAST\n");
-	}
-	printf("PREFIX: %s/%d\n",prefix, e->prefix_length);
-	printf("SEQUENCE: %d\n",e->seq);
+      for (i = 0; i < e->entry_count; i++) {
+        // This is slightly nasty - as we want to print multiple entries
+        // for multiple peers, we may need to print another TIME ourselves
+        if (i)
+          printf("\nTIME: %s\n", time_str_fixed);
+        if (e->afi == AFI_IP) {
+          printf("TYPE: TABLE_DUMP_V2/IPV4_UNICAST\n");
+        } else if (e->afi == AFI_IP6) {
+          printf("TYPE: TABLE_DUMP_V2/IPV6_UNICAST\n");
+        }
+        printf("PREFIX: %s/%d\n", prefix, e->prefix_length);
+        printf("SEQUENCE: %d\n", e->seq);
 
-	if(e->entries[i].peer.afi == AFI_IP){
-	  bgpdump_fmt_ipv4(e->entries[i].peer.peer_ip, peer_ip);
-	} else if (e->entries[i].peer.afi == AFI_IP6){
-	  bgpdump_fmt_ipv6(e->entries[i].peer.peer_ip, peer_ip);
-	} else {
-	  sprintf(peer_ip, "[N/A, unsupported AF]");
-	}
-	printf("FROM: %s AS%u\n", peer_ip, e->entries[i].peer.peer_as);
-	time_t time_temp = (time_t)((e->entries[i]).originated_time);
-	bgpdump_time2str(gmtime(&time_temp),time_str);
-	printf("ORIGINATED: %s\n",time_str); 	
-	if (e->entries[i].attr && e->entries[i].attr->len)
-	  show_attr(e->entries[i].attr);
+        if (e->entries[i].peer.afi == AFI_IP) {
+          bgpdump_fmt_ipv4(e->entries[i].peer.peer_ip, peer_ip);
+        } else if (e->entries[i].peer.afi == AFI_IP6) {
+          bgpdump_fmt_ipv6(e->entries[i].peer.peer_ip, peer_ip);
+        } else {
+          sprintf(peer_ip, "[N/A, unsupported AF]");
+        }
+        printf("FROM: %s AS%u\n", peer_ip, e->entries[i].peer.peer_as);
+        time_t time_temp = (time_t)((e->entries[i]).originated_time);
+        bgpdump_time2str(gmtime(&time_temp), time_str);
+        printf("ORIGINATED: %s\n", time_str);
+        if (e->entries[i].attr && e->entries[i].attr->len)
+          show_attr(e->entries[i].attr);
       }
-    } else if (mode==1 || mode==2) { // -m -M
-      table_line_dump_v2_prefix(&entry->body.mrtd_table_dump_v2_prefix,entry);	     
+    } else if (mode == 1 || mode == 2) { // -m -M
+      table_line_dump_v2_prefix(&entry->body.mrtd_table_dump_v2_prefix, entry);
     }
     break;
-	    
+
   case BGPDUMP_TYPE_ZEBRA_BGP:
-	    
-    switch(entry->subtype) 
+
+    switch (entry->subtype) {
+    case BGPDUMP_SUBTYPE_ZEBRA_BGP_MESSAGE:
+    case BGPDUMP_SUBTYPE_ZEBRA_BGP_MESSAGE_AS4:
+
+      switch (entry->body.zebra_message.type) {
+      case BGP_MSG_UPDATE:
+        if (mode == 0) {
+          printf("TYPE: BGP4MP/MESSAGE/Update\n");
+          if (entry->body.zebra_message.source_as) {
+            printf("FROM:");
+            switch (entry->body.zebra_message.address_family) {
+            case AFI_IP6:
+              bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip, prefix);
+              printf(" %s ", prefix);
+              break;
+            case AFI_IP:
+            default:
+              if (entry->body.zebra_message.source_ip.v4_addr.s_addr !=
+                  0x00000000L)
+                printf(" %s ",
+                       inet_ntoa(entry->body.zebra_message.source_ip.v4_addr));
+              else
+                printf(" N/A ");
+            }
+            printf("AS%u\n", entry->body.zebra_message.source_as);
+          }
+          if (entry->body.zebra_message.destination_as) {
+            printf("TO:");
+            switch (entry->body.zebra_message.address_family) {
+            case AFI_IP6:
+              bgpdump_fmt_ipv6(entry->body.zebra_message.destination_ip,
+                               prefix);
+              printf(" %s ", prefix);
+              break;
+            case AFI_IP:
+            default:
+              if (entry->body.zebra_message.destination_ip.v4_addr.s_addr !=
+                  0x00000000L)
+                printf(
+                  " %s ",
+                  inet_ntoa(entry->body.zebra_message.destination_ip.v4_addr));
+              else
+                printf(" N/A ");
+            }
+            printf("AS%u\n", entry->body.zebra_message.destination_as);
+          }
+          if (entry->attr && entry->attr->len)
+            show_attr(entry->attr);
+          if (entry->body.zebra_message.cut_bytes) {
+            u_int16_t cutted, idx;
+            u_int8_t buf[128];
+
+            printf("   INCOMPLETE PACKET: %d bytes cutted\n",
+                   entry->body.zebra_message.cut_bytes);
+            printf("   INCOMPLETE PART: ");
+            if (entry->body.zebra_message.incomplete.orig_len) {
+              cutted = entry->body.zebra_message.incomplete.prefix.len / 8 + 1;
+              buf[0] = entry->body.zebra_message.incomplete.orig_len;
+              memcpy(buf + 1,
+                     &entry->body.zebra_message.incomplete.prefix.address,
+                     cutted - 1);
+
+              for (idx = 0; idx < cutted; idx++) {
+                if (buf[idx] < 0x10)
+                  printf("0%x ", buf[idx]);
+                else
+                  printf("%x ", buf[idx]);
+              }
+            }
+            printf("\n");
+          }
+          if (!entry->attr)
+            return;
+          if ((entry->body.zebra_message.withdraw_count) ||
+              (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MP_UNREACH_NLRI))) {
+            if ((entry->body.zebra_message.withdraw_count) ||
+                (entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST] &&
+                 entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST]
+                   ->prefix_count) ||
+                (entry->attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST] &&
+                 entry->attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST]
+                   ->prefix_count) ||
+                (entry->attr->mp_info
+                   ->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST] &&
+                 entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST]
+                   ->prefix_count) ||
+                (entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST] &&
+                 entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST]
+                   ->prefix_count) ||
+                (entry->attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST] &&
+                 entry->attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST]
+                   ->prefix_count) ||
+                (entry->attr->mp_info
+                   ->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST] &&
+                 entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST]
+                   ->prefix_count))
+              printf("WITHDRAW\n");
+            if (entry->body.zebra_message.withdraw_count)
+              show_prefixes(entry->body.zebra_message.withdraw_count,
+                            entry->body.zebra_message.withdraw);
+
+            if (entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST] &&
+                entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST]
+                  ->prefix_count)
+              show_prefixes(
+                entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST]
+                  ->prefix_count,
+                entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST]->nlri);
+
+            if (entry->attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST] &&
+                entry->attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST]
+                  ->prefix_count)
+              show_prefixes(
+                entry->attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST]
+                  ->prefix_count,
+                entry->attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST]->nlri);
+
+            if (entry->attr->mp_info
+                  ->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST] &&
+                entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST]
+                  ->prefix_count)
+              show_prefixes(
+                entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST]
+                  ->prefix_count,
+                entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST]
+                  ->nlri);
+
+            if (entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST] &&
+                entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST]
+                  ->prefix_count)
+              show_prefixes6(
+                entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST]
+                  ->prefix_count,
+                entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST]->nlri);
+
+            if (entry->attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST] &&
+                entry->attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST]
+                  ->prefix_count)
+              show_prefixes6(
+                entry->attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST]
+                  ->prefix_count,
+                entry->attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST]->nlri);
+
+            if (entry->attr->mp_info
+                  ->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST] &&
+                entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST]
+                  ->prefix_count)
+              show_prefixes6(
+                entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST]
+                  ->prefix_count,
+                entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST]
+                  ->nlri);
+          }
+          if ((entry->body.zebra_message.announce_count) ||
+              (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MP_REACH_NLRI))) {
+            printf("ANNOUNCE\n");
+            if (entry->body.zebra_message.announce_count)
+              show_prefixes(entry->body.zebra_message.announce_count,
+                            entry->body.zebra_message.announce);
+
+            if (entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST] &&
+                entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST]
+                  ->prefix_count)
+              show_prefixes(
+                entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST]
+                  ->prefix_count,
+                entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST]->nlri);
+
+            if (entry->attr->mp_info->announce[AFI_IP][SAFI_MULTICAST] &&
+                entry->attr->mp_info->announce[AFI_IP][SAFI_MULTICAST]
+                  ->prefix_count)
+              show_prefixes(
+                entry->attr->mp_info->announce[AFI_IP][SAFI_MULTICAST]
+                  ->prefix_count,
+                entry->attr->mp_info->announce[AFI_IP][SAFI_MULTICAST]->nlri);
+
+            if (entry->attr->mp_info
+                  ->announce[AFI_IP][SAFI_UNICAST_MULTICAST] &&
+                entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST]
+                  ->prefix_count)
+              show_prefixes(
+                entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST]
+                  ->prefix_count,
+                entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST]
+                  ->nlri);
+
+            if (entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST] &&
+                entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]
+                  ->prefix_count)
+              show_prefixes6(
+                entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]
+                  ->prefix_count,
+                entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]->nlri);
+
+            if (entry->attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST] &&
+                entry->attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST]
+                  ->prefix_count)
+              show_prefixes6(
+                entry->attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST]
+                  ->prefix_count,
+                entry->attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST]->nlri);
+
+            if (entry->attr->mp_info
+                  ->announce[AFI_IP6][SAFI_UNICAST_MULTICAST] &&
+                entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST]
+                  ->prefix_count)
+              show_prefixes6(
+                entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST]
+                  ->prefix_count,
+                entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST]
+                  ->nlri);
+          }
+        } else if (mode == 1 || mode == 2) //-m -M
+        {
+          if ((entry->body.zebra_message.withdraw_count) ||
+              (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MP_UNREACH_NLRI))) {
+
+            table_line_withdraw(entry->body.zebra_message.withdraw,
+                                entry->body.zebra_message.withdraw_count, entry,
+                                time_str);
+
+            if (entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST] &&
+                entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST]
+                  ->prefix_count)
+              table_line_withdraw(
+                entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST]->nlri,
+                entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST]
+                  ->prefix_count,
+                entry, time_str);
+
+            if (entry->attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST] &&
+                entry->attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST]
+                  ->prefix_count)
+              table_line_withdraw(
+                entry->attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST]->nlri,
+                entry->attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST]
+                  ->prefix_count,
+                entry, time_str);
+
+            if (entry->attr->mp_info
+                  ->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST] &&
+                entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST]
+                  ->prefix_count)
+              table_line_withdraw(
+                entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST]
+                  ->nlri,
+                entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST]
+                  ->prefix_count,
+                entry, time_str);
+
+            if (entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST] &&
+                entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST]
+                  ->prefix_count)
+              table_line_withdraw6(
+                entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST]->nlri,
+                entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST]
+                  ->prefix_count,
+                entry, time_str);
+
+            if (entry->attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST] &&
+                entry->attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST]
+                  ->prefix_count)
+              table_line_withdraw6(
+                entry->attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST]->nlri,
+                entry->attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST]
+                  ->prefix_count,
+                entry, time_str);
+
+            if (entry->attr->mp_info
+                  ->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST] &&
+                entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST]
+                  ->prefix_count)
+              table_line_withdraw6(
+                entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST]
+                  ->nlri,
+                entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST]
+                  ->prefix_count,
+                entry, time_str);
+          }
+          if ((entry->body.zebra_message.announce_count) ||
+              (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MP_REACH_NLRI))) {
+            table_line_announce(entry->body.zebra_message.announce,
+                                entry->body.zebra_message.announce_count, entry,
+                                time_str);
+            if (entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST] &&
+                entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST]
+                  ->prefix_count)
+              table_line_announce_1(
+                entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST],
+                entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST]
+                  ->prefix_count,
+                entry, time_str);
+            if (entry->attr->mp_info->announce[AFI_IP][SAFI_MULTICAST] &&
+                entry->attr->mp_info->announce[AFI_IP][SAFI_MULTICAST]
+                  ->prefix_count)
+              table_line_announce_1(
+                entry->attr->mp_info->announce[AFI_IP][SAFI_MULTICAST],
+                entry->attr->mp_info->announce[AFI_IP][SAFI_MULTICAST]
+                  ->prefix_count,
+                entry, time_str);
+            if (entry->attr->mp_info
+                  ->announce[AFI_IP][SAFI_UNICAST_MULTICAST] &&
+                entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST]
+                  ->prefix_count)
+              table_line_announce_1(
+                entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST],
+                entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST]
+                  ->prefix_count,
+                entry, time_str);
+            if (entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST] &&
+                entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]
+                  ->prefix_count)
+              table_line_announce6(
+                entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST],
+                entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]
+                  ->prefix_count,
+                entry, time_str);
+            if (entry->attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST] &&
+                entry->attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST]
+                  ->prefix_count)
+              table_line_announce6(
+                entry->attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST],
+                entry->attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST]
+                  ->prefix_count,
+                entry, time_str);
+            if (entry->attr->mp_info
+                  ->announce[AFI_IP6][SAFI_UNICAST_MULTICAST] &&
+                entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST]
+                  ->prefix_count)
+              table_line_announce6(
+                entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST],
+                entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST]
+                  ->prefix_count,
+                entry, time_str);
+          }
+        }
+        break;
+
+      case BGP_MSG_OPEN:
+        if (mode != 0)
+          break;
+        printf("TYPE: BGP4MP/MESSAGE/Open\n");
+        if (entry->body.zebra_message.source_as) {
+          printf("FROM:");
+          switch (entry->body.zebra_message.address_family) {
+          case AFI_IP6:
+            bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip, prefix);
+            printf(" %s ", prefix);
+            break;
+          case AFI_IP:
+          default:
+            if (entry->body.zebra_message.source_ip.v4_addr.s_addr !=
+                0x00000000L)
+              printf(" %s ",
+                     inet_ntoa(entry->body.zebra_message.source_ip.v4_addr));
+            else
+              printf(" N/A ");
+          }
+          printf("AS%u\n", entry->body.zebra_message.source_as);
+        }
+        if (entry->body.zebra_message.destination_as) {
+          printf("TO:");
+          switch (entry->body.zebra_message.address_family) {
+          case AFI_IP6:
+            bgpdump_fmt_ipv6(entry->body.zebra_message.destination_ip, prefix);
+            printf(" %s ", prefix);
+            break;
+          case AFI_IP:
+          default:
+            if (entry->body.zebra_message.destination_ip.v4_addr.s_addr !=
+                0x00000000L)
+              printf(
+                " %s ",
+                inet_ntoa(entry->body.zebra_message.destination_ip.v4_addr));
+            else
+              printf(" N/A ");
+          }
+          printf("AS%u\n", entry->body.zebra_message.destination_as);
+        }
+
+        printf("VERSION: %d\n", entry->body.zebra_message.version);
+        printf("AS: %u\n", entry->body.zebra_message.my_as);
+        printf("HOLD_TIME: %d\n", entry->body.zebra_message.hold_time);
+        printf("ID: %s\n", inet_ntoa(entry->body.zebra_message.bgp_id));
+        printf("OPT_PARM_LEN: %d\n", entry->body.zebra_message.opt_len);
+        break;
+
+      case BGP_MSG_NOTIFY:
+        if (mode != 0)
+          break;
+        printf("TYPE: BGP4MP/MESSAGE/Notify\n");
+        if (entry->body.zebra_message.source_as) {
+          printf("FROM:");
+          switch (entry->body.zebra_message.address_family) {
+          case AFI_IP6:
+            bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip, prefix);
+            printf(" %s ", prefix);
+            break;
+          case AFI_IP:
+          default:
+            if (entry->body.zebra_message.source_ip.v4_addr.s_addr !=
+                0x00000000L)
+              printf(" %s ",
+                     inet_ntoa(entry->body.zebra_message.source_ip.v4_addr));
+            else
+              printf(" N/A ");
+          }
+          printf("AS%u\n", entry->body.zebra_message.source_as);
+        }
+        if (entry->body.zebra_message.destination_as) {
+          printf("TO:");
+          switch (entry->body.zebra_message.address_family) {
+          case AFI_IP6:
+            bgpdump_fmt_ipv6(entry->body.zebra_message.destination_ip, prefix);
+            printf(" %s ", prefix);
+            break;
+          case AFI_IP:
+          default:
+            if (entry->body.zebra_message.destination_ip.v4_addr.s_addr !=
+                0x00000000L)
+              printf(
+                " %s ",
+                inet_ntoa(entry->body.zebra_message.destination_ip.v4_addr));
+            else
+              printf(" N/A ");
+          }
+          printf("AS%u\n", entry->body.zebra_message.destination_as);
+        }
+
+        switch (entry->body.zebra_message.error_code) {
+        case 1:
+          printf("    ERROR CODE  : 1 (Message Header Error)\n");
+          switch (entry->body.zebra_message.sub_error_code) {
+          case 1:
+            printf("    SUB ERROR   : 1 (Connection Not Synchronized)\n");
+            break;
+
+          case 2:
+            printf("    SUB ERROR   : 2 (Bad Message Length)\n");
+            break;
+
+          case 3:
+            printf("    SUB ERROR   : 3 (Bad Message Type)\n");
+            break;
+
+          default:
+            printf("    SUB ERROR   : %d\n",
+                   entry->body.zebra_message.sub_error_code);
+            break;
+          }
+          break;
+        case 2:
+          printf("    ERROR CODE  : 2 (OPEN Message Error)\n");
+          switch (entry->body.zebra_message.sub_error_code) {
+          case 1:
+            printf("    SUB ERROR   : 1 (Unsupported Version Number)\n");
+            break;
+
+          case 2:
+            printf("    SUB ERROR   : 2 (Bad Peer AS)\n");
+            break;
+
+          case 3:
+            printf("    SUB ERROR   : 3 (Bad BGP Identifier)\n");
+            break;
+
+          case 4:
+            printf("    SUB ERROR   : 4 (Unsupported Optional Parameter)\n");
+            break;
+
+          case 5:
+            printf("    SUB ERROR   : 5 (Authentication Failure)\n");
+            break;
+
+          case 6:
+            printf("    SUB ERROR   : 6 (Unacceptable Hold Time)\n");
+            break;
+
+          default:
+            printf("    SUB ERROR   : %d\n",
+                   entry->body.zebra_message.sub_error_code);
+            break;
+          }
+          break;
+        case 3:
+          printf("    ERROR CODE  : 3 (UPDATE Message Error)\n");
+          switch (entry->body.zebra_message.sub_error_code) {
+          case 1:
+            printf("    SUB ERROR   : 1 (Malformed Attribute List)\n");
+            break;
+
+          case 2:
+            printf("    SUB ERROR   : 2 (Unrecognized Well-known Attribute)\n");
+            break;
+
+          case 3:
+            printf("    SUB ERROR   : 3 (Missing Well-known Attribute)\n");
+            break;
+
+          case 4:
+            printf("    SUB ERROR   : 4 (Attribute Flags Error)\n");
+            break;
+
+          case 5:
+            printf("    SUB ERROR   : 5 (Attribute Length Error)\n");
+            break;
+
+          case 6:
+            printf("    SUB ERROR   : 6 (Invalid ORIGIN Attribute)\n");
+            break;
+
+          case 7:
+            printf("    SUB ERROR   : 7 (AS Routing Loop)\n");
+            break;
+
+          case 8:
+            printf("    SUB ERROR   : 8 (Invalid NEXT-HOP Attribute)\n");
+            break;
+
+          case 9:
+            printf("    SUB ERROR   : 9 (Optional Attribute Error)\n");
+            break;
+
+          case 10:
+            printf("    SUB ERROR   : 10 (Invalid Network Field)\n");
+            break;
+
+          case 11:
+            printf("    SUB ERROR   : 11 (Malformed AS-PATH)\n");
+            break;
+
+          default:
+            printf("    SUB ERROR   : %d\n",
+                   entry->body.zebra_message.sub_error_code);
+            break;
+          }
+          break;
+        case 4:
+          printf("    ERROR CODE  : 4 (Hold Timer Expired)\n");
+          break;
+        case 5:
+          printf("    ERROR CODE  : 5 (Finite State Machine Error)\n");
+          break;
+        case 6:
+          printf("    ERROR CODE  : 6 (Cease)\n");
+          break;
+        default:
+          printf("    ERROR CODE  : %d\n",
+                 entry->body.zebra_message.error_code);
+          break;
+        }
+        break;
+
+      case BGP_MSG_KEEPALIVE:
+        if (mode != 0)
+          break;
+
+        printf("TYPE: BGP4MP/MESSAGE/Keepalive\n");
+        if (entry->body.zebra_message.source_as) {
+          printf("FROM:");
+          switch (entry->body.zebra_message.address_family) {
+          case AFI_IP6:
+            bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip, prefix);
+            printf(" %s ", prefix);
+            break;
+          case AFI_IP:
+          default:
+            if (entry->body.zebra_message.source_ip.v4_addr.s_addr !=
+                0x00000000L)
+              printf(" %s ",
+                     inet_ntoa(entry->body.zebra_message.source_ip.v4_addr));
+            else
+              printf(" N/A ");
+          }
+          printf("AS%u\n", entry->body.zebra_message.source_as);
+        }
+        if (entry->body.zebra_message.destination_as) {
+          printf("TO:");
+          switch (entry->body.zebra_message.address_family) {
+          case AFI_IP6:
+            bgpdump_fmt_ipv6(entry->body.zebra_message.destination_ip, prefix);
+            printf(" %s ", prefix);
+            break;
+          case AFI_IP:
+          default:
+            if (entry->body.zebra_message.destination_ip.v4_addr.s_addr !=
+                0x00000000L)
+              printf(
+                " %s ",
+                inet_ntoa(entry->body.zebra_message.destination_ip.v4_addr));
+            else
+              printf(" N/A ");
+          }
+          printf("AS%u\n", entry->body.zebra_message.destination_as);
+        }
+
+        break;
+      }
+      break;
+
+    case BGPDUMP_SUBTYPE_ZEBRA_BGP_STATE_CHANGE:
+    case BGPDUMP_SUBTYPE_ZEBRA_BGP_STATE_CHANGE_AS4:
+      if (mode == 0) {
+        printf("TYPE: BGP4MP/STATE_CHANGE\n");
+
+        printf("PEER:");
+        switch (entry->body.zebra_state_change.address_family) {
+        case AFI_IP6:
+          bgpdump_fmt_ipv6(entry->body.zebra_state_change.source_ip, prefix);
+          printf(" %s ", prefix);
+          break;
+        case AFI_IP:
+        default:
+          if (entry->body.zebra_state_change.source_ip.v4_addr.s_addr !=
+              0x00000000L)
+            printf(" %s ",
+                   inet_ntoa(entry->body.zebra_message.source_ip.v4_addr));
+          else
+            printf(" N/A ");
+        }
+        // if (entry->body.zebra_message.source_ip.s_addr != 0x00000000L)
+        //	printf(" %s ",inet_ntoa(entry->body.zebra_message.source_ip));
+        // else
+        //	printf(" N/A ");
+        printf("AS%u\n", entry->body.zebra_state_change.source_as);
+
+        printf("STATE: %s/%s\n",
+               bgp_state_name[entry->body.zebra_state_change.old_state],
+               bgp_state_name[entry->body.zebra_state_change.new_state]);
+      } else if (mode == 1 || mode == 2) //-m -M
       {
-      case BGPDUMP_SUBTYPE_ZEBRA_BGP_MESSAGE:
-      case BGPDUMP_SUBTYPE_ZEBRA_BGP_MESSAGE_AS4:
-
-	switch(entry->body.zebra_message.type) 
-	  {
-	  case BGP_MSG_UPDATE:
-	    if (mode ==0)
-	      {
-		printf("TYPE: BGP4MP/MESSAGE/Update\n");	 
-		if (entry->body.zebra_message.source_as)
-		  {
-		    printf("FROM:");
-		    switch(entry->body.zebra_message.address_family)
-		      {
-		      case AFI_IP6:
-			bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip,prefix);
-			printf(" %s ",prefix);
-			break;
-		      case AFI_IP:
-		      default:
-			if (entry->body.zebra_message.source_ip.v4_addr.s_addr != 0x00000000L)
-			  printf(" %s ",inet_ntoa(entry->body.zebra_message.source_ip.v4_addr));
-			else
-			  printf(" N/A ");
-		      }
-		    printf("AS%u\n",entry->body.zebra_message.source_as);
-		  }
-		if (entry->body.zebra_message.destination_as)
-		  {
-		    printf("TO:");
-		    switch(entry->body.zebra_message.address_family)
-		      {
-		      case AFI_IP6:
-			bgpdump_fmt_ipv6(entry->body.zebra_message.destination_ip,prefix);
-			printf(" %s ",prefix);
-			break;
-		      case AFI_IP:
-		      default:
-			if (entry->body.zebra_message.destination_ip.v4_addr.s_addr != 0x00000000L)
-			  printf(" %s ",inet_ntoa(entry->body.zebra_message.destination_ip.v4_addr));
-			else
-			  printf(" N/A ");
-		      }	
-		    printf("AS%u\n",entry->body.zebra_message.destination_as);
-		  }
-		if (entry->attr && entry->attr->len)
-		  show_attr(entry->attr);
-		if (entry->body.zebra_message.cut_bytes)
-		  {
-		    u_int16_t cutted,idx;
-		    u_int8_t buf[128];
-					
-		    printf("   INCOMPLETE PACKET: %d bytes cutted\n",entry->body.zebra_message.cut_bytes);
-		    printf("   INCOMPLETE PART: ");
-		    if (entry->body.zebra_message.incomplete.orig_len)
-		      {
-			cutted=entry->body.zebra_message.incomplete.prefix.len/8+1;
-			buf[0]=entry->body.zebra_message.incomplete.orig_len;
-			memcpy(buf+1,&entry->body.zebra_message.incomplete.prefix.address,cutted-1);
-						
-			for (idx=0;idx<cutted;idx++)
-			  {
-			    if (buf[idx]<0x10)
-			      printf("0%x ",buf[idx]);
-			    else
-			      printf("%x ",buf[idx]);
-			  }
-		      }
-		    printf("\n");
-		  }
-		if(! entry->attr)
-		  return;
-		if ((entry->body.zebra_message.withdraw_count) || (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MP_UNREACH_NLRI))) 
-		  {
-		    if ((entry->body.zebra_message.withdraw_count)||(entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST] && entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST]->prefix_count) || (entry->attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST] && entry->attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST]->prefix_count) || (entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST] && entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST]->prefix_count) ||(entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST] && entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST]->prefix_count) || (entry->attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST] && entry->attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST]->prefix_count) || (entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST] && entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST]->prefix_count) )
-			printf("WITHDRAW\n");
-		    if (entry->body.zebra_message.withdraw_count)
-		      show_prefixes(entry->body.zebra_message.withdraw_count,entry->body.zebra_message.withdraw);
-
-		    if (entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST] && entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST]->prefix_count)
-		      show_prefixes(entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST]->prefix_count,entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST]->nlri);
-                                
-		    if (entry->attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST] && entry->attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST]->prefix_count)
-		      show_prefixes(entry->attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST]->prefix_count,entry->attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST]->nlri);
-
-		    if (entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST] && entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST]->prefix_count)
-		      show_prefixes(entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST]->prefix_count,entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST]->nlri);
-
-		    if (entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST] && entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST]->prefix_count)
-		      show_prefixes6(entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST]->prefix_count,entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST]->nlri);
-                                
-		    if (entry->attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST] && entry->attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST]->prefix_count)
-		      show_prefixes6(entry->attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST]->prefix_count,entry->attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST]->nlri);
-
-		    if (entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST] && entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST]->prefix_count)
-		      show_prefixes6(entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST]->prefix_count,entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST]->nlri);
-		  }
-		if ( (entry->body.zebra_message.announce_count) || (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MP_REACH_NLRI))) 
-		  {
-		    printf("ANNOUNCE\n");
-		    if (entry->body.zebra_message.announce_count)
-		      show_prefixes(entry->body.zebra_message.announce_count,entry->body.zebra_message.announce);
-
-		    if (entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST] && entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST]->prefix_count)
-		      show_prefixes(entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST]->prefix_count,entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST]->nlri);
-                                
-		    if (entry->attr->mp_info->announce[AFI_IP][SAFI_MULTICAST] && entry->attr->mp_info->announce[AFI_IP][SAFI_MULTICAST]->prefix_count)
-		      show_prefixes(entry->attr->mp_info->announce[AFI_IP][SAFI_MULTICAST]->prefix_count,entry->attr->mp_info->announce[AFI_IP][SAFI_MULTICAST]->nlri);
-
-		    if (entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST] && entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST]->prefix_count)
-		      show_prefixes(entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST]->prefix_count,entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST]->nlri);
-
-		    if (entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST] && entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]->prefix_count)
-		      show_prefixes6(entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]->prefix_count,entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]->nlri);
-                                
-		    if (entry->attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST] && entry->attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST]->prefix_count)
-		      show_prefixes6(entry->attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST]->prefix_count,entry->attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST]->nlri);
-
-		    if (entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST] && entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST]->prefix_count)
-		      show_prefixes6(entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST]->prefix_count,entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST]->nlri);
-		  }
-	      }
-	    else if (mode == 1  || mode == 2) //-m -M
-	      {
-		if ((entry->body.zebra_message.withdraw_count) || (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MP_UNREACH_NLRI)))
-		  {
-
-		    table_line_withdraw(entry->body.zebra_message.withdraw,entry->body.zebra_message.withdraw_count,entry,time_str);
-
-		    if (entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST] && entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST]->prefix_count)
-		      table_line_withdraw(entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST]->nlri,entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST]->prefix_count,entry,time_str);	
-
-		    if (entry->attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST] && entry->attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST]->prefix_count)
-		      table_line_withdraw(entry->attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST]->nlri,entry->attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST]->prefix_count,entry,time_str);
-                                        
-		    if (entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST] && entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST]->prefix_count)
-		      table_line_withdraw(entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST]->nlri,entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST]->prefix_count,entry,time_str);
-
-		    if (entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST] && entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST]->prefix_count)
-		      table_line_withdraw6(entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST]->nlri,entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST]->prefix_count,entry,time_str);	
-                                        
-		    if (entry->attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST] && entry->attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST]->prefix_count)
-		      table_line_withdraw6(entry->attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST]->nlri,entry->attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST]->prefix_count,entry,time_str);
-                                        
-		    if (entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST] && entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST]->prefix_count)
-		      table_line_withdraw6(entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST]->nlri,entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST]->prefix_count,entry,time_str);
-                        
-		  }
-		if ( (entry->body.zebra_message.announce_count) || (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MP_REACH_NLRI)))
-		  {
-		    table_line_announce(entry->body.zebra_message.announce,entry->body.zebra_message.announce_count,entry,time_str);
-		    if (entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST] && entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST]->prefix_count)
-		      table_line_announce_1(entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST],entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST]->prefix_count,entry,time_str);	
-		    if (entry->attr->mp_info->announce[AFI_IP][SAFI_MULTICAST] && entry->attr->mp_info->announce[AFI_IP][SAFI_MULTICAST]->prefix_count)
-		      table_line_announce_1(entry->attr->mp_info->announce[AFI_IP][SAFI_MULTICAST],entry->attr->mp_info->announce[AFI_IP][SAFI_MULTICAST]->prefix_count,entry,time_str);
-		    if (entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST] && entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST]->prefix_count)
-		      table_line_announce_1(entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST],entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST]->prefix_count,entry,time_str);
-		    if (entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST] && entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]->prefix_count)
-		      table_line_announce6(entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST],entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]->prefix_count,entry,time_str);	
-		    if (entry->attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST] && entry->attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST]->prefix_count)
-		      table_line_announce6(entry->attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST],entry->attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST]->prefix_count,entry,time_str);
-		    if (entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST] && entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST]->prefix_count)
-		      table_line_announce6(entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST],entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST]->prefix_count,entry,time_str);
-					
-		  }  
-	      }
-	    break;
-		    
-	  case BGP_MSG_OPEN:
-	    if (mode != 0)
-	      break;
-	    printf("TYPE: BGP4MP/MESSAGE/Open\n");
-	    if (entry->body.zebra_message.source_as)
-	      {
-		printf("FROM:");
-		switch(entry->body.zebra_message.address_family)
-		  {
-		  case AFI_IP6:
-		    bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip,prefix);
-		    printf(" %s ",prefix);
-		    break;
-		  case AFI_IP:
-		  default:
-		    if (entry->body.zebra_message.source_ip.v4_addr.s_addr != 0x00000000L)
-		      printf(" %s ",inet_ntoa(entry->body.zebra_message.source_ip.v4_addr));
-		    else
-		      printf(" N/A ");
-		  }
-		printf("AS%u\n",entry->body.zebra_message.source_as);
-	      }
-	    if (entry->body.zebra_message.destination_as)
-	      {
-		printf("TO:");
-		switch(entry->body.zebra_message.address_family)
-		  {
-		  case AFI_IP6:
-		    bgpdump_fmt_ipv6(entry->body.zebra_message.destination_ip,prefix);
-		    printf(" %s ",prefix);
-		    break;
-		  case AFI_IP:
-		  default:
-		    if (entry->body.zebra_message.destination_ip.v4_addr.s_addr != 0x00000000L)
-		      printf(" %s ",inet_ntoa(entry->body.zebra_message.destination_ip.v4_addr));
-		    else
-		      printf(" N/A ");
-		  }
-		printf("AS%u\n",entry->body.zebra_message.destination_as);
-	      }
-
-	    printf("VERSION: %d\n",entry->body.zebra_message.version);
-	    printf("AS: %u\n",entry->body.zebra_message.my_as);
-	    printf("HOLD_TIME: %d\n",entry->body.zebra_message.hold_time);
-	    printf("ID: %s\n",inet_ntoa(entry->body.zebra_message.bgp_id));
-	    printf("OPT_PARM_LEN: %d\n",entry->body.zebra_message.opt_len);
-	    break;
-			
-	  case BGP_MSG_NOTIFY:
-	    if (mode != 0)
-	      break;
-	    printf("TYPE: BGP4MP/MESSAGE/Notify\n");
-	    if (entry->body.zebra_message.source_as)
-	      {
-		printf("FROM:");
-		switch(entry->body.zebra_message.address_family)
-		  {
-		  case AFI_IP6:
-		    bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip,prefix);
-		    printf(" %s ",prefix);
-		    break;
-		  case AFI_IP:
-		  default:
-		    if (entry->body.zebra_message.source_ip.v4_addr.s_addr != 0x00000000L)
-		      printf(" %s ",inet_ntoa(entry->body.zebra_message.source_ip.v4_addr));
-		    else
-		      printf(" N/A ");
-		  }
-		printf("AS%u\n",entry->body.zebra_message.source_as);
-	      }
-	    if (entry->body.zebra_message.destination_as)
-	      {
-		printf("TO:");
-		switch(entry->body.zebra_message.address_family)
-		  {
-		  case AFI_IP6:
-		    bgpdump_fmt_ipv6(entry->body.zebra_message.destination_ip,prefix);
-		    printf(" %s ",prefix);
-		    break;
-		  case AFI_IP:
-		  default:
-		    if (entry->body.zebra_message.destination_ip.v4_addr.s_addr != 0x00000000L)
-		      printf(" %s ",inet_ntoa(entry->body.zebra_message.destination_ip.v4_addr));
-		    else
-		      printf(" N/A ");
-		  }
-		printf("AS%u\n",entry->body.zebra_message.destination_as);
-	      }
-
-	    switch (entry->body.zebra_message.error_code)
-	      {
-	      case 	1:
-		printf("    ERROR CODE  : 1 (Message Header Error)\n");
-		switch(entry->body.zebra_message.sub_error_code)
-		  {
-		  case	1:
-		    printf("    SUB ERROR   : 1 (Connection Not Synchronized)\n");
-		    break;
-					    
-		  case	2:
-		    printf("    SUB ERROR   : 2 (Bad Message Length)\n");
-		    break;
-
-		  case	3:
-		    printf("    SUB ERROR   : 3 (Bad Message Type)\n");
-		    break;
-					    
-		  default:
-		    printf("    SUB ERROR   : %d\n",entry->body.zebra_message.sub_error_code);
-		    break;
-		  }
-		break;
-	      case	2:
-		printf("    ERROR CODE  : 2 (OPEN Message Error)\n");
-		switch(entry->body.zebra_message.sub_error_code)
-		  {
-		  case	1:
-		    printf("    SUB ERROR   : 1 (Unsupported Version Number)\n");
-		    break;
-					    
-		  case	2:
-		    printf("    SUB ERROR   : 2 (Bad Peer AS)\n");
-		    break;
-
-		  case	3:
-		    printf("    SUB ERROR   : 3 (Bad BGP Identifier)\n");
-		    break;
-			           
-		  case	4:
-		    printf("    SUB ERROR   : 4 (Unsupported Optional Parameter)\n");
-		    break;
-
-		  case	5:
-		    printf("    SUB ERROR   : 5 (Authentication Failure)\n");
-		    break;
-
-		  case	6:
-		    printf("    SUB ERROR   : 6 (Unacceptable Hold Time)\n");
-		    break;
-					    
-		  default:
-		    printf("    SUB ERROR   : %d\n",entry->body.zebra_message.sub_error_code);
-		    break;
-		  }
-		break;
-	      case	3:
-		printf("    ERROR CODE  : 3 (UPDATE Message Error)\n");
-		switch(entry->body.zebra_message.sub_error_code)
-		  {
-		  case	1:
-		    printf("    SUB ERROR   : 1 (Malformed Attribute List)\n");
-		    break;
-					    
-		  case	2:
-		    printf("    SUB ERROR   : 2 (Unrecognized Well-known Attribute)\n");
-		    break;
-
-		  case	3:
-		    printf("    SUB ERROR   : 3 (Missing Well-known Attribute)\n");
-		    break;
-			           
-		  case	4:
-		    printf("    SUB ERROR   : 4 (Attribute Flags Error)\n");
-		    break;
-
-		  case	5:
-		    printf("    SUB ERROR   : 5 (Attribute Length Error)\n");
-		    break;
-
-		  case	6:
-		    printf("    SUB ERROR   : 6 (Invalid ORIGIN Attribute)\n");
-		    break;
-				
-		  case	7:
-		    printf("    SUB ERROR   : 7 (AS Routing Loop)\n");
-		    break;
-					    
-		  case	8:
-		    printf("    SUB ERROR   : 8 (Invalid NEXT-HOP Attribute)\n");
-		    break;
-
-		  case	9:
-		    printf("    SUB ERROR   : 9 (Optional Attribute Error)\n");
-		    break;
-			           
-		  case	10:
-		    printf("    SUB ERROR   : 10 (Invalid Network Field)\n");
-		    break;
-
-		  case	11:
-		    printf("    SUB ERROR   : 11 (Malformed AS-PATH)\n");
-		    break;
-	    
-		  default:
-		    printf("    SUB ERROR   : %d\n",entry->body.zebra_message.sub_error_code);
-		    break;
-		  }
-		break;
-	      case	4:
-		printf("    ERROR CODE  : 4 (Hold Timer Expired)\n");
-		break;
-	      case	5:
-		printf("    ERROR CODE  : 5 (Finite State Machine Error)\n");
-		break;
-	      case	6:
-		printf("    ERROR CODE  : 6 (Cease)\n");
-		break;
-	      default:
-		printf("    ERROR CODE  : %d\n",entry->body.zebra_message.error_code);	
-		break;
-					    
-	      }
-	    break;
-			    
-	  case BGP_MSG_KEEPALIVE:
-	    if ( mode != 0)
-	      break;
-
-	    printf("TYPE: BGP4MP/MESSAGE/Keepalive\n");
-	    if (entry->body.zebra_message.source_as)
-	      {
-		printf("FROM:");
-		switch(entry->body.zebra_message.address_family)
-		  {
-		  case AFI_IP6:
-		    bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip,prefix);
-		    printf(" %s ",prefix);
-		    break;
-		  case AFI_IP:
-		  default:
-		    if (entry->body.zebra_message.source_ip.v4_addr.s_addr != 0x00000000L)
-		      printf(" %s ",inet_ntoa(entry->body.zebra_message.source_ip.v4_addr));
-		    else
-		      printf(" N/A ");
-		  }
-		printf("AS%u\n",entry->body.zebra_message.source_as);
-	      }
-	    if (entry->body.zebra_message.destination_as)
-	      {
-		printf("TO:");
-		switch(entry->body.zebra_message.address_family)
-		  {
-		  case AFI_IP6:
-		    bgpdump_fmt_ipv6(entry->body.zebra_message.destination_ip,prefix);
-		    printf(" %s ",prefix);
-		    break;
-		  case AFI_IP:
-		  default:
-		    if (entry->body.zebra_message.destination_ip.v4_addr.s_addr != 0x00000000L)
-		      printf(" %s ",inet_ntoa(entry->body.zebra_message.destination_ip.v4_addr));
-		    else
-		      printf(" N/A ");
-		  }
-		printf("AS%u\n",entry->body.zebra_message.destination_as);
-	      }
-
-
-	    break;
-	  }
-	break;
-
-      case BGPDUMP_SUBTYPE_ZEBRA_BGP_STATE_CHANGE:
-      case BGPDUMP_SUBTYPE_ZEBRA_BGP_STATE_CHANGE_AS4:
-	if (mode==0)
-	  {
-	    printf("TYPE: BGP4MP/STATE_CHANGE\n");
-
-	    printf("PEER:");
-	    switch(entry->body.zebra_state_change.address_family)
-	      {
-	      case AFI_IP6:
-		bgpdump_fmt_ipv6(entry->body.zebra_state_change.source_ip,prefix);
-		printf(" %s ",prefix);
-		break;
-	      case AFI_IP:
-	      default:
-		if (entry->body.zebra_state_change.source_ip.v4_addr.s_addr != 0x00000000L)
-		  printf(" %s ",inet_ntoa(entry->body.zebra_message.source_ip.v4_addr));
-		else
-		  printf(" N/A ");
-	      }	
-	    //if (entry->body.zebra_message.source_ip.s_addr != 0x00000000L)
-	    //	printf(" %s ",inet_ntoa(entry->body.zebra_message.source_ip));
-	    //else
-	    //	printf(" N/A ");
-	    printf("AS%u\n",entry->body.zebra_state_change.source_as);
-
-	    printf("STATE: %s/%s\n",bgp_state_name[entry->body.zebra_state_change.old_state],bgp_state_name[entry->body.zebra_state_change.new_state]);
-	  }
-	else if (mode==1 || mode==2 ) //-m -M
-	  {
-	    switch(entry->body.zebra_state_change.address_family)
-	      {
-	      case AFI_IP6:
-		bgpdump_fmt_ipv6(entry->body.zebra_state_change.source_ip,prefix);
-		if (mode == 1)
-		  printf("BGP4MP|%ld|STATE|%s|%u|%d|%d\n",
-			 entry->time,
-			 prefix,
-			 entry->body.zebra_state_change.source_as,
-			 entry->body.zebra_state_change.old_state,
-			 entry->body.zebra_state_change.new_state);
-		else
-		  printf("BGP4MP|%s|STATE|%s|%u|%d|%d\n",
-			 time_str,
-			 prefix,
-			 entry->body.zebra_state_change.source_as,
-			 entry->body.zebra_state_change.old_state,
-			 entry->body.zebra_state_change.new_state);
-		break;
-	      case AFI_IP:
-	      default:
-		if (mode == 1)
-		  printf("BGP4MP|%ld|STATE|%s|%u|%d|%d\n",
-			 entry->time,
-			 inet_ntoa(entry->body.zebra_state_change.source_ip.v4_addr),
-			 entry->body.zebra_state_change.source_as,
-			 entry->body.zebra_state_change.old_state,
-			 entry->body.zebra_state_change.new_state);
-		else
-		  printf("BGP4MP|%s|STATE|%s|%u|%d|%d\n",
-			 time_str,
-			 inet_ntoa(entry->body.zebra_state_change.source_ip.v4_addr),
-			 entry->body.zebra_state_change.source_as,
-			 entry->body.zebra_state_change.old_state,
-			 entry->body.zebra_state_change.new_state);
-		break;
-
-	      }
-	  }
-	break;
-		
-      } 
+        switch (entry->body.zebra_state_change.address_family) {
+        case AFI_IP6:
+          bgpdump_fmt_ipv6(entry->body.zebra_state_change.source_ip, prefix);
+          if (mode == 1)
+            printf("BGP4MP|%ld|STATE|%s|%u|%d|%d\n", entry->time, prefix,
+                   entry->body.zebra_state_change.source_as,
+                   entry->body.zebra_state_change.old_state,
+                   entry->body.zebra_state_change.new_state);
+          else
+            printf("BGP4MP|%s|STATE|%s|%u|%d|%d\n", time_str, prefix,
+                   entry->body.zebra_state_change.source_as,
+                   entry->body.zebra_state_change.old_state,
+                   entry->body.zebra_state_change.new_state);
+          break;
+        case AFI_IP:
+        default:
+          if (mode == 1)
+            printf("BGP4MP|%ld|STATE|%s|%u|%d|%d\n", entry->time,
+                   inet_ntoa(entry->body.zebra_state_change.source_ip.v4_addr),
+                   entry->body.zebra_state_change.source_as,
+                   entry->body.zebra_state_change.old_state,
+                   entry->body.zebra_state_change.new_state);
+          else
+            printf("BGP4MP|%s|STATE|%s|%u|%d|%d\n", time_str,
+                   inet_ntoa(entry->body.zebra_state_change.source_ip.v4_addr),
+                   entry->body.zebra_state_change.source_as,
+                   entry->body.zebra_state_change.old_state,
+                   entry->body.zebra_state_change.new_state);
+          break;
+        }
+      }
+      break;
+    }
     break;
   }
-  if (mode==0)
+  if (mode == 0)
     printf("\n");
 }
 
-static void show_attr(attributes_t *attr) {
-    
-  if(attr != NULL) {
+static void show_attr(attributes_t *attr)
+{
 
-    if( (attr->flag & ATTR_FLAG_BIT (BGP_ATTR_ORIGIN) ) !=0 )
-      {
-	switch (attr->origin)
-	  {
-	  case 0:
-	    printf("ORIGIN: IGP\n");
-	    break;
-	  case 1:
-	    printf("ORIGIN: EGP\n");
-	    break;
-	  case 2:
-	    printf("ORIGIN: INCOMPLETE\n");
-				    
-	  }
-		   
+  if (attr != NULL) {
+
+    if ((attr->flag & ATTR_FLAG_BIT(BGP_ATTR_ORIGIN)) != 0) {
+      switch (attr->origin) {
+      case 0:
+        printf("ORIGIN: IGP\n");
+        break;
+      case 1:
+        printf("ORIGIN: EGP\n");
+        break;
+      case 2:
+        printf("ORIGIN: INCOMPLETE\n");
       }
+    }
 
     if (!attr->aspath->str) {
       process_attr_aspath_string(attr->aspath, 1);
     }
 
-    if( (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_AS_PATH) ) !=0)		
-      printf("ASPATH: %s\n",attr->aspath->str);
+    if ((attr->flag & ATTR_FLAG_BIT(BGP_ATTR_AS_PATH)) != 0)
+      printf("ASPATH: %s\n", attr->aspath->str);
 
-    if( (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP) ) !=0)		
-      printf("NEXT_HOP: %s\n",inet_ntoa(attr->nexthop));
+    if ((attr->flag & ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP)) != 0)
+      printf("NEXT_HOP: %s\n", inet_ntoa(attr->nexthop));
 
-    if( (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC) ) !=0)	
-      printf("MULTI_EXIT_DISC: %u\n",attr->med);
+    if ((attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC)) != 0)
+      printf("MULTI_EXIT_DISC: %u\n", attr->med);
 
-    if( (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF) ) !=0)		
-      printf("LOCAL_PREF: %u\n",attr->local_pref);
+    if ((attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF)) != 0)
+      printf("LOCAL_PREF: %u\n", attr->local_pref);
 
-    if( (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_ATOMIC_AGGREGATE) ) !=0)	
+    if ((attr->flag & ATTR_FLAG_BIT(BGP_ATTR_ATOMIC_AGGREGATE)) != 0)
       printf("ATOMIC_AGGREGATE\n");
 
-    if( (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_AGGREGATOR) ) !=0)		
-      printf("AGGREGATOR: AS%u %s\n",attr->aggregator_as,inet_ntoa(attr->aggregator_addr));
+    if ((attr->flag & ATTR_FLAG_BIT(BGP_ATTR_AGGREGATOR)) != 0)
+      printf("AGGREGATOR: AS%u %s\n", attr->aggregator_as,
+             inet_ntoa(attr->aggregator_addr));
 
-    if( (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_ORIGINATOR_ID) ) !=0)
-      printf("ORIGINATOR_ID: %s\n",inet_ntoa(attr->originator_id));
-	
-    if( (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_CLUSTER_LIST) ) !=0)
-      {
-	int cluster_index;
+    if ((attr->flag & ATTR_FLAG_BIT(BGP_ATTR_ORIGINATOR_ID)) != 0)
+      printf("ORIGINATOR_ID: %s\n", inet_ntoa(attr->originator_id));
 
-	printf("CLUSTER_LIST: ");
+    if ((attr->flag & ATTR_FLAG_BIT(BGP_ATTR_CLUSTER_LIST)) != 0) {
+      int cluster_index;
 
-	for (cluster_index = 0;cluster_index<attr->cluster->length;cluster_index++)
-	  printf("%s ",inet_ntoa(attr->cluster->list[cluster_index]));
-	printf("\n");
-      }
+      printf("CLUSTER_LIST: ");
+
+      for (cluster_index = 0; cluster_index < attr->cluster->length;
+           cluster_index++)
+        printf("%s ", inet_ntoa(attr->cluster->list[cluster_index]));
+      printf("\n");
+    }
 
     int idx;
-    for (idx=0;idx<attr->unknown_num;idx++)
+    for (idx = 0; idx < attr->unknown_num; idx++) {
+      struct unknown_attr *unknown = attr->unknown + idx;
+      printf("   UNKNOWN_ATTR(%i, %i, %i):", unknown->flag, unknown->type,
+             unknown->len);
+      int b;
+      for (b = 0; b < unknown->len; ++b)
+        printf(" %02x", unknown->raw[b]);
+      printf("\n");
+    }
+
+    if ((attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MP_REACH_NLRI)) != 0) {
+      printf("MP_REACH_NLRI");
+      if (attr->mp_info->announce[AFI_IP6][SAFI_UNICAST] ||
+          attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST] ||
+          attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST])
+
       {
-	struct unknown_attr *unknown = attr->unknown + idx;
-	printf("   UNKNOWN_ATTR(%i, %i, %i):", unknown->flag, unknown->type, unknown->len);
-	int b;
-	for(b = 0; b < unknown->len; ++b)
-	  printf(" %02x", unknown->raw[b]);
-	printf("\n");
+        char buf[128];
+
+        if (attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]) {
+          printf("(IPv6 Unicast)\n");
+          printf(
+            "NEXT_HOP: %s\n",
+            bgpdump_fmt_ipv6(
+              attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]->nexthop, buf));
+          if (attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]->nexthop_len == 32)
+            printf(
+              "NEXT_HOP: %s\n",
+              bgpdump_fmt_ipv6(
+                attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]->nexthop_local,
+                buf));
+        } else if (attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST]) {
+          printf("(IPv6 Multicast)\n");
+          printf(
+            "NEXT_HOP: %s\n",
+            bgpdump_fmt_ipv6(
+              attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST]->nexthop, buf));
+          if (attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST]->nexthop_len ==
+              32)
+            printf(
+              "NEXT_HOP: %s\n",
+              bgpdump_fmt_ipv6(
+                attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST]->nexthop_local,
+                buf));
+
+        } else {
+          printf("(IPv6 Both unicast and multicast)\n");
+          printf(
+            "NEXT_HOP: %s\n",
+            bgpdump_fmt_ipv6(
+              attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST]->nexthop,
+              buf));
+          if (attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST]
+                ->nexthop_len == 32)
+            printf("NEXT_HOP: %s\n",
+                   bgpdump_fmt_ipv6(
+                     attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST]
+                       ->nexthop_local,
+                     buf));
+        }
+      } else {
+
+        if (attr->mp_info->announce[AFI_IP][SAFI_UNICAST]) {
+          printf("(IPv4 Unicast)\n");
+          printf(
+            "NEXT_HOP: %s\n",
+            inet_ntoa(
+              attr->mp_info->announce[AFI_IP][SAFI_UNICAST]->nexthop.v4_addr));
+          if (attr->mp_info->announce[AFI_IP][SAFI_UNICAST]->nexthop_len == 32)
+            printf("NEXT_HOP: %s\n",
+                   inet_ntoa(attr->mp_info->announce[AFI_IP][SAFI_UNICAST]
+                               ->nexthop_local.v4_addr));
+
+        } else if (attr->mp_info->announce[AFI_IP][SAFI_MULTICAST]) {
+          printf("(IPv4 Multicast)\n");
+          printf("NEXT_HOP: %s\n",
+                 inet_ntoa(attr->mp_info->announce[AFI_IP][SAFI_MULTICAST]
+                             ->nexthop.v4_addr));
+          if (attr->mp_info->announce[AFI_IP][SAFI_MULTICAST]->nexthop_len ==
+              32)
+            printf("NEXT_HOP: %s\n",
+                   inet_ntoa(attr->mp_info->announce[AFI_IP][SAFI_MULTICAST]
+                               ->nexthop_local.v4_addr));
+
+        } else if (attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST]) {
+          printf("(IPv4 Both unicast and multicast)\n");
+          printf(
+            "NEXT_HOP: %s\n",
+            inet_ntoa(attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST]
+                        ->nexthop.v4_addr));
+          if (attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST]
+                ->nexthop_len == 32)
+            printf(
+              "NEXT_HOP: %s\n",
+              inet_ntoa(attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST]
+                          ->nexthop_local.v4_addr));
+        }
       }
+    }
 
-    if( (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MP_REACH_NLRI) )!=0)
+    if ((attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MP_UNREACH_NLRI)) != 0) {
+      printf("MP_UNREACH_NLRI");
+      if (attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST] ||
+          attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST] ||
+          attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST])
+
       {
-	printf("MP_REACH_NLRI");
-	if (attr->mp_info->announce[AFI_IP6][SAFI_UNICAST] || attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST] || attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST])
 
-	  {
-	    char buf[128];
-			    
-	    if (attr->mp_info->announce[AFI_IP6][SAFI_UNICAST])
-	      {
-		printf("(IPv6 Unicast)\n");
-		printf("NEXT_HOP: %s\n",bgpdump_fmt_ipv6(attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]->nexthop,buf));
-		if (attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]->nexthop_len==32)
-		  printf("NEXT_HOP: %s\n",bgpdump_fmt_ipv6(attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]->nexthop_local,buf));
-	      }
-	    else if (attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST])	 
-	      {
-		printf("(IPv6 Multicast)\n");
-		printf("NEXT_HOP: %s\n",bgpdump_fmt_ipv6(attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST]->nexthop,buf));
-		if (attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST]->nexthop_len==32)
-		  printf("NEXT_HOP: %s\n",bgpdump_fmt_ipv6(attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST]->nexthop_local,buf));
+        if (attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST]) {
+          printf("(IPv6 Unicast)\n");
+        } else if (attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST]) {
+          printf("(IPv6 Multicast)\n");
 
-	      }
-	    else
-	      {
-		printf("(IPv6 Both unicast and multicast)\n");
-		printf("NEXT_HOP: %s\n",bgpdump_fmt_ipv6(attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST]->nexthop,buf));
-		if (attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST]->nexthop_len==32)
-		  printf("NEXT_HOP: %s\n",bgpdump_fmt_ipv6(attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST]->nexthop_local,buf));
+        } else {
+          printf("(IPv6 Both unicast and multicast)\n");
+        }
+      } else {
 
+        if (attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST]) {
+          printf("(IPv4 Unicast)\n");
 
-	      }
-	  }
-	else
-	  {
-			   
-	    if (attr->mp_info->announce[AFI_IP][SAFI_UNICAST])
-	      {
-		printf("(IPv4 Unicast)\n");
-		printf("NEXT_HOP: %s\n",inet_ntoa(attr->mp_info->announce[AFI_IP][SAFI_UNICAST]->nexthop.v4_addr));
-		if (attr->mp_info->announce[AFI_IP][SAFI_UNICAST]->nexthop_len==32)
-		  printf("NEXT_HOP: %s\n",inet_ntoa(attr->mp_info->announce[AFI_IP][SAFI_UNICAST]->nexthop_local.v4_addr));
-			  
-	      }
-	    else if (attr->mp_info->announce[AFI_IP][SAFI_MULTICAST])	 
-	      {
-		printf("(IPv4 Multicast)\n");
-		printf("NEXT_HOP: %s\n",inet_ntoa(attr->mp_info->announce[AFI_IP][SAFI_MULTICAST]->nexthop.v4_addr));
-		if (attr->mp_info->announce[AFI_IP][SAFI_MULTICAST]->nexthop_len==32)
-		  printf("NEXT_HOP: %s\n",inet_ntoa(attr->mp_info->announce[AFI_IP][SAFI_MULTICAST]->nexthop_local.v4_addr));
-			  
-		
-	      }
-	    else if (attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST])
-	      {
-		printf("(IPv4 Both unicast and multicast)\n");
-		printf("NEXT_HOP: %s\n",inet_ntoa(attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST]->nexthop.v4_addr));
-		if (attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST]->nexthop_len==32)
-		  printf("NEXT_HOP: %s\n",inet_ntoa(attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST]->nexthop_local.v4_addr));
-			  
+        } else if (attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST]) {
+          printf("(IPv4 Multicast)\n");
 
-	      }
-  
-	  }
+        } else if (attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST]) {
+          printf("(IPv4 Both unicast and multicast)\n");
+        }
       }
-	    
-    if( (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MP_UNREACH_NLRI) )!=0)
-      {
-	printf("MP_UNREACH_NLRI");
-	if (attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST] || attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST] || attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST])
-
-	  {
-			    
-	    if (attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST])
-	      {
-		printf("(IPv6 Unicast)\n");
-	      }
-	    else if (attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST])	 
-	      {
-		printf("(IPv6 Multicast)\n");
-
-	      }
-	    else
-	      {
-		printf("(IPv6 Both unicast and multicast)\n");
-
-
-	      }
-	  }
-	else
-	  {
-			   
-	    if (attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST])
-	      {
-		printf("(IPv4 Unicast)\n");
-			  
-	      }
-	    else if (attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST])	 
-	      {
-		printf("(IPv4 Multicast)\n");
-			  
-		
-	      }
-	    else if (attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST])
-	      {
-		printf("(IPv4 Both unicast and multicast)\n");
-			  
-
-	      }
-  
-	  }
-      } 
-    if( (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES) ) !=0)
-      {
-        if(attr->community->str == NULL)
-          {
-            process_attr_community_string(attr->community);
-          }
-        printf("COMMUNITY:%s\n",attr->community->str);
+    }
+    if ((attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES)) != 0) {
+      if (attr->community->str == NULL) {
+        process_attr_community_string(attr->community);
       }
+      printf("COMMUNITY:%s\n", attr->community->str);
+    }
   }
- 
 }
 
-static void show_prefixes(int count,struct prefix *prefix) {
+static void show_prefixes(int count, struct prefix *prefix)
+{
   int i;
-  for(i=0;i<count;i++)
-    printf("  %s/%d\n",inet_ntoa(prefix[i].address.v4_addr),prefix[i].len);
+  for (i = 0; i < count; i++)
+    printf("  %s/%d\n", inet_ntoa(prefix[i].address.v4_addr), prefix[i].len);
 }
 
-void show_prefixes6(int count,struct prefix *prefix)
+void show_prefixes6(int count, struct prefix *prefix)
 {
   int i;
   char buf[128];
 
-  for (i=0;i<count;i++)
-    printf("  %s/%d\n",bgpdump_fmt_ipv6(prefix[i].address,buf),prefix[i].len);
+  for (i = 0; i < count; i++)
+    printf("  %s/%d\n", bgpdump_fmt_ipv6(prefix[i].address, buf),
+           prefix[i].len);
 }
 
-
-static void table_line_withdraw(struct prefix *prefix,int count,BGPDUMP_ENTRY *entry,char *time_str)
+static void table_line_withdraw(struct prefix *prefix, int count,
+                                BGPDUMP_ENTRY *entry, char *time_str)
 {
   int idx;
   char buf[128];
-	
-  for (idx=0;idx<count;idx++)
-    {
-      if (mode==1)
-	{
-	  switch(entry->body.zebra_message.address_family)
-	    {
-	    case AFI_IP6:
-	      printf("BGP4MP|%ld|W|%s|%u|",
-		     entry->time,
-		     bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip,buf),
-		     entry->body.zebra_message.source_as);
-	      break;
-	    case AFI_IP:
-	    default:
-	      printf("BGP4MP|%ld|W|%s|%u|",
-		     entry->time,
-		     inet_ntoa(entry->body.zebra_message.source_ip.v4_addr),
-		     entry->body.zebra_message.source_as);
-	      break;
-	    }
-	  printf("%s/%d\n",inet_ntoa(prefix[idx].address.v4_addr),prefix[idx].len);
-	}
-      else
-	{
-	  switch(entry->body.zebra_message.address_family)
-	    {
-	    case AFI_IP6:
-	      printf("BGP4MP|%s|W|%s|%u|",
-		     time_str,
-		     bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip,buf),
-		     entry->body.zebra_message.source_as);
-	      break;
-	    case AFI_IP:
-	    default:
-	      printf("BGP4MP|%s|W|%s|%u|",
-		     time_str,
-		     inet_ntoa(entry->body.zebra_message.source_ip.v4_addr),
-		     entry->body.zebra_message.source_as);
-	      break;
-	    }
-	  printf("%s/%d\n",inet_ntoa(prefix[idx].address.v4_addr),prefix[idx].len);
-	}
-		
+
+  for (idx = 0; idx < count; idx++) {
+    if (mode == 1) {
+      switch (entry->body.zebra_message.address_family) {
+      case AFI_IP6:
+        printf("BGP4MP|%ld|W|%s|%u|", entry->time,
+               bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip, buf),
+               entry->body.zebra_message.source_as);
+        break;
+      case AFI_IP:
+      default:
+        printf("BGP4MP|%ld|W|%s|%u|", entry->time,
+               inet_ntoa(entry->body.zebra_message.source_ip.v4_addr),
+               entry->body.zebra_message.source_as);
+        break;
+      }
+      printf("%s/%d\n", inet_ntoa(prefix[idx].address.v4_addr),
+             prefix[idx].len);
+    } else {
+      switch (entry->body.zebra_message.address_family) {
+      case AFI_IP6:
+        printf("BGP4MP|%s|W|%s|%u|", time_str,
+               bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip, buf),
+               entry->body.zebra_message.source_as);
+        break;
+      case AFI_IP:
+      default:
+        printf("BGP4MP|%s|W|%s|%u|", time_str,
+               inet_ntoa(entry->body.zebra_message.source_ip.v4_addr),
+               entry->body.zebra_message.source_as);
+        break;
+      }
+      printf("%s/%d\n", inet_ntoa(prefix[idx].address.v4_addr),
+             prefix[idx].len);
     }
+  }
 }
 
-
-static void table_line_withdraw6(struct prefix *prefix,int count,BGPDUMP_ENTRY *entry,char *time_str)
+static void table_line_withdraw6(struct prefix *prefix, int count,
+                                 BGPDUMP_ENTRY *entry, char *time_str)
 {
   int idx;
   char buf[128];
   char buf1[128];
 
-  for (idx=0;idx<count;idx++)
-    {
-      if (mode==1)
-	{
-	  switch(entry->body.zebra_message.address_family)
-	    {
-	    case AFI_IP6:
-	      printf("BGP4MP|%ld|W|%s|%u|%s/%d\n",
-		     entry->time,
-		     bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip,buf1),
-		     entry->body.zebra_message.source_as,
-		     bgpdump_fmt_ipv6(prefix[idx].address,buf),prefix[idx].len);
-	      break;
-	    case AFI_IP:
-	    default:
-	      printf("BGP4MP|%ld|W|%s|%u|%s/%d\n",
-		     entry->time,
-		     bgpdump_fmt_ipv4(entry->body.zebra_message.source_ip,buf1),
-		     entry->body.zebra_message.source_as,
-		     bgpdump_fmt_ipv6(prefix[idx].address,buf),prefix[idx].len);
-	      break;
-	    }
-	}	
-      else
-	{
-	  switch(entry->body.zebra_message.address_family)
-	    {
-	    case AFI_IP6:
-	      printf("BGP4MP|%s|W|%s|%u|%s/%d\n",
-		     time_str,
-		     bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip,buf1),
-		     entry->body.zebra_message.source_as,
-		     bgpdump_fmt_ipv6(prefix[idx].address,buf),prefix[idx].len);
-	      break;
-	    case AFI_IP:
-	    default:
-	      printf("BGP4MP|%s|W|%s|%u|%s/%d\n",
-		     time_str,
-		     bgpdump_fmt_ipv4(entry->body.zebra_message.source_ip,buf1),
-		     entry->body.zebra_message.source_as,
-		     bgpdump_fmt_ipv6(prefix[idx].address,buf),prefix[idx].len);
-	      break;
-	    }
-	}
-
+  for (idx = 0; idx < count; idx++) {
+    if (mode == 1) {
+      switch (entry->body.zebra_message.address_family) {
+      case AFI_IP6:
+        printf("BGP4MP|%ld|W|%s|%u|%s/%d\n", entry->time,
+               bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip, buf1),
+               entry->body.zebra_message.source_as,
+               bgpdump_fmt_ipv6(prefix[idx].address, buf), prefix[idx].len);
+        break;
+      case AFI_IP:
+      default:
+        printf("BGP4MP|%ld|W|%s|%u|%s/%d\n", entry->time,
+               bgpdump_fmt_ipv4(entry->body.zebra_message.source_ip, buf1),
+               entry->body.zebra_message.source_as,
+               bgpdump_fmt_ipv6(prefix[idx].address, buf), prefix[idx].len);
+        break;
+      }
+    } else {
+      switch (entry->body.zebra_message.address_family) {
+      case AFI_IP6:
+        printf("BGP4MP|%s|W|%s|%u|%s/%d\n", time_str,
+               bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip, buf1),
+               entry->body.zebra_message.source_as,
+               bgpdump_fmt_ipv6(prefix[idx].address, buf), prefix[idx].len);
+        break;
+      case AFI_IP:
+      default:
+        printf("BGP4MP|%s|W|%s|%u|%s/%d\n", time_str,
+               bgpdump_fmt_ipv4(entry->body.zebra_message.source_ip, buf1),
+               entry->body.zebra_message.source_as,
+               bgpdump_fmt_ipv6(prefix[idx].address, buf), prefix[idx].len);
+        break;
+      }
     }
+  }
 }
 
-
-static void table_line_announce(struct prefix *prefix,int count,BGPDUMP_ENTRY *entry,char *time_str)
+static void table_line_announce(struct prefix *prefix, int count,
+                                BGPDUMP_ENTRY *entry, char *time_str)
 {
-  int idx  ;
+  int idx;
   char buf[128];
-  //char buf1[128];
-  //char buf2[128];
+  // char buf1[128];
+  // char buf2[128];
   char tmp1[20];
   char tmp2[20];
   unsigned int npref;
   unsigned int nmed;
-				
-  switch (entry->attr->origin)
-    {
 
-    case 0 :
-      sprintf(tmp1,"IGP");
-      break;
-    case 1:
-      sprintf(tmp1,"EGP");
-      break;
-    case 2:
-    default:
-      sprintf(tmp1,"INCOMPLETE");
-      break;
-    }
+  switch (entry->attr->origin) {
+
+  case 0:
+    sprintf(tmp1, "IGP");
+    break;
+  case 1:
+    sprintf(tmp1, "EGP");
+    break;
+  case 2:
+  default:
+    sprintf(tmp1, "INCOMPLETE");
+    break;
+  }
   if (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_ATOMIC_AGGREGATE))
-    sprintf(tmp2,"AG");
+    sprintf(tmp2, "AG");
   else
-    sprintf(tmp2,"NAG");
+    sprintf(tmp2, "NAG");
 
-  for (idx=0;idx<count;idx++)
-    {
-      if (mode == 1)
-	{
-	  switch(entry->body.zebra_message.address_family)
-	    {
-	    case AFI_IP6:
-	      printf("BGP4MP|%ld|A|%s|%u|",entry->time,bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip,buf),entry->body.zebra_message.source_as);
-	      break;
-	    case AFI_IP:
-	    default:
-	      printf("BGP4MP|%ld|A|%s|%u|",entry->time,inet_ntoa(entry->body.zebra_message.source_ip.v4_addr),entry->body.zebra_message.source_as);
-	      break;
-	    }
-	  printf("%s/%d|%s|%s|",inet_ntoa(prefix[idx].address.v4_addr),prefix[idx].len,attr_aspath(entry->attr),tmp1);
-	  npref=entry->attr->local_pref;
-	  if( (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF) ) ==0)
-	    npref=0;
-	  nmed=entry->attr->med;
-	  if( (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC) ) ==0)
-	    nmed=0;
-			    
-	  printf("%s|%u|%u|",inet_ntoa(entry->attr->nexthop),npref,nmed);
-	  if( (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES) ) !=0)
-            {
-              if(entry->attr->community->str == NULL)
-                {
-                  process_attr_community_string(entry->attr->community);
-                }
-              printf("%s|%s|",entry->attr->community->str+1,tmp2);
-            }
-	  else
-	    printf("|%s|",tmp2);
-				
-	  if (entry->attr->aggregator_addr.s_addr != -1)
-	    printf("%u %s|\n",entry->attr->aggregator_as,inet_ntoa(entry->attr->aggregator_addr));
-	  else
-	    printf("|\n");
-	}
+  for (idx = 0; idx < count; idx++) {
+    if (mode == 1) {
+      switch (entry->body.zebra_message.address_family) {
+      case AFI_IP6:
+        printf("BGP4MP|%ld|A|%s|%u|", entry->time,
+               bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip, buf),
+               entry->body.zebra_message.source_as);
+        break;
+      case AFI_IP:
+      default:
+        printf("BGP4MP|%ld|A|%s|%u|", entry->time,
+               inet_ntoa(entry->body.zebra_message.source_ip.v4_addr),
+               entry->body.zebra_message.source_as);
+        break;
+      }
+      printf("%s/%d|%s|%s|", inet_ntoa(prefix[idx].address.v4_addr),
+             prefix[idx].len, attr_aspath(entry->attr), tmp1);
+      npref = entry->attr->local_pref;
+      if ((entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF)) == 0)
+        npref = 0;
+      nmed = entry->attr->med;
+      if ((entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC)) == 0)
+        nmed = 0;
+
+      printf("%s|%u|%u|", inet_ntoa(entry->attr->nexthop), npref, nmed);
+      if ((entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES)) != 0) {
+        if (entry->attr->community->str == NULL) {
+          process_attr_community_string(entry->attr->community);
+        }
+        printf("%s|%s|", entry->attr->community->str + 1, tmp2);
+      } else
+        printf("|%s|", tmp2);
+
+      if (entry->attr->aggregator_addr.s_addr != -1)
+        printf("%u %s|\n", entry->attr->aggregator_as,
+               inet_ntoa(entry->attr->aggregator_addr));
       else
-	{
-	  switch(entry->body.zebra_message.address_family)
-	    {
-	    case AFI_IP6:
-	      printf("BGP4MP|%s|A|%s|%u|",time_str,bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip,buf),entry->body.zebra_message.source_as);
-	      break;
-	    case AFI_IP:
-	    default:
-	      printf("BGP4MP|%s|A|%s|%u|",time_str,inet_ntoa(entry->body.zebra_message.source_ip.v4_addr),entry->body.zebra_message.source_as);
-	      break;
-	    }
-	  printf("%s/%d|%s|%s\n",inet_ntoa(prefix[idx].address.v4_addr),prefix[idx].len,attr_aspath(entry->attr),tmp1);
-				
-	}
+        printf("|\n");
+    } else {
+      switch (entry->body.zebra_message.address_family) {
+      case AFI_IP6:
+        printf("BGP4MP|%s|A|%s|%u|", time_str,
+               bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip, buf),
+               entry->body.zebra_message.source_as);
+        break;
+      case AFI_IP:
+      default:
+        printf("BGP4MP|%s|A|%s|%u|", time_str,
+               inet_ntoa(entry->body.zebra_message.source_ip.v4_addr),
+               entry->body.zebra_message.source_as);
+        break;
+      }
+      printf("%s/%d|%s|%s\n", inet_ntoa(prefix[idx].address.v4_addr),
+             prefix[idx].len, attr_aspath(entry->attr), tmp1);
     }
-
+  }
 }
-static void table_line_announce_1(struct mp_nlri *prefix,int count,BGPDUMP_ENTRY *entry,char *time_str)
+static void table_line_announce_1(struct mp_nlri *prefix, int count,
+                                  BGPDUMP_ENTRY *entry, char *time_str)
 {
-  int idx  ;
+  int idx;
   char buf[128];
-  //char buf1[128];
-  //char buf2[128];
+  // char buf1[128];
+  // char buf2[128];
   char tmp1[20];
   char tmp2[20];
   unsigned int npref;
   unsigned int nmed;
-				
-  switch (entry->attr->origin)
-    {
 
-    case 0 :
-      sprintf(tmp1,"IGP");
-      break;
-    case 1:
-      sprintf(tmp1,"EGP");
-      break;
-    case 2:
-    default:
-      sprintf(tmp1,"INCOMPLETE");
-      break;
-    }
+  switch (entry->attr->origin) {
+
+  case 0:
+    sprintf(tmp1, "IGP");
+    break;
+  case 1:
+    sprintf(tmp1, "EGP");
+    break;
+  case 2:
+  default:
+    sprintf(tmp1, "INCOMPLETE");
+    break;
+  }
   if (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_ATOMIC_AGGREGATE))
-    sprintf(tmp2,"AG");
+    sprintf(tmp2, "AG");
   else
-    sprintf(tmp2,"NAG");
+    sprintf(tmp2, "NAG");
 
-  for (idx=0;idx<count;idx++)
-    {
-      if (mode == 1)
-	{
-	  if (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MP_REACH_NLRI))
-	    {
-	      switch(entry->body.zebra_message.address_family)
-		{
-		case AFI_IP6:
-		  printf("BGP4MP|%ld|A|%s|%u|",entry->time,bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip,buf),entry->body.zebra_message.source_as);
-		  break;
-		case AFI_IP:
-		default:
-		  printf("BGP4MP|%ld|A|%s|%u|",entry->time,inet_ntoa(entry->body.zebra_message.source_ip.v4_addr),entry->body.zebra_message.source_as);
-		  break;
-		}
-	      printf("%s/%d|%s|%s|",inet_ntoa(prefix->nlri[idx].address.v4_addr),prefix->nlri[idx].len,attr_aspath(entry->attr),tmp1);
+  for (idx = 0; idx < count; idx++) {
+    if (mode == 1) {
+      if (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MP_REACH_NLRI)) {
+        switch (entry->body.zebra_message.address_family) {
+        case AFI_IP6:
+          printf("BGP4MP|%ld|A|%s|%u|", entry->time,
+                 bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip, buf),
+                 entry->body.zebra_message.source_as);
+          break;
+        case AFI_IP:
+        default:
+          printf("BGP4MP|%ld|A|%s|%u|", entry->time,
+                 inet_ntoa(entry->body.zebra_message.source_ip.v4_addr),
+                 entry->body.zebra_message.source_as);
+          break;
+        }
+        printf("%s/%d|%s|%s|", inet_ntoa(prefix->nlri[idx].address.v4_addr),
+               prefix->nlri[idx].len, attr_aspath(entry->attr), tmp1);
 
-	      npref=entry->attr->local_pref;
-	      if( (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF) ) ==0)
-		npref=0;
-	      nmed=entry->attr->med;
-	      if( (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC) ) ==0)
-		nmed=0;
-			    
-	      printf("%s|%d|%d|",inet_ntoa(entry->attr->nexthop),npref,nmed);
-	      //printf("%s|%d|%d|",inet_ntoa(prefix->nexthop.v4_addr),entry->attr->local_pref,entry->attr->med);
-	      if( (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES) ) !=0)
-                {
-                  if(entry->attr->community->str == NULL)
-                    {
-                      process_attr_community_string(entry->attr->community);
-                    }
-                  printf("%s|%s|",entry->attr->community->str+1,tmp2);
-                }
-	      else
-		printf("|%s|",tmp2);
+        npref = entry->attr->local_pref;
+        if ((entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF)) == 0)
+          npref = 0;
+        nmed = entry->attr->med;
+        if ((entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC)) == 0)
+          nmed = 0;
 
-	    }
-	  else 
-	    {
-	      switch(entry->body.zebra_message.address_family)
-		{
-		case AFI_IP6:
-		  printf("BGP4MP|%ld|A|%s|%u|",entry->time,bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip,buf),entry->body.zebra_message.source_as);
-		  break;
-		case AFI_IP:
-		default:
-		  printf("BGP4MP|%ld|A|%s|%u|",entry->time,inet_ntoa(entry->body.zebra_message.source_ip.v4_addr),entry->body.zebra_message.source_as);
-		  break;
-		}
-	      printf("%s/%d|%s|%s|",inet_ntoa(prefix->nlri[idx].address.v4_addr),prefix->nlri[idx].len,attr_aspath(entry->attr),tmp1);
+        printf("%s|%d|%d|", inet_ntoa(entry->attr->nexthop), npref, nmed);
+        // printf("%s|%d|%d|",inet_ntoa(prefix->nexthop.v4_addr),entry->attr->local_pref,entry->attr->med);
+        if ((entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES)) != 0) {
+          if (entry->attr->community->str == NULL) {
+            process_attr_community_string(entry->attr->community);
+          }
+          printf("%s|%s|", entry->attr->community->str + 1, tmp2);
+        } else
+          printf("|%s|", tmp2);
 
-	      npref=entry->attr->local_pref;
-	      if( (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF) ) ==0)
-		npref=0;
-	      nmed=entry->attr->med;
-	      if( (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC) ) ==0)
-		nmed=0;
-			    
-	      printf("%s|%d|%d|",inet_ntoa(entry->attr->nexthop),npref,nmed);
-	      //printf("%s|%d|%d|",inet_ntoa(entry->attr->nexthop),entry->attr->local_pref,entry->attr->med);
-	      if( (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES) ) !=0)
-                {
-                  if(entry->attr->community->str == NULL)
-                    {
-                      process_attr_community_string(entry->attr->community);
-                    }
-                  printf("%s|%s|",entry->attr->community->str+1,tmp2);
-                }
-	      else
-		printf("|%s|",tmp2);
+      } else {
+        switch (entry->body.zebra_message.address_family) {
+        case AFI_IP6:
+          printf("BGP4MP|%ld|A|%s|%u|", entry->time,
+                 bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip, buf),
+                 entry->body.zebra_message.source_as);
+          break;
+        case AFI_IP:
+        default:
+          printf("BGP4MP|%ld|A|%s|%u|", entry->time,
+                 inet_ntoa(entry->body.zebra_message.source_ip.v4_addr),
+                 entry->body.zebra_message.source_as);
+          break;
+        }
+        printf("%s/%d|%s|%s|", inet_ntoa(prefix->nlri[idx].address.v4_addr),
+               prefix->nlri[idx].len, attr_aspath(entry->attr), tmp1);
 
+        npref = entry->attr->local_pref;
+        if ((entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF)) == 0)
+          npref = 0;
+        nmed = entry->attr->med;
+        if ((entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC)) == 0)
+          nmed = 0;
 
-	    }
-	  if (entry->attr->aggregator_addr.s_addr != -1)
-	    printf("%u %s|\n",entry->attr->aggregator_as,inet_ntoa(entry->attr->aggregator_addr));
-	  else
-	    printf("|\n");
-	}
+        printf("%s|%d|%d|", inet_ntoa(entry->attr->nexthop), npref, nmed);
+        // printf("%s|%d|%d|",inet_ntoa(entry->attr->nexthop),entry->attr->local_pref,entry->attr->med);
+        if ((entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES)) != 0) {
+          if (entry->attr->community->str == NULL) {
+            process_attr_community_string(entry->attr->community);
+          }
+          printf("%s|%s|", entry->attr->community->str + 1, tmp2);
+        } else
+          printf("|%s|", tmp2);
+      }
+      if (entry->attr->aggregator_addr.s_addr != -1)
+        printf("%u %s|\n", entry->attr->aggregator_as,
+               inet_ntoa(entry->attr->aggregator_addr));
       else
-	{
-	  switch(entry->body.zebra_message.address_family)
-	    {
-	    case AFI_IP6:
-	      printf("BGP4MP|%s|A|%s|%u|",time_str,bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip,buf),entry->body.zebra_message.source_as);
-	      break;
-	    case AFI_IP:
-	    default:
-	      printf("BGP4MP|%s|A|%s|%u|",time_str,inet_ntoa(entry->body.zebra_message.source_ip.v4_addr),entry->body.zebra_message.source_as);
-	      break;
-	    }
-	  printf("%s/%d|%s|%s\n",inet_ntoa(prefix->nlri[idx].address.v4_addr),prefix->nlri[idx].len,attr_aspath(entry->attr),tmp1);
-				
-	}
+        printf("|\n");
+    } else {
+      switch (entry->body.zebra_message.address_family) {
+      case AFI_IP6:
+        printf("BGP4MP|%s|A|%s|%u|", time_str,
+               bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip, buf),
+               entry->body.zebra_message.source_as);
+        break;
+      case AFI_IP:
+      default:
+        printf("BGP4MP|%s|A|%s|%u|", time_str,
+               inet_ntoa(entry->body.zebra_message.source_ip.v4_addr),
+               entry->body.zebra_message.source_as);
+        break;
+      }
+      printf("%s/%d|%s|%s\n", inet_ntoa(prefix->nlri[idx].address.v4_addr),
+             prefix->nlri[idx].len, attr_aspath(entry->attr), tmp1);
     }
-
+  }
 }
 
-static void table_line_announce6(struct mp_nlri *prefix,int count,BGPDUMP_ENTRY *entry,char *time_str)
+static void table_line_announce6(struct mp_nlri *prefix, int count,
+                                 BGPDUMP_ENTRY *entry, char *time_str)
 {
-  int idx  ;
+  int idx;
   char buf[128];
   char buf1[128];
   char buf2[128];
@@ -1268,286 +1412,285 @@ static void table_line_announce6(struct mp_nlri *prefix,int count,BGPDUMP_ENTRY 
   char tmp2[20];
   unsigned int npref;
   unsigned int nmed;
-				
-  switch (entry->attr->origin)
-    {
 
-    case 0 :
-      sprintf(tmp1,"IGP");
-      break;
-    case 1:
-      sprintf(tmp1,"EGP");
-      break;
-    case 2:
-    default:
-      sprintf(tmp1,"INCOMPLETE");
-      break;
-    }
+  switch (entry->attr->origin) {
+
+  case 0:
+    sprintf(tmp1, "IGP");
+    break;
+  case 1:
+    sprintf(tmp1, "EGP");
+    break;
+  case 2:
+  default:
+    sprintf(tmp1, "INCOMPLETE");
+    break;
+  }
   if (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_ATOMIC_AGGREGATE))
-    sprintf(tmp2,"AG");
+    sprintf(tmp2, "AG");
   else
-    sprintf(tmp2,"NAG");
+    sprintf(tmp2, "NAG");
 
-  for (idx=0;idx<count;idx++)
-    {
-      if (mode == 1)
-	{
-	  switch(entry->body.zebra_message.address_family)
-	    {
-	    case AFI_IP6:
-				
-	      npref=entry->attr->local_pref;
-	      if( (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF) ) ==0)
-		npref=0;
-	      nmed=entry->attr->med;
-	      if( (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC) ) ==0)
-		nmed=0;
-			    
-	      printf("BGP4MP|%ld|A|%s|%u|%s/%d|%s|%s|%s|%u|%u|",entry->time,bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip,buf1),entry->body.zebra_message.source_as,bgpdump_fmt_ipv6(prefix->nlri[idx].address,buf2),prefix->nlri[idx].len,attr_aspath(entry->attr),tmp1,bgpdump_fmt_ipv6(prefix->nexthop,buf),npref,nmed);
-	      break;
-	    case AFI_IP:
-	    default:
+  for (idx = 0; idx < count; idx++) {
+    if (mode == 1) {
+      switch (entry->body.zebra_message.address_family) {
+      case AFI_IP6:
 
-	      npref=entry->attr->local_pref;
-	      if( (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF) ) ==0)
-		npref=0;
-	      nmed=entry->attr->med;
-	      if( (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC) ) ==0)
-		nmed=0;
-			    
-	      //printf("%s|%d|%d|",inet_ntoa(entry->attr->nexthop),nprof,nmed);
-	      printf("BGP4MP|%ld|A|%s|%u|%s/%d|%s|%s|%s|%u|%u|",entry->time,bgpdump_fmt_ipv4(entry->body.zebra_message.source_ip,buf1),entry->body.zebra_message.source_as,bgpdump_fmt_ipv6(prefix->nlri[idx].address,buf2),prefix->nlri[idx].len,attr_aspath(entry->attr),tmp1,bgpdump_fmt_ipv6(prefix->nexthop,buf),npref,nmed);
-	      break;
-	    }
-	  if( (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES) ) !=0)
-            {
-              if(entry->attr->community->str == NULL)
-                {
-                  process_attr_community_string(entry->attr->community);
-                }
-              printf("%s|%s|",entry->attr->community->str+1,tmp2);
-            }
-	  else
-	    printf("|%s|",tmp2);
+        npref = entry->attr->local_pref;
+        if ((entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF)) == 0)
+          npref = 0;
+        nmed = entry->attr->med;
+        if ((entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC)) == 0)
+          nmed = 0;
 
+        printf("BGP4MP|%ld|A|%s|%u|%s/%d|%s|%s|%s|%u|%u|", entry->time,
+               bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip, buf1),
+               entry->body.zebra_message.source_as,
+               bgpdump_fmt_ipv6(prefix->nlri[idx].address, buf2),
+               prefix->nlri[idx].len, attr_aspath(entry->attr), tmp1,
+               bgpdump_fmt_ipv6(prefix->nexthop, buf), npref, nmed);
+        break;
+      case AFI_IP:
+      default:
 
-	  if (entry->attr->aggregator_addr.s_addr != -1)
-	    printf("%u %s|\n",entry->attr->aggregator_as,inet_ntoa(entry->attr->aggregator_addr));
-	  else
-	    printf("|\n");
+        npref = entry->attr->local_pref;
+        if ((entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF)) == 0)
+          npref = 0;
+        nmed = entry->attr->med;
+        if ((entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC)) == 0)
+          nmed = 0;
 
-	}
+        // printf("%s|%d|%d|",inet_ntoa(entry->attr->nexthop),nprof,nmed);
+        printf("BGP4MP|%ld|A|%s|%u|%s/%d|%s|%s|%s|%u|%u|", entry->time,
+               bgpdump_fmt_ipv4(entry->body.zebra_message.source_ip, buf1),
+               entry->body.zebra_message.source_as,
+               bgpdump_fmt_ipv6(prefix->nlri[idx].address, buf2),
+               prefix->nlri[idx].len, attr_aspath(entry->attr), tmp1,
+               bgpdump_fmt_ipv6(prefix->nexthop, buf), npref, nmed);
+        break;
+      }
+      if ((entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES)) != 0) {
+        if (entry->attr->community->str == NULL) {
+          process_attr_community_string(entry->attr->community);
+        }
+        printf("%s|%s|", entry->attr->community->str + 1, tmp2);
+      } else
+        printf("|%s|", tmp2);
+
+      if (entry->attr->aggregator_addr.s_addr != -1)
+        printf("%u %s|\n", entry->attr->aggregator_as,
+               inet_ntoa(entry->attr->aggregator_addr));
       else
-	{
-	  switch(entry->body.zebra_message.address_family)
-	    {
-	    case AFI_IP6:
-	      printf("BGP4MP|%s|A|%s|%u|%s/%d|%s|%s\n",time_str,bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip,buf1),entry->body.zebra_message.source_as,bgpdump_fmt_ipv6(prefix->nlri[idx].address,buf),prefix->nlri[idx].len,attr_aspath(entry->attr),tmp1);
-	      break;
-	    case AFI_IP:
-	    default:
-	      printf("BGP4MP|%s|A|%s|%u|%s/%d|%s|%s\n",time_str,bgpdump_fmt_ipv4(entry->body.zebra_message.source_ip,buf1),entry->body.zebra_message.source_as,bgpdump_fmt_ipv6(prefix->nlri[idx].address,buf),prefix->nlri[idx].len,attr_aspath(entry->attr),tmp1);
-	      break;
-	    }
-	}		
+        printf("|\n");
 
+    } else {
+      switch (entry->body.zebra_message.address_family) {
+      case AFI_IP6:
+        printf("BGP4MP|%s|A|%s|%u|%s/%d|%s|%s\n", time_str,
+               bgpdump_fmt_ipv6(entry->body.zebra_message.source_ip, buf1),
+               entry->body.zebra_message.source_as,
+               bgpdump_fmt_ipv6(prefix->nlri[idx].address, buf),
+               prefix->nlri[idx].len, attr_aspath(entry->attr), tmp1);
+        break;
+      case AFI_IP:
+      default:
+        printf("BGP4MP|%s|A|%s|%u|%s/%d|%s|%s\n", time_str,
+               bgpdump_fmt_ipv4(entry->body.zebra_message.source_ip, buf1),
+               entry->body.zebra_message.source_as,
+               bgpdump_fmt_ipv6(prefix->nlri[idx].address, buf),
+               prefix->nlri[idx].len, attr_aspath(entry->attr), tmp1);
+        break;
+      }
     }
+  }
 }
 
-
-static void table_line_mrtd_route(BGPDUMP_MRTD_TABLE_DUMP *route,BGPDUMP_ENTRY *entry)
+static void table_line_mrtd_route(BGPDUMP_MRTD_TABLE_DUMP *route,
+                                  BGPDUMP_ENTRY *entry)
 {
-	
+
   struct tm *date = NULL;
   char tmp1[20];
-  char tmp2[20];	
+  char tmp2[20];
   unsigned int npref;
   unsigned int nmed;
-  char  time_str[20];
-  char peer[BGPDUMP_ADDRSTRLEN], prefix[BGPDUMP_ADDRSTRLEN], nexthop[BGPDUMP_ADDRSTRLEN];
+  char time_str[20];
+  char peer[BGPDUMP_ADDRSTRLEN], prefix[BGPDUMP_ADDRSTRLEN],
+    nexthop[BGPDUMP_ADDRSTRLEN];
 
-  switch (entry->attr->origin)
-    {
+  switch (entry->attr->origin) {
 
-    case 0 :
-      sprintf(tmp1,"IGP");
-      break;
-    case 1:
-      sprintf(tmp1,"EGP");
-      break;
-    case 2:
-    default:
-      sprintf(tmp1,"INCOMPLETE");
-      break;
-    }
+  case 0:
+    sprintf(tmp1, "IGP");
+    break;
+  case 1:
+    sprintf(tmp1, "EGP");
+    break;
+  case 2:
+  default:
+    sprintf(tmp1, "INCOMPLETE");
+    break;
+  }
   if (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_ATOMIC_AGGREGATE))
-    sprintf(tmp2,"AG");
+    sprintf(tmp2, "AG");
   else
-    sprintf(tmp2,"NAG");
+    sprintf(tmp2, "NAG");
 
-  if (entry->subtype == AFI_IP6)
-    {
-      bgpdump_fmt_ipv6(route->peer_ip,peer);
-      bgpdump_fmt_ipv6(route->prefix,prefix);
-    }
-  else
-    {
-      strncpy(peer, inet_ntoa(route->peer_ip.v4_addr), BGPDUMP_ADDRSTRLEN);
-      strncpy(prefix, inet_ntoa(route->prefix.v4_addr), BGPDUMP_ADDRSTRLEN);
-    }
+  if (entry->subtype == AFI_IP6) {
+    bgpdump_fmt_ipv6(route->peer_ip, peer);
+    bgpdump_fmt_ipv6(route->prefix, prefix);
+  } else {
+    strncpy(peer, inet_ntoa(route->peer_ip.v4_addr), BGPDUMP_ADDRSTRLEN);
+    strncpy(prefix, inet_ntoa(route->prefix.v4_addr), BGPDUMP_ADDRSTRLEN);
+  }
 
-  if (mode == 1)
-    {
-      if(timetype==0){
-	printf("TABLE_DUMP|%ld|B|%s|%u|",entry->time,peer,route->peer_as);
-      }else if(timetype==1){
-	printf("TABLE_DUMP|%ld|B|%s|%u|",route->uptime,peer,route->peer_as);
+  if (mode == 1) {
+    if (timetype == 0) {
+      printf("TABLE_DUMP|%ld|B|%s|%u|", entry->time, peer, route->peer_as);
+    } else if (timetype == 1) {
+      printf("TABLE_DUMP|%ld|B|%s|%u|", route->uptime, peer, route->peer_as);
+    }
+    printf("%s/%d|%s|%s|", prefix, route->mask, attr_aspath(entry->attr), tmp1);
+
+    npref = entry->attr->local_pref;
+    if ((entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF)) == 0)
+      npref = 0;
+    nmed = entry->attr->med;
+    if ((entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC)) == 0)
+      nmed = 0;
+
+    if ((entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MP_REACH_NLRI)) &&
+        entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]) {
+      bgpdump_fmt_ipv6(
+        entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]->nexthop,
+        nexthop);
+    } else {
+      strncpy(nexthop, inet_ntoa(entry->attr->nexthop), BGPDUMP_ADDRSTRLEN);
+    }
+    printf("%s|%u|%u|", nexthop, npref, nmed);
+
+    if ((entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES)) != 0) {
+      if (entry->attr->community->str == NULL) {
+        process_attr_community_string(entry->attr->community);
       }
-      printf("%s/%d|%s|%s|",prefix,route->mask,attr_aspath(entry->attr),tmp1);
+      printf("%s|%s|", entry->attr->community->str + 1, tmp2);
+    } else
+      printf("|%s|", tmp2);
 
-      npref=entry->attr->local_pref;
-      if( (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF) ) ==0)
-	npref=0;
-      nmed=entry->attr->med;
-      if( (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC) ) ==0)
-	nmed=0;
-			    
-      if ((entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MP_REACH_NLRI)) && entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST])
-	{
-	  bgpdump_fmt_ipv6(entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]->nexthop,nexthop);
-	}
-      else
-	{
-	  strncpy(nexthop, inet_ntoa(entry->attr->nexthop), BGPDUMP_ADDRSTRLEN);
-	}
-      printf("%s|%u|%u|",nexthop,npref,nmed);
-
-      if( (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES) ) !=0)
-        {
-          if(entry->attr->community->str == NULL)
-            {
-              process_attr_community_string(entry->attr->community);
-            }
-          printf("%s|%s|",entry->attr->community->str+1,tmp2);
-        }
-      else
-	printf("|%s|",tmp2);
-				
-      if (entry->attr->aggregator_addr.s_addr != -1)
-	printf("%u %s|\n",entry->attr->aggregator_as,inet_ntoa(entry->attr->aggregator_addr));
-      else
-	printf("|\n");
+    if (entry->attr->aggregator_addr.s_addr != -1)
+      printf("%u %s|\n", entry->attr->aggregator_as,
+             inet_ntoa(entry->attr->aggregator_addr));
+    else
+      printf("|\n");
+  } else {
+    if (timetype == 0) {
+      date = gmtime(&entry->time);
+    } else if (timetype == 1) {
+      date = gmtime(&route->uptime);
     }
-  else
-    {
-      if(timetype==0){
-	date=gmtime(&entry->time);
-      }else if(timetype==1){
-	date=gmtime(&route->uptime);
-      }
-      bgpdump_time2str(date,time_str);	
-      printf("TABLE_DUMP|%s|A|%s|%u|",time_str,peer,route->peer_as);
-      printf("%s/%d|%s|%s\n",prefix,route->mask,attr_aspath(entry->attr),tmp1);
-				
-    }
-
+    bgpdump_time2str(date, time_str);
+    printf("TABLE_DUMP|%s|A|%s|%u|", time_str, peer, route->peer_as);
+    printf("%s/%d|%s|%s\n", prefix, route->mask, attr_aspath(entry->attr),
+           tmp1);
+  }
 }
 
-static char *describe_origin(int origin) {
-  if(origin == 0) return "IGP";
-  if(origin == 1) return "EGP";
+static char *describe_origin(int origin)
+{
+  if (origin == 0)
+    return "IGP";
+  if (origin == 1)
+    return "EGP";
   return "INCOMPLETE";
 }
 
-static void table_line_dump_v2_prefix(BGPDUMP_TABLE_DUMP_V2_PREFIX *e,BGPDUMP_ENTRY *entry)
+static void table_line_dump_v2_prefix(BGPDUMP_TABLE_DUMP_V2_PREFIX *e,
+                                      BGPDUMP_ENTRY *entry)
 {
   struct tm *date = NULL;
   unsigned int npref;
   unsigned int nmed;
-  char  time_str[20];
-  char peer[BGPDUMP_ADDRSTRLEN], prefix[BGPDUMP_ADDRSTRLEN], nexthop[BGPDUMP_ADDRSTRLEN];
-    
+  char time_str[20];
+  char peer[BGPDUMP_ADDRSTRLEN], prefix[BGPDUMP_ADDRSTRLEN],
+    nexthop[BGPDUMP_ADDRSTRLEN];
+
   int i;
-    
-  for(i = 0; i < e->entry_count; i++) {
+
+  for (i = 0; i < e->entry_count; i++) {
     attributes_t *attr = e->entries[i].attr;
-    if(! attr)
+    if (!attr)
       continue;
-        
+
     char *origin = describe_origin(attr->origin);
     if (attr->aspath && !attr->aspath->str) { // AK HAX
       process_attr_aspath_string(attr->aspath, 1);
     }
-    char *aspath_str = (attr->aspath) ? attr->aspath->str: "";
-    char *aggregate = attr->flag & ATTR_FLAG_BIT(BGP_ATTR_ATOMIC_AGGREGATE) ? "AG" : "NAG";
-        
-    if(e->entries[i].peer.afi == AFI_IP){
+    char *aspath_str = (attr->aspath) ? attr->aspath->str : "";
+    char *aggregate =
+      attr->flag & ATTR_FLAG_BIT(BGP_ATTR_ATOMIC_AGGREGATE) ? "AG" : "NAG";
+
+    if (e->entries[i].peer.afi == AFI_IP) {
       bgpdump_fmt_ipv4(e->entries[i].peer.peer_ip, peer);
-    } else if(e->entries[i].peer.afi == AFI_IP6){
+    } else if (e->entries[i].peer.afi == AFI_IP6) {
       bgpdump_fmt_ipv6(e->entries[i].peer.peer_ip, peer);
     }
-        
-    if(e->afi == AFI_IP) {
+
+    if (e->afi == AFI_IP) {
       bgpdump_fmt_ipv4(e->prefix, prefix);
-    } else if(e->afi == AFI_IP6) {
+    } else if (e->afi == AFI_IP6) {
       bgpdump_fmt_ipv6(e->prefix, prefix);
     }
-        
-    if (mode == 1)
-      {
-	if(timetype==0){
-	  printf("TABLE_DUMP2|%ld|B|%s|%u|",entry->time,peer,e->entries[i].peer.peer_as);
-	}else if(timetype==1){
-	  printf("TABLE_DUMP2|%u|B|%s|%u|",e->entries[i].originated_time,peer,e->entries[i].peer.peer_as);
-	}
-	printf("%s/%d|%s|%s|",prefix,e->prefix_length,aspath_str,origin);
-            
-	npref=attr->local_pref;
-	if( (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF) ) ==0)
-	  npref=0;
-	nmed=attr->med;
-	if( (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC) ) ==0)
-	  nmed=0;
-            
-	if ((attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MP_REACH_NLRI)) && attr->mp_info->announce[AFI_IP6][SAFI_UNICAST])
-	  {
-	    bgpdump_fmt_ipv6(attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]->nexthop,nexthop);
-	  }
-	else
-	  {
-	    strncpy(nexthop, inet_ntoa(attr->nexthop), BGPDUMP_ADDRSTRLEN);
-	  }
-	printf("%s|%u|%u|",nexthop,npref,nmed);
-            
-	if( (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES) ) !=0)
-          {
-            if(attr->community->str == NULL)
-              {
-                process_attr_community_string(attr->community);
-              }
-            printf("%s|%s|",attr->community->str+1,aggregate);
-          }
-	else
-	  printf("|%s|",aggregate);
-            
-	if (attr->aggregator_addr.s_addr != -1)
-	  printf("%u %s|\n",attr->aggregator_as,inet_ntoa(attr->aggregator_addr));
-	else
-	  printf("|\n");
+
+    if (mode == 1) {
+      if (timetype == 0) {
+        printf("TABLE_DUMP2|%ld|B|%s|%u|", entry->time, peer,
+               e->entries[i].peer.peer_as);
+      } else if (timetype == 1) {
+        printf("TABLE_DUMP2|%u|B|%s|%u|", e->entries[i].originated_time, peer,
+               e->entries[i].peer.peer_as);
       }
-    else
-      {
-	if(timetype==0){
-	  date=gmtime(&entry->time);
-	}else if(timetype==1){
-	  time_t time_temp = (time_t)((e->entries[i]).originated_time);
-	  date=gmtime(&time_temp);
-	}
-	bgpdump_time2str(date,time_str);	
-	printf("TABLE_DUMP_V2|%s|A|%s|%u|",time_str,peer,e->entries[i].peer.peer_as);
-	printf("%s/%d|%s|%s\n",prefix,e->prefix_length,aspath_str,origin);
-            
+      printf("%s/%d|%s|%s|", prefix, e->prefix_length, aspath_str, origin);
+
+      npref = attr->local_pref;
+      if ((attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF)) == 0)
+        npref = 0;
+      nmed = attr->med;
+      if ((attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC)) == 0)
+        nmed = 0;
+
+      if ((attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MP_REACH_NLRI)) &&
+          attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]) {
+        bgpdump_fmt_ipv6(
+          attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]->nexthop, nexthop);
+      } else {
+        strncpy(nexthop, inet_ntoa(attr->nexthop), BGPDUMP_ADDRSTRLEN);
       }
+      printf("%s|%u|%u|", nexthop, npref, nmed);
+
+      if ((attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES)) != 0) {
+        if (attr->community->str == NULL) {
+          process_attr_community_string(attr->community);
+        }
+        printf("%s|%s|", attr->community->str + 1, aggregate);
+      } else
+        printf("|%s|", aggregate);
+
+      if (attr->aggregator_addr.s_addr != -1)
+        printf("%u %s|\n", attr->aggregator_as,
+               inet_ntoa(attr->aggregator_addr));
+      else
+        printf("|\n");
+    } else {
+      if (timetype == 0) {
+        date = gmtime(&entry->time);
+      } else if (timetype == 1) {
+        time_t time_temp = (time_t)((e->entries[i]).originated_time);
+        date = gmtime(&time_temp);
+      }
+      bgpdump_time2str(date, time_str);
+      printf("TABLE_DUMP_V2|%s|A|%s|%u|", time_str, peer,
+             e->entries[i].peer.peer_as);
+      printf("%s/%d|%s|%s\n", prefix, e->prefix_length, aspath_str, origin);
+    }
   }
-    
 }

--- a/lib/bgpdump/bgpdump_process.h
+++ b/lib/bgpdump/bgpdump_process.h
@@ -21,7 +21,6 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #ifndef _BGPDUMP_PROCESS_H
 #define _BGPDUMP_PROCESS_H
 

--- a/lib/bgpdump/bgpdump_util.c
+++ b/lib/bgpdump/bgpdump_util.c
@@ -1,6 +1,6 @@
 /*
  Copyright (c) 2007 - 2010 RIPE NCC - All Rights Reserved
- 
+
  Permission to use, copy, modify, and distribute this software and its
  documentation for any purpose and without fee is hereby granted, provided
  that the above copyright notice appear in all copies and that both that
@@ -8,132 +8,145 @@
  documentation, and that the name of the author not be used in advertising or
  publicity pertaining to distribution of the software without specific,
  written prior permission.
- 
+
  THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
  ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS; IN NO EVENT SHALL
  AUTHOR BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY
  DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
  AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- 
+
  Created by Devin Bayer on 9/1/10.
 */
 
 #include "bgpdump_util.h"
 
 #include <arpa/inet.h>
-#include <sys/socket.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <stdarg.h>
 #include <assert.h>
+#include <inttypes.h>
+#include <stdarg.h>
 #include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
 #include <syslog.h>
 #include <time.h>
-#include <string.h>
-#include <inttypes.h>
 
 static bool bgpdump_use_syslog = false;
 
-void bgpdump_log_to_syslog() {
-    bgpdump_use_syslog = true;
-}
-
-void bgpdump_log_to_stderr() {
-    bgpdump_use_syslog = false;
-}
-
-#define log(lvl, lvl_str) \
-    va_list args; \
-    va_start(args, fmt); \
-    _log(LOG_##lvl, #lvl_str, fmt, args)
-
-static char *now_str() {
-    static char buffer[1000];
-    time_t now = time(0);
-    strftime(buffer, sizeof buffer, "%Y-%m-%d %H:%M:%S", localtime(&now));
-    return buffer;
-}
-
-static void _log(int lvl, char *lvl_str, const char *fmt, va_list args) {
-    if(bgpdump_use_syslog) {
-        syslog(lvl, fmt, args);
-    } else {
-        char prefix[strlen(fmt) + 1000];
-        sprintf(prefix, "%s [%s] %s\n", now_str(), lvl_str, fmt);
-        vfprintf(stderr, prefix, args);
-    }
-}
-
-void bgpdump_err(const char *fmt, ...) { log(ERR, error); }
-void bgpdump_warn(const char *fmt, ...) { log(WARNING, warn); }
-void bgpdump_debug(const char *fmt, ...) { log(INFO, info); }
-
-void bgpdump_time2str(struct tm* date,char *time_str)
+void bgpdump_log_to_syslog()
 {
-    char tmp_str[10];
-    
-    if (date->tm_mon+1<10)
-        sprintf(tmp_str,"0%d/",date->tm_mon+1);
-    else
-        sprintf(tmp_str,"%d/",date->tm_mon+1);
-    strcpy(time_str,tmp_str);
-    
-    if (date->tm_mday<10)
-        sprintf(tmp_str,"0%d/",date->tm_mday);
-    else
-        sprintf(tmp_str,"%d/",date->tm_mday);
-    strcat(time_str,tmp_str);
-    
-    if (date->tm_year%100 <10)
-        sprintf(tmp_str,"0%d ",date->tm_year%100);
-    else
-        sprintf(tmp_str,"%d ",date->tm_year%100);
-    strcat(time_str,tmp_str);
-    
-    if (date->tm_hour<10)
-        sprintf(tmp_str,"0%d:",date->tm_hour);
-    else
-        sprintf(tmp_str,"%d:",date->tm_hour);
-    strcat(time_str,tmp_str);
-    
-    if (date->tm_min<10)
-        sprintf(tmp_str,"0%d:",date->tm_min);
-    else
-        sprintf(tmp_str,"%d:",date->tm_min);
-    strcat(time_str,tmp_str);
-    
-    if (date->tm_sec <10)
-        sprintf(tmp_str,"0%d",date->tm_sec);
-    else
-        sprintf(tmp_str,"%d",date->tm_sec);
-    strcat(time_str,tmp_str);
-    
+  bgpdump_use_syslog = true;
 }
 
-int bgpdump_int2str(uint32_t value, char* str)
+void bgpdump_log_to_stderr()
+{
+  bgpdump_use_syslog = false;
+}
+
+#define log(lvl, lvl_str)                                                      \
+  va_list args;                                                                \
+  va_start(args, fmt);                                                         \
+  _log(LOG_##lvl, #lvl_str, fmt, args)
+
+static char *now_str()
+{
+  static char buffer[1000];
+  time_t now = time(0);
+  strftime(buffer, sizeof buffer, "%Y-%m-%d %H:%M:%S", localtime(&now));
+  return buffer;
+}
+
+static void _log(int lvl, char *lvl_str, const char *fmt, va_list args)
+{
+  if (bgpdump_use_syslog) {
+    syslog(lvl, fmt, args);
+  } else {
+    char prefix[strlen(fmt) + 1000];
+    sprintf(prefix, "%s [%s] %s\n", now_str(), lvl_str, fmt);
+    vfprintf(stderr, prefix, args);
+  }
+}
+
+void bgpdump_err(const char *fmt, ...)
+{
+  log(ERR, error);
+}
+void bgpdump_warn(const char *fmt, ...)
+{
+  log(WARNING, warn);
+}
+void bgpdump_debug(const char *fmt, ...)
+{
+  log(INFO, info);
+}
+
+void bgpdump_time2str(struct tm *date, char *time_str)
+{
+  char tmp_str[10];
+
+  if (date->tm_mon + 1 < 10)
+    sprintf(tmp_str, "0%d/", date->tm_mon + 1);
+  else
+    sprintf(tmp_str, "%d/", date->tm_mon + 1);
+  strcpy(time_str, tmp_str);
+
+  if (date->tm_mday < 10)
+    sprintf(tmp_str, "0%d/", date->tm_mday);
+  else
+    sprintf(tmp_str, "%d/", date->tm_mday);
+  strcat(time_str, tmp_str);
+
+  if (date->tm_year % 100 < 10)
+    sprintf(tmp_str, "0%d ", date->tm_year % 100);
+  else
+    sprintf(tmp_str, "%d ", date->tm_year % 100);
+  strcat(time_str, tmp_str);
+
+  if (date->tm_hour < 10)
+    sprintf(tmp_str, "0%d:", date->tm_hour);
+  else
+    sprintf(tmp_str, "%d:", date->tm_hour);
+  strcat(time_str, tmp_str);
+
+  if (date->tm_min < 10)
+    sprintf(tmp_str, "0%d:", date->tm_min);
+  else
+    sprintf(tmp_str, "%d:", date->tm_min);
+  strcat(time_str, tmp_str);
+
+  if (date->tm_sec < 10)
+    sprintf(tmp_str, "0%d", date->tm_sec);
+  else
+    sprintf(tmp_str, "%d", date->tm_sec);
+  strcat(time_str, tmp_str);
+}
+
+int bgpdump_int2str(uint32_t value, char *str)
 {
   const int MAX_UINT32_STRLEN = 11; /* 2**32-1 => 4294967295 */
-  return snprintf(str, MAX_UINT32_STRLEN, "%"PRIu32, value);
+  return snprintf(str, MAX_UINT32_STRLEN, "%" PRIu32, value);
 }
 
-static void ti2s(uint32_t value) {
-    char buf[100], ref[100];
-    sprintf(ref, "%u", value);
-    int len = bgpdump_int2str(value, buf);
-    printf("%s =?= %s (%i)\n", ref, buf, len);
+static void ti2s(uint32_t value)
+{
+  char buf[100], ref[100];
+  sprintf(ref, "%u", value);
+  int len = bgpdump_int2str(value, buf);
+  printf("%s =?= %s (%i)\n", ref, buf, len);
 }
 
 void bgpdump_test_utils()
 {
-    ti2s(0);
-    ti2s(99999);
-    ti2s(4294967295L);
+  ti2s(0);
+  ti2s(99999);
+  ti2s(4294967295L);
 }
 
 char *bgpdump_fmt_ipv4(BGPDUMP_IP_ADDRESS addr, char *buffer)
 {
-  if(inet_ntop(AF_INET, &addr.v4_addr, buffer, INET_ADDRSTRLEN) == NULL) {
+  if (inet_ntop(AF_INET, &addr.v4_addr, buffer, INET_ADDRSTRLEN) == NULL) {
     return NULL;
   } else {
     return buffer;
@@ -142,7 +155,7 @@ char *bgpdump_fmt_ipv4(BGPDUMP_IP_ADDRESS addr, char *buffer)
 
 char *bgpdump_fmt_ipv6(BGPDUMP_IP_ADDRESS addr, char *buffer)
 {
-  if(inet_ntop(AF_INET6, &addr.v6_addr, buffer, INET6_ADDRSTRLEN) == NULL) {
+  if (inet_ntop(AF_INET6, &addr.v6_addr, buffer, INET6_ADDRSTRLEN) == NULL) {
     return NULL;
   } else {
     return buffer;
@@ -151,18 +164,18 @@ char *bgpdump_fmt_ipv6(BGPDUMP_IP_ADDRESS addr, char *buffer)
 
 static void test_roundtrip(char *str)
 {
-    BGPDUMP_IP_ADDRESS addr;
-    inet_pton(AF_INET6, str, &addr.v6_addr);
-    char tmp[1000];
-    bgpdump_fmt_ipv6(addr, tmp);
-    printf("%s -> %s [%s]\n", str, tmp, strcmp(str, tmp) ? "ERROR" : "ok");
+  BGPDUMP_IP_ADDRESS addr;
+  inet_pton(AF_INET6, str, &addr.v6_addr);
+  char tmp[1000];
+  bgpdump_fmt_ipv6(addr, tmp);
+  printf("%s -> %s [%s]\n", str, tmp, strcmp(str, tmp) ? "ERROR" : "ok");
 }
 
 void bgpdump_test_fmt_ip()
 {
-    test_roundtrip("fe80::");
-    test_roundtrip("2001:db8::1");
-    test_roundtrip("::ffff:192.168.2.1");
-    test_roundtrip("::192.168.1.2");
-    test_roundtrip("2001:7f8:30::2:1:0:8447");
+  test_roundtrip("fe80::");
+  test_roundtrip("2001:db8::1");
+  test_roundtrip("::ffff:192.168.2.1");
+  test_roundtrip("::192.168.1.2");
+  test_roundtrip("2001:7f8:30::2:1:0:8447");
 }

--- a/lib/bgpdump/bgpdump_util.h
+++ b/lib/bgpdump/bgpdump_util.h
@@ -1,6 +1,6 @@
 /*
  Copyright (c) 2007 - 2010 RIPE NCC - All Rights Reserved
- 
+
  Permission to use, copy, modify, and distribute this software and its
  documentation for any purpose and without fee is hereby granted, provided
  that the above copyright notice appear in all copies and that both that
@@ -8,7 +8,7 @@
  documentation, and that the name of the author not be used in advertising or
  publicity pertaining to distribution of the software without specific,
  written prior permission.
- 
+
  THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
  ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS; IN NO EVENT SHALL
  AUTHOR BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY
@@ -34,12 +34,12 @@ void bgpdump_debug(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
 
 // system inet_ntop() functions format IPv6 addresses
 // inconsistently, so use these versions
-char * bgpdump_fmt_ipv4(BGPDUMP_IP_ADDRESS addr, char *buffer);
-char * bgpdump_fmt_ipv6(BGPDUMP_IP_ADDRESS addr, char *buffer);
+char *bgpdump_fmt_ipv4(BGPDUMP_IP_ADDRESS addr, char *buffer);
+char *bgpdump_fmt_ipv6(BGPDUMP_IP_ADDRESS addr, char *buffer);
 void bgpdump_test_fmt_ip(void);
 
-void bgpdump_time2str(struct tm* date,char *time_str);
-int bgpdump_int2str(uint32_t value, char* str);
+void bgpdump_time2str(struct tm *date, char *time_str);
+int bgpdump_int2str(uint32_t value, char *str);
 void bgpdump_test_utils(void);
 
 #endif

--- a/lib/bgpstream.c
+++ b/lib/bgpstream.c
@@ -25,51 +25,44 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-
-#include "utils.h"
-#include "bgpdump_lib.h"
 #include "bgpstream_int.h"
+#include "bgpdump_lib.h"
 #include "bgpstream_debug.h"
+#include "utils.h"
 
 /* TEMPORARY STRUCTURES TO FAKE DATA INTERFACE PLUGIN API */
 
 /* this should be the complete list of interface types */
 static bgpstream_data_interface_id_t bgpstream_data_interfaces[] = {
-  BGPSTREAM_DATA_INTERFACE_BROKER,
-  BGPSTREAM_DATA_INTERFACE_SINGLEFILE,
-  BGPSTREAM_DATA_INTERFACE_CSVFILE,
-  BGPSTREAM_DATA_INTERFACE_SQLITE,
+  BGPSTREAM_DATA_INTERFACE_BROKER, BGPSTREAM_DATA_INTERFACE_SINGLEFILE,
+  BGPSTREAM_DATA_INTERFACE_CSVFILE, BGPSTREAM_DATA_INTERFACE_SQLITE,
 };
 
 #ifdef WITH_DATA_INTERFACE_SINGLEFILE
 static bgpstream_data_interface_info_t bgpstream_singlefile_info = {
-    BGPSTREAM_DATA_INTERFACE_SINGLEFILE,
-    "singlefile",
-    "Read a single mrt data file (a RIB and/or an update)",
+  BGPSTREAM_DATA_INTERFACE_SINGLEFILE, "singlefile",
+  "Read a single mrt data file (a RIB and/or an update)",
 };
 #endif
 
 #ifdef WITH_DATA_INTERFACE_CSVFILE
 static bgpstream_data_interface_info_t bgpstream_csvfile_info = {
-    BGPSTREAM_DATA_INTERFACE_CSVFILE,
-    "csvfile",
-    "Retrieve metadata information from a csv file",
+  BGPSTREAM_DATA_INTERFACE_CSVFILE, "csvfile",
+  "Retrieve metadata information from a csv file",
 };
 #endif
 
 #ifdef WITH_DATA_INTERFACE_SQLITE
 static bgpstream_data_interface_info_t bgpstream_sqlite_info = {
-  BGPSTREAM_DATA_INTERFACE_SQLITE,
-  "sqlite",
+  BGPSTREAM_DATA_INTERFACE_SQLITE, "sqlite",
   "Retrieve metadata information from a sqlite database",
 };
 #endif
 
 #ifdef WITH_DATA_INTERFACE_BROKER
 static bgpstream_data_interface_info_t bgpstream_broker_info = {
-    BGPSTREAM_DATA_INTERFACE_BROKER,
-    "broker",
-    "Retrieve metadata information from the BGPStream Broker service",
+  BGPSTREAM_DATA_INTERFACE_BROKER, "broker",
+  "Retrieve metadata information from the BGPStream Broker service",
 };
 #endif
 
@@ -108,16 +101,13 @@ static bgpstream_data_interface_info_t *bgpstream_data_interface_infos[] = {
 static bgpstream_data_interface_option_t bgpstream_singlefile_options[] = {
   /* RIB MRT file path */
   {
-    BGPSTREAM_DATA_INTERFACE_SINGLEFILE,
-    0,
-    "rib-file",
+    BGPSTREAM_DATA_INTERFACE_SINGLEFILE, 0, "rib-file",
     "rib mrt file to read (default: " STR(BGPSTREAM_DS_SINGLEFILE_RIB_FILE) ")",
   },
   {
-    BGPSTREAM_DATA_INTERFACE_SINGLEFILE,
-    1,
-    "upd-file",
-    "updates mrt file to read (default: " STR(BGPSTREAM_DS_SINGLEFILE_UPDATE_FILE) ")",
+    BGPSTREAM_DATA_INTERFACE_SINGLEFILE, 1, "upd-file",
+    "updates mrt file to read (default: " STR(
+      BGPSTREAM_DS_SINGLEFILE_UPDATE_FILE) ")",
   },
 };
 #endif
@@ -126,10 +116,9 @@ static bgpstream_data_interface_option_t bgpstream_singlefile_options[] = {
 static bgpstream_data_interface_option_t bgpstream_csvfile_options[] = {
   /* CSV file name */
   {
-    BGPSTREAM_DATA_INTERFACE_CSVFILE,
-    0,
-    "csv-file",
-    "csv file listing the mrt data to read (default: " STR(BGPSTREAM_DS_CSVFILE_CSV_FILE) ")",
+    BGPSTREAM_DATA_INTERFACE_CSVFILE, 0, "csv-file",
+    "csv file listing the mrt data to read (default: " STR(
+      BGPSTREAM_DS_CSVFILE_CSV_FILE) ")",
   },
 };
 #endif
@@ -138,9 +127,7 @@ static bgpstream_data_interface_option_t bgpstream_csvfile_options[] = {
 static bgpstream_data_interface_option_t bgpstream_sqlite_options[] = {
   /* SQLITE database file name */
   {
-    BGPSTREAM_DATA_INTERFACE_SQLITE,
-    0,
-    "db-file",
+    BGPSTREAM_DATA_INTERFACE_SQLITE, 0, "db-file",
     "sqlite database (default: " STR(BGPSTREAM_DS_SQLITE_DB_FILE) ")",
   },
 };
@@ -150,16 +137,12 @@ static bgpstream_data_interface_option_t bgpstream_sqlite_options[] = {
 static bgpstream_data_interface_option_t bgpstream_broker_options[] = {
   /* Broker URL */
   {
-    BGPSTREAM_DATA_INTERFACE_BROKER,
-    0,
-    "url",
+    BGPSTREAM_DATA_INTERFACE_BROKER, 0, "url",
     "Broker URL (default: " STR(BGPSTREAM_DS_BROKER_URL) ")",
   },
   /* Broker Param */
   {
-    BGPSTREAM_DATA_INTERFACE_BROKER,
-    1,
-    "param",
+    BGPSTREAM_DATA_INTERFACE_BROKER, 1, "param",
     "Additional Broker GET parameter*",
   },
 };
@@ -167,20 +150,21 @@ static bgpstream_data_interface_option_t bgpstream_broker_options[] = {
 
 /* allocate memory for a new bgpstream interface
  */
-bgpstream_t *bgpstream_create() {
+bgpstream_t *bgpstream_create()
+{
   bgpstream_debug("BS: create start");
-  bgpstream_t *  bs = (bgpstream_t*) malloc(sizeof(bgpstream_t));
-  if(bs == NULL) {
+  bgpstream_t *bs = (bgpstream_t *)malloc(sizeof(bgpstream_t));
+  if (bs == NULL) {
     return NULL; // can't allocate memory
   }
   bs->filter_mgr = bgpstream_filter_mgr_create();
-  if(bs->filter_mgr == NULL) {
+  if (bs->filter_mgr == NULL) {
     bgpstream_destroy(bs);
     bs = NULL;
     return NULL;
   }
   bs->datasource_mgr = bgpstream_datasource_mgr_create();
-  if(bs->datasource_mgr == NULL) {
+  if (bs->datasource_mgr == NULL) {
     bgpstream_destroy(bs);
     return NULL;
   }
@@ -188,13 +172,13 @@ bgpstream_t *bgpstream_create() {
    * the input queue will be populated when a
    * bgpstream record is requested */
   bs->input_mgr = bgpstream_input_mgr_create();
-  if(bs->input_mgr == NULL) {
+  if (bs->input_mgr == NULL) {
     bgpstream_destroy(bs);
     bs = NULL;
     return NULL;
   }
   bs->reader_mgr = bgpstream_reader_mgr_create(bs->filter_mgr);
-  if(bs->reader_mgr == NULL) {
+  if (bs->reader_mgr == NULL) {
     bgpstream_destroy(bs);
     bs = NULL;
     return NULL;
@@ -212,14 +196,12 @@ bgpstream_t *bgpstream_create() {
  * of the data provided by the input_mgr)
  */
 
-
-
 /* configure filters in order to select a subset of the bgp data available */
-void bgpstream_add_filter(bgpstream_t *bs,
-                          bgpstream_filter_type_t filter_type,
-			  const char* filter_value) {
+void bgpstream_add_filter(bgpstream_t *bs, bgpstream_filter_type_t filter_type,
+                          const char *filter_value)
+{
   bgpstream_debug("BS: set_filter start");
-  if(bs == NULL || (bs != NULL && bs->status != BGPSTREAM_STATUS_ALLOCATED)) {
+  if (bs == NULL || (bs != NULL && bs->status != BGPSTREAM_STATUS_ALLOCATED)) {
     return; // nothing to customize
   }
   bgpstream_filter_mgr_filter_add(bs->filter_mgr, filter_type, filter_value);
@@ -229,24 +211,25 @@ void bgpstream_add_filter(bgpstream_t *bs,
 void bgpstream_add_rib_period_filter(bgpstream_t *bs, uint32_t period)
 {
   bgpstream_debug("BS: set_filter start");
-  if(bs == NULL || (bs != NULL && bs->status != BGPSTREAM_STATUS_ALLOCATED)) {
+  if (bs == NULL || (bs != NULL && bs->status != BGPSTREAM_STATUS_ALLOCATED)) {
     return; // nothing to customize
   }
   bgpstream_filter_mgr_rib_period_filter_add(bs->filter_mgr, period);
   bgpstream_debug("BS: set_filter end");
 }
 
-void bgpstream_add_interval_filter(bgpstream_t *bs,
-				   uint32_t begin_time,
-                                   uint32_t end_time) {
+void bgpstream_add_interval_filter(bgpstream_t *bs, uint32_t begin_time,
+                                   uint32_t end_time)
+{
   bgpstream_debug("BS: set_filter start");
-  if(bs == NULL || (bs != NULL && bs->status != BGPSTREAM_STATUS_ALLOCATED)) {
+  if (bs == NULL || (bs != NULL && bs->status != BGPSTREAM_STATUS_ALLOCATED)) {
     return; // nothing to customize
   }
-  if(end_time == BGPSTREAM_FOREVER) {
+  if (end_time == BGPSTREAM_FOREVER) {
     bgpstream_set_live_mode(bs);
   }
-  bgpstream_filter_mgr_interval_filter_add(bs->filter_mgr, begin_time, end_time);
+  bgpstream_filter_mgr_interval_filter_add(bs->filter_mgr, begin_time,
+                                           end_time);
   bgpstream_debug("BS: set_filter end");
 }
 
@@ -263,14 +246,12 @@ bgpstream_get_data_interface_id_by_name(bgpstream_t *bs, const char *name)
 {
   int i;
 
-  for(i=1; i<ARR_CNT(bgpstream_data_interface_infos); i++)
-    {
-      if(bgpstream_data_interface_infos[i] != NULL &&
-         strcmp(bgpstream_data_interface_infos[i]->name, name) == 0)
-        {
-          return bgpstream_data_interface_infos[i]->id;
-        }
+  for (i = 1; i < ARR_CNT(bgpstream_data_interface_infos); i++) {
+    if (bgpstream_data_interface_infos[i] != NULL &&
+        strcmp(bgpstream_data_interface_infos[i]->name, name) == 0) {
+      return bgpstream_data_interface_infos[i]->id;
     }
+  }
 
   return 0;
 }
@@ -282,54 +263,51 @@ bgpstream_get_data_interface_info(bgpstream_t *bs,
   return bgpstream_data_interface_infos[if_id];
 }
 
-int bgpstream_get_data_interface_options(bgpstream_t *bs,
-                                         bgpstream_data_interface_id_t if_id,
-                                         bgpstream_data_interface_option_t **opts)
+int bgpstream_get_data_interface_options(
+  bgpstream_t *bs, bgpstream_data_interface_id_t if_id,
+  bgpstream_data_interface_option_t **opts)
 {
   assert(opts != NULL);
 
-  switch(if_id)
-    {
+  switch (if_id) {
 
 #ifdef WITH_DATA_INTERFACE_SINGLEFILE
-    case BGPSTREAM_DATA_INTERFACE_SINGLEFILE:
-      *opts = bgpstream_singlefile_options;
-      return ARR_CNT(bgpstream_singlefile_options);
-      break;
+  case BGPSTREAM_DATA_INTERFACE_SINGLEFILE:
+    *opts = bgpstream_singlefile_options;
+    return ARR_CNT(bgpstream_singlefile_options);
+    break;
 #endif
 
 #ifdef WITH_DATA_INTERFACE_CSVFILE
-    case BGPSTREAM_DATA_INTERFACE_CSVFILE:
-      *opts = bgpstream_csvfile_options;
-      return ARR_CNT(bgpstream_csvfile_options);
-      break;
+  case BGPSTREAM_DATA_INTERFACE_CSVFILE:
+    *opts = bgpstream_csvfile_options;
+    return ARR_CNT(bgpstream_csvfile_options);
+    break;
 #endif
 
 #ifdef WITH_DATA_INTERFACE_SQLITE
-    case BGPSTREAM_DATA_INTERFACE_SQLITE:
-      *opts = bgpstream_sqlite_options;
-      return ARR_CNT(bgpstream_sqlite_options);
-      break;
+  case BGPSTREAM_DATA_INTERFACE_SQLITE:
+    *opts = bgpstream_sqlite_options;
+    return ARR_CNT(bgpstream_sqlite_options);
+    break;
 #endif
 
 #ifdef WITH_DATA_INTERFACE_BROKER
-    case BGPSTREAM_DATA_INTERFACE_BROKER:
-      *opts = bgpstream_broker_options;
-      return ARR_CNT(bgpstream_broker_options);
-      break;
+  case BGPSTREAM_DATA_INTERFACE_BROKER:
+    *opts = bgpstream_broker_options;
+    return ARR_CNT(bgpstream_broker_options);
+    break;
 #endif
 
-    default:
-      *opts = NULL;
-      return 0;
-      break;
-    }
+  default:
+    *opts = NULL;
+    return 0;
+    break;
+  }
 }
 
-bgpstream_data_interface_option_t *
-bgpstream_get_data_interface_option_by_name(bgpstream_t *bs,
-                                            bgpstream_data_interface_id_t if_id,
-                                            const char *name)
+bgpstream_data_interface_option_t *bgpstream_get_data_interface_option_by_name(
+  bgpstream_t *bs, bgpstream_data_interface_id_t if_id, const char *name)
 {
   bgpstream_data_interface_option_t *options;
   int opt_cnt = 0;
@@ -337,30 +315,28 @@ bgpstream_get_data_interface_option_by_name(bgpstream_t *bs,
 
   opt_cnt = bgpstream_get_data_interface_options(bs, if_id, &options);
 
-  if(options == NULL || opt_cnt == 0)
-    {
-      return NULL;
-    }
+  if (options == NULL || opt_cnt == 0) {
+    return NULL;
+  }
 
-  for(i=0; i<opt_cnt; i++)
-    {
-      if(strcmp(options[i].name, name) == 0)
-        {
-          return &options[i];
-        }
+  for (i = 0; i < opt_cnt; i++) {
+    if (strcmp(options[i].name, name) == 0) {
+      return &options[i];
     }
+  }
 
   return NULL;
 }
 
 /* configure the datasource interface options */
 
-void bgpstream_set_data_interface_option(bgpstream_t *bs,
-			        bgpstream_data_interface_option_t *option_type,
-                                const char *option_value) {
+void bgpstream_set_data_interface_option(
+  bgpstream_t *bs, bgpstream_data_interface_option_t *option_type,
+  const char *option_value)
+{
 
   bgpstream_debug("BS: set_data_interface_options start");
-  if(bs == NULL || (bs != NULL && bs->status != BGPSTREAM_STATUS_ALLOCATED)) {
+  if (bs == NULL || (bs != NULL && bs->status != BGPSTREAM_STATUS_ALLOCATED)) {
     return; // nothing to customize
   }
 
@@ -374,17 +350,17 @@ void bgpstream_set_data_interface_option(bgpstream_t *bs,
  * to a specific datasource interface
  */
 void bgpstream_set_data_interface(bgpstream_t *bs,
-                                  bgpstream_data_interface_id_t datasource) {
+                                  bgpstream_data_interface_id_t datasource)
+{
   bgpstream_debug("BS: set_data_interface start");
-  if(bs == NULL || (bs != NULL && bs->status != BGPSTREAM_STATUS_ALLOCATED)) {
+  if (bs == NULL || (bs != NULL && bs->status != BGPSTREAM_STATUS_ALLOCATED)) {
     return; // nothing to customize
   }
   bgpstream_datasource_mgr_set_data_interface(bs->datasource_mgr, datasource);
   bgpstream_debug("BS: set_data_interface stop");
 }
 
-bgpstream_data_interface_id_t
-bgpstream_get_data_interface_id(bgpstream_t *bs)
+bgpstream_data_interface_id_t bgpstream_get_data_interface_id(bgpstream_t *bs)
 {
   return bs->datasource_mgr->datasource;
 }
@@ -392,40 +368,40 @@ bgpstream_get_data_interface_id(bgpstream_t *bs)
 /* configure the interface so that it blocks
  * waiting for new data
  */
-void bgpstream_set_live_mode(bgpstream_t *bs) {
+void bgpstream_set_live_mode(bgpstream_t *bs)
+{
   bgpstream_debug("BS: set_live_mode start");
-  if(bs == NULL || (bs != NULL && bs->status != BGPSTREAM_STATUS_ALLOCATED)) {
+  if (bs == NULL || (bs != NULL && bs->status != BGPSTREAM_STATUS_ALLOCATED)) {
     return; // nothing to customize
   }
   bgpstream_datasource_mgr_set_blocking(bs->datasource_mgr);
   bgpstream_debug("BS: set_blocking stop");
 }
 
-
 /* turn on the bgpstream interface, i.e.:
  * it makes the interface ready
  * for a new get next call
 */
-int bgpstream_start(bgpstream_t *bs) {
+int bgpstream_start(bgpstream_t *bs)
+{
   bgpstream_debug("BS: init start");
-  if(bs == NULL || (bs != NULL && bs->status != BGPSTREAM_STATUS_ALLOCATED)) {
+  if (bs == NULL || (bs != NULL && bs->status != BGPSTREAM_STATUS_ALLOCATED)) {
     return 0; // nothing to init
   }
 
   // validate the filters that have been set
   int rc;
-  if((rc = bgpstream_filter_mgr_validate(bs->filter_mgr)) != 0) {
+  if ((rc = bgpstream_filter_mgr_validate(bs->filter_mgr)) != 0) {
     return rc;
   }
 
   // turn on datasource interface
   bgpstream_datasource_mgr_init(bs->datasource_mgr, bs->filter_mgr);
-  if(bs->datasource_mgr->status == BGPSTREAM_DATASOURCE_STATUS_ON) {
+  if (bs->datasource_mgr->status == BGPSTREAM_DATASOURCE_STATUS_ON) {
     bs->status = BGPSTREAM_STATUS_ON; // interface is on
     bgpstream_debug("BS: init end: ok");
     return 0;
-  }
-  else{
+  } else {
     // interface is not on (something wrong with datasource)
     bs->status = BGPSTREAM_STATUS_ALLOCATED;
     bgpstream_debug("BS: init warning: check if the datasource provided is ok");
@@ -441,13 +417,12 @@ int bgpstream_start(bgpstream_t *bs) {
  * triggers a mechanism to populate the queues or
  * return 0 if nothing is available
  */
-int bgpstream_get_next_record(bgpstream_t *bs,
-                              bgpstream_record_t *record) {
+int bgpstream_get_next_record(bgpstream_t *bs, bgpstream_record_t *record)
+{
   bgpstream_debug("BS: get next");
-  if(bs == NULL || (bs != NULL && bs->status != BGPSTREAM_STATUS_ON)) {
+  if (bs == NULL || (bs != NULL && bs->status != BGPSTREAM_STATUS_ON)) {
     return -1; // wrong status
   }
-
 
   int num_query_results = 0;
   bgpstream_input_t *bs_in = NULL;
@@ -455,23 +430,22 @@ int bgpstream_get_next_record(bgpstream_t *bs,
   // if bs_record contains an initialized bgpdump entry we destroy it
   bgpstream_record_clear(record);
 
-  while(bgpstream_reader_mgr_is_empty(bs->reader_mgr)) {
+  while (bgpstream_reader_mgr_is_empty(bs->reader_mgr)) {
     bgpstream_debug("BS: reader mgr is empty");
     // get new data to process and set the reader_mgr
-    while(bgpstream_input_mgr_is_empty(bs->input_mgr)) {
+    while (bgpstream_input_mgr_is_empty(bs->input_mgr)) {
       bgpstream_debug("BS: input mgr is empty");
       /* query the external source and append new
        * input objects to the input_mgr queue */
-      num_query_results =
-        bgpstream_datasource_mgr_update_input_queue(bs->datasource_mgr,
-                                                    bs->input_mgr);
-      if(num_query_results == 0){
-	bgpstream_debug("BS: no (more) data are available");
-	return 0; // no (more) data are available
+      num_query_results = bgpstream_datasource_mgr_update_input_queue(
+        bs->datasource_mgr, bs->input_mgr);
+      if (num_query_results == 0) {
+        bgpstream_debug("BS: no (more) data are available");
+        return 0; // no (more) data are available
       }
-      if(num_query_results < 0){
-	bgpstream_debug("BS: error during datasource_mgr_update_input_queue");
-	return -1; // error during execution
+      if (num_query_results < 0) {
+        bgpstream_debug("BS: error during datasource_mgr_update_input_queue");
+        return -1; // error during execution
       }
       bgpstream_debug("BS: got results from datasource");
     }
@@ -488,11 +462,11 @@ int bgpstream_get_next_record(bgpstream_t *bs,
                                               bs->filter_mgr);
 }
 
-
 /* turn off the bgpstream interface */
-void bgpstream_stop(bgpstream_t *bs) {
+void bgpstream_stop(bgpstream_t *bs)
+{
   bgpstream_debug("BS: close start");
-  if(bs == NULL || (bs != NULL && bs->status != BGPSTREAM_STATUS_ON)) {
+  if (bs == NULL || (bs != NULL && bs->status != BGPSTREAM_STATUS_ON)) {
     return; // nothing to close
   }
   bgpstream_datasource_mgr_close(bs->datasource_mgr);
@@ -500,12 +474,12 @@ void bgpstream_stop(bgpstream_t *bs) {
   bgpstream_debug("BS: close end");
 }
 
-
 /* destroy a bgpstream interface istance
  */
-void bgpstream_destroy(bgpstream_t *bs){
+void bgpstream_destroy(bgpstream_t *bs)
+{
   bgpstream_debug("BS: destroy start");
-  if(bs == NULL) {
+  if (bs == NULL) {
     return; // nothing to destroy
   }
   bgpstream_input_mgr_destroy(bs->input_mgr);

--- a/lib/bgpstream.h
+++ b/lib/bgpstream.h
@@ -24,9 +24,9 @@
 #ifndef __BGPSTREAM_H
 #define __BGPSTREAM_H
 
-#include "bgpstream_utils.h"
 #include "bgpstream_elem.h"
 #include "bgpstream_record.h"
+#include "bgpstream_utils.h"
 
 /** @file
  *
@@ -68,43 +68,41 @@ typedef struct struct_bgpstream_t bgpstream_t;
 typedef enum {
 
   /** Filter records based on associated project (e.g. 'ris') */
-  BGPSTREAM_FILTER_TYPE_PROJECT       = 1,
+  BGPSTREAM_FILTER_TYPE_PROJECT = 1,
 
   /** Filter records based on collector (e.g. 'rrc01') */
-  BGPSTREAM_FILTER_TYPE_COLLECTOR     = 2,
+  BGPSTREAM_FILTER_TYPE_COLLECTOR = 2,
 
   /** Filter records based on record type (e.g. 'updates') */
-  BGPSTREAM_FILTER_TYPE_RECORD_TYPE   = 3,
+  BGPSTREAM_FILTER_TYPE_RECORD_TYPE = 3,
 
   /** Filter elems based on peer ASN  */
   BGPSTREAM_FILTER_TYPE_ELEM_PEER_ASN = 4,
 
   /** Filter elems based on prefix  */
-  BGPSTREAM_FILTER_TYPE_ELEM_PREFIX   = 5,
+  BGPSTREAM_FILTER_TYPE_ELEM_PREFIX = 5,
 
   /** Filter elems based on the community attribute  */
   BGPSTREAM_FILTER_TYPE_ELEM_COMMUNITY = 6,
 
 } bgpstream_filter_type_t;
 
-
 /** Data Interface IDs */
 typedef enum {
 
   /** Broker data interface */
-  BGPSTREAM_DATA_INTERFACE_BROKER     = 1,
+  BGPSTREAM_DATA_INTERFACE_BROKER = 1,
 
   /** Customlist interface */
   BGPSTREAM_DATA_INTERFACE_SINGLEFILE = 2,
 
   /** CSV file interface */
-  BGPSTREAM_DATA_INTERFACE_CSVFILE    = 3,
+  BGPSTREAM_DATA_INTERFACE_CSVFILE = 3,
 
   /** SQLITE file interface */
-  BGPSTREAM_DATA_INTERFACE_SQLITE     = 4,
+  BGPSTREAM_DATA_INTERFACE_SQLITE = 4,
 
 } bgpstream_data_interface_id_t;
-
 
 /** @} */
 
@@ -114,8 +112,7 @@ typedef enum {
  * @{ */
 
 /** Structure that contains information about a BGP Stream Data Interface */
-typedef struct struct_bgpstream_data_interface_info
-{
+typedef struct struct_bgpstream_data_interface_info {
 
   /** The ID of this data interface */
   bgpstream_data_interface_id_t id;
@@ -129,8 +126,7 @@ typedef struct struct_bgpstream_data_interface_info
 } bgpstream_data_interface_info_t;
 
 /** Structure that represents BGP Stream Data Interface Option */
-typedef struct struct_bgpstream_data_interface_option
-{
+typedef struct struct_bgpstream_data_interface_option {
 
   /** The ID of the data interface that this option applies to */
   bgpstream_data_interface_id_t if_id;
@@ -165,12 +161,11 @@ bgpstream_t *bgpstream_create();
  * @param filter_type   the type of the filter to apply
  * @param filter_value  the value to set the filter to
  */
-void bgpstream_add_filter(bgpstream_t *bs,
-                          bgpstream_filter_type_t filter_type,
-			  const char* filter_value);
+void bgpstream_add_filter(bgpstream_t *bs, bgpstream_filter_type_t filter_type,
+                          const char *filter_value);
 
 /** Add a filter to configure the minimum bgp time interval between RIB
- *  files that belong to the same collector. This information can be 
+ *  files that belong to the same collector. This information can be
  *  changed at run time.
  *
  * @param bs        pointer to a BGP Stream instance to filter
@@ -187,8 +182,7 @@ void bgpstream_add_rib_period_filter(bgpstream_t *bs, uint32_t period);
  * If end_time is set to BGPSTREAM_FOREVER, the stream will be set to live mode,
  * and will process data forever.
  */
-void bgpstream_add_interval_filter(bgpstream_t *bs,
-				   uint32_t begin_time,
+void bgpstream_add_interval_filter(bgpstream_t *bs, uint32_t begin_time,
                                    uint32_t end_time);
 
 /** Get a list of data interfaces that are currently supported
@@ -235,9 +229,9 @@ bgpstream_get_data_interface_info(bgpstream_t *bs,
  * @note the returned array belongs to BGP Stream. It must not be freed by the
  * user.
  */
-int bgpstream_get_data_interface_options(bgpstream_t *bs,
-                                      bgpstream_data_interface_id_t if_id,
-                                      bgpstream_data_interface_option_t **opts);
+int bgpstream_get_data_interface_options(
+  bgpstream_t *bs, bgpstream_data_interface_id_t if_id,
+  bgpstream_data_interface_option_t **opts);
 
 /** Get the data interface option for the given data interface and option name
  *
@@ -247,10 +241,8 @@ int bgpstream_get_data_interface_options(bgpstream_t *bs,
  * @return pointer to the option information with the given name, NULL if either
  * the interface ID is not valid, or the name does not match any options
  */
-bgpstream_data_interface_option_t *
-bgpstream_get_data_interface_option_by_name(bgpstream_t *bs,
-                                            bgpstream_data_interface_id_t if_id,
-                                            const char *name);
+bgpstream_data_interface_option_t *bgpstream_get_data_interface_option_by_name(
+  bgpstream_t *bs, bgpstream_data_interface_id_t if_id, const char *name);
 
 /** Set a data interface option
  *
@@ -261,9 +253,9 @@ bgpstream_get_data_interface_option_by_name(bgpstream_t *bs,
  * Use the bgpstream_get_data_interface_options function to discover the set of
  * options for an interface.
  */
-void bgpstream_set_data_interface_option(bgpstream_t *bs,
-                                bgpstream_data_interface_option_t *option_type,
-                                const char *option_value);
+void bgpstream_set_data_interface_option(
+  bgpstream_t *bs, bgpstream_data_interface_option_t *option_type,
+  const char *option_value);
 
 /** Get the ID of the currently active data interface
  *
@@ -273,8 +265,7 @@ void bgpstream_set_data_interface_option(bgpstream_t *bs,
  * If no data interface has been explicitly set, this function will return the
  * ID of the default data interface.
  */
-bgpstream_data_interface_id_t
-bgpstream_get_data_interface_id(bgpstream_t *bs);
+bgpstream_data_interface_id_t bgpstream_get_data_interface_id(bgpstream_t *bs);
 
 /** Set the data interface that BGP Stream uses to find BGP data
  *
@@ -318,8 +309,7 @@ int bgpstream_start(bgpstream_t *bs);
  * independently of each other). If records are not processed independently,
  * then a new record must be created for each call to this function.
  */
-int bgpstream_get_next_record(bgpstream_t *bs,
-                              bgpstream_record_t *record);
+int bgpstream_get_next_record(bgpstream_t *bs, bgpstream_record_t *record);
 
 /** Stop the given BGP Stream instance
  *

--- a/lib/bgpstream_constants.h
+++ b/lib/bgpstream_constants.h
@@ -33,5 +33,4 @@
 // parameters/attribute/filters max length
 #define BGPSTREAM_PAR_MAX_LEN 512
 
-
 #endif /* _BGPSTREAM_CONSTANTS_H */

--- a/lib/bgpstream_datasource.c
+++ b/lib/bgpstream_datasource.c
@@ -21,64 +21,58 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
-#include "utils.h"
 #include "bgpstream_datasource.h"
 #include "bgpstream_debug.h"
+#include "config.h"
+#include "utils.h"
 
 #include <assert.h>
 #include <inttypes.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <sys/stat.h>
-#include <sys/time.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #define DATASOURCE_BLOCKING_MIN_WAIT 30
 #define DATASOURCE_BLOCKING_MAX_WAIT 150
 
+#define GET_DEFAULT_STR_VALUE(var_store, default_value)                        \
+  do {                                                                         \
+    if (strcmp(default_value, "not-set") == 0) {                               \
+      var_store = NULL;                                                        \
+    } else {                                                                   \
+      var_store = strdup(default_value);                                       \
+    }                                                                          \
+  } while (0)
 
-#define GET_DEFAULT_STR_VALUE(var_store, default_value) \
-  do {                                                  \
-    if(strcmp(default_value, "not-set") == 0)           \
-      {                                                 \
-        var_store = NULL;                               \
-      }                                                 \
-    else                                                \
-      {                                                 \
-        var_store = strdup(default_value);              \
-      }                                                 \
-  } while(0)
-
-#define GET_DEFAULT_INT_VALUE(var_store, default_value) \
-  do {                                                  \
-    if(strcmp(default_value, "not-set") == 0)           \
-      {                                                 \
-        var_store = 0;                                  \
-      }                                                 \
-    else                                                \
-      {                                                 \
-        var_store = atoi(default_value);                \
-      }                                                 \
-  } while(0)
-
+#define GET_DEFAULT_INT_VALUE(var_store, default_value)                        \
+  do {                                                                         \
+    if (strcmp(default_value, "not-set") == 0) {                               \
+      var_store = 0;                                                           \
+    } else {                                                                   \
+      var_store = atoi(default_value);                                         \
+    }                                                                          \
+  } while (0)
 
 /* datasource mgr related functions */
 
-
-bgpstream_datasource_mgr_t *bgpstream_datasource_mgr_create(){
+bgpstream_datasource_mgr_t *bgpstream_datasource_mgr_create()
+{
   bgpstream_debug("\tBSDS_MGR: create start");
-  bgpstream_datasource_mgr_t *datasource_mgr = (bgpstream_datasource_mgr_t*) malloc(sizeof(bgpstream_datasource_mgr_t));
-  if(datasource_mgr == NULL) {
+  bgpstream_datasource_mgr_t *datasource_mgr =
+    (bgpstream_datasource_mgr_t *)malloc(sizeof(bgpstream_datasource_mgr_t));
+  if (datasource_mgr == NULL) {
     return NULL; // can't allocate memory
   }
   // default values
-  datasource_mgr->datasource = BGPSTREAM_DATA_INTERFACE_BROKER; // default data source
+  datasource_mgr->datasource =
+    BGPSTREAM_DATA_INTERFACE_BROKER; // default data source
   datasource_mgr->blocking = 0;
   datasource_mgr->backoff_time = DATASOURCE_BLOCKING_MIN_WAIT;
-  // datasources (none of them is active at the beginning)
+// datasources (none of them is active at the beginning)
 
 #ifdef WITH_DATA_INTERFACE_SINGLEFILE
   datasource_mgr->singlefile_ds = NULL;
@@ -102,8 +96,7 @@ bgpstream_datasource_mgr_t *bgpstream_datasource_mgr_create(){
 
 #ifdef WITH_DATA_INTERFACE_BROKER
   datasource_mgr->broker_ds = NULL;
-  GET_DEFAULT_STR_VALUE(datasource_mgr->broker_url,
-                        BGPSTREAM_DS_BROKER_URL);
+  GET_DEFAULT_STR_VALUE(datasource_mgr->broker_url, BGPSTREAM_DS_BROKER_URL);
   datasource_mgr->broker_params = NULL;
   datasource_mgr->broker_params_cnt = 0;
 #endif
@@ -114,293 +107,281 @@ bgpstream_datasource_mgr_t *bgpstream_datasource_mgr_create(){
   return datasource_mgr;
 }
 
-void bgpstream_datasource_mgr_set_data_interface(bgpstream_datasource_mgr_t *datasource_mgr,
-						 const bgpstream_data_interface_id_t datasource) {
+void bgpstream_datasource_mgr_set_data_interface(
+  bgpstream_datasource_mgr_t *datasource_mgr,
+  const bgpstream_data_interface_id_t datasource)
+{
   bgpstream_debug("\tBSDS_MGR: set data interface start");
-  if(datasource_mgr == NULL) {
+  if (datasource_mgr == NULL) {
     return; // no manager
   }
-  datasource_mgr->datasource = datasource;   
+  datasource_mgr->datasource = datasource;
   bgpstream_debug("\tBSDS_MGR: set  data interface end");
 }
 
-
-int bgpstream_datasource_mgr_set_data_interface_option(bgpstream_datasource_mgr_t *datasource_mgr,
-                                                        const bgpstream_data_interface_option_t *option_type,
-							const char *option_value) {
+int bgpstream_datasource_mgr_set_data_interface_option(
+  bgpstream_datasource_mgr_t *datasource_mgr,
+  const bgpstream_data_interface_option_t *option_type,
+  const char *option_value)
+{
   // this option has no effect if the datasource selected is not
   // using this option
-  switch(option_type->if_id)
-    {
+  switch (option_type->if_id) {
 #ifdef WITH_DATA_INTERFACE_SINGLEFILE
-    case BGPSTREAM_DATA_INTERFACE_SINGLEFILE:
-      switch(option_type->id)
-        {
-        case 0:
-          if(datasource_mgr->singlefile_rib_mrtfile!=NULL)
-            {
-              free(datasource_mgr->singlefile_rib_mrtfile);
-            }
-          datasource_mgr->singlefile_rib_mrtfile = strdup(option_value);
-          break;
-        case 1:
-          if(datasource_mgr->singlefile_upd_mrtfile!=NULL)
-            {
-              free(datasource_mgr->singlefile_upd_mrtfile);
-            }
-          datasource_mgr->singlefile_upd_mrtfile = strdup(option_value);
-          break;
-        }
+  case BGPSTREAM_DATA_INTERFACE_SINGLEFILE:
+    switch (option_type->id) {
+    case 0:
+      if (datasource_mgr->singlefile_rib_mrtfile != NULL) {
+        free(datasource_mgr->singlefile_rib_mrtfile);
+      }
+      datasource_mgr->singlefile_rib_mrtfile = strdup(option_value);
       break;
+    case 1:
+      if (datasource_mgr->singlefile_upd_mrtfile != NULL) {
+        free(datasource_mgr->singlefile_upd_mrtfile);
+      }
+      datasource_mgr->singlefile_upd_mrtfile = strdup(option_value);
+      break;
+    }
+    break;
 #endif
 
 #ifdef WITH_DATA_INTERFACE_CSVFILE
-    case BGPSTREAM_DATA_INTERFACE_CSVFILE:
-      switch(option_type->id)
-        {
-        case 0:
-          if(datasource_mgr->csvfile_file!=NULL)
-            {
-              free(datasource_mgr->csvfile_file);
-            }
-          datasource_mgr->csvfile_file = strdup(option_value);
-          break;
-        }
+  case BGPSTREAM_DATA_INTERFACE_CSVFILE:
+    switch (option_type->id) {
+    case 0:
+      if (datasource_mgr->csvfile_file != NULL) {
+        free(datasource_mgr->csvfile_file);
+      }
+      datasource_mgr->csvfile_file = strdup(option_value);
       break;
+    }
+    break;
 #endif
 
 #ifdef WITH_DATA_INTERFACE_SQLITE
-      case BGPSTREAM_DATA_INTERFACE_SQLITE:
-      switch(option_type->id)
-        {
-        case 0:
-          if(datasource_mgr->sqlite_file!=NULL)
-            {
-              free(datasource_mgr->sqlite_file);
-            }
-          datasource_mgr->sqlite_file = strdup(option_value);
-          break;
-        }
+  case BGPSTREAM_DATA_INTERFACE_SQLITE:
+    switch (option_type->id) {
+    case 0:
+      if (datasource_mgr->sqlite_file != NULL) {
+        free(datasource_mgr->sqlite_file);
+      }
+      datasource_mgr->sqlite_file = strdup(option_value);
+      break;
+    }
 #endif
 
 #ifdef WITH_DATA_INTERFACE_BROKER
-    case BGPSTREAM_DATA_INTERFACE_BROKER:
-      switch(option_type->id)
-        {
-        case 0:
-          if(datasource_mgr->broker_url!=NULL)
-            {
-              free(datasource_mgr->broker_url);
-            }
-          datasource_mgr->broker_url = strdup(option_value);
-          break;
-
-        case 1:
-          if((datasource_mgr->broker_params =
-              realloc(datasource_mgr->broker_params,
-                      sizeof(char*) * (datasource_mgr->broker_params_cnt+1)))
-             == NULL)
-            {
-              return -1;
-            }
-          datasource_mgr->broker_params[datasource_mgr->broker_params_cnt++]
-            = strdup(option_value);
-          break;
-        }
+  case BGPSTREAM_DATA_INTERFACE_BROKER:
+    switch (option_type->id) {
+    case 0:
+      if (datasource_mgr->broker_url != NULL) {
+        free(datasource_mgr->broker_url);
+      }
+      datasource_mgr->broker_url = strdup(option_value);
       break;
+
+    case 1:
+      if ((datasource_mgr->broker_params = realloc(
+             datasource_mgr->broker_params,
+             sizeof(char *) * (datasource_mgr->broker_params_cnt + 1))) ==
+          NULL) {
+        return -1;
+      }
+      datasource_mgr->broker_params[datasource_mgr->broker_params_cnt++] =
+        strdup(option_value);
+      break;
+    }
+    break;
 #endif
 
-    default:
-      fprintf(stderr, "Invalid data interface (are all interfaces built?\n");
-      return -1;
-    }
+  default:
+    fprintf(stderr, "Invalid data interface (are all interfaces built?\n");
+    return -1;
+  }
   return 0;
 }
 
-
 void bgpstream_datasource_mgr_init(bgpstream_datasource_mgr_t *datasource_mgr,
-				   bgpstream_filter_mgr_t *filter_mgr){
+                                   bgpstream_filter_mgr_t *filter_mgr)
+{
   bgpstream_debug("\tBSDS_MGR: init start");
-  if(datasource_mgr == NULL) {
+  if (datasource_mgr == NULL) {
     return; // no manager
   }
 
   void *ds = NULL;
-  
-  switch(datasource_mgr->datasource)
-    {
+
+  switch (datasource_mgr->datasource) {
 #ifdef WITH_DATA_INTERFACE_SINGLEFILE
-    case BGPSTREAM_DATA_INTERFACE_SINGLEFILE:
-      datasource_mgr->singlefile_ds =
-        bgpstream_singlefile_datasource_create(filter_mgr,
-                                               datasource_mgr->singlefile_rib_mrtfile,
-                                               datasource_mgr->singlefile_upd_mrtfile);
-      ds = (void *) datasource_mgr->singlefile_ds;
-      break;
+  case BGPSTREAM_DATA_INTERFACE_SINGLEFILE:
+    datasource_mgr->singlefile_ds = bgpstream_singlefile_datasource_create(
+      filter_mgr, datasource_mgr->singlefile_rib_mrtfile,
+      datasource_mgr->singlefile_upd_mrtfile);
+    ds = (void *)datasource_mgr->singlefile_ds;
+    break;
 #endif
 
 #ifdef WITH_DATA_INTERFACE_CSVFILE
-    case BGPSTREAM_DATA_INTERFACE_CSVFILE:
-      datasource_mgr->csvfile_ds =
-        bgpstream_csvfile_datasource_create(filter_mgr,
-                                            datasource_mgr->csvfile_file);
-      ds = (void *) datasource_mgr->csvfile_ds;
-      break;
+  case BGPSTREAM_DATA_INTERFACE_CSVFILE:
+    datasource_mgr->csvfile_ds = bgpstream_csvfile_datasource_create(
+      filter_mgr, datasource_mgr->csvfile_file);
+    ds = (void *)datasource_mgr->csvfile_ds;
+    break;
 #endif
 
 #ifdef WITH_DATA_INTERFACE_SQLITE
-    case BGPSTREAM_DATA_INTERFACE_SQLITE:
-      datasource_mgr->sqlite_ds =
-        bgpstream_sqlite_datasource_create(filter_mgr,
-                                           datasource_mgr->sqlite_file);
-      ds = (void *) datasource_mgr->sqlite_ds;
-      break;
+  case BGPSTREAM_DATA_INTERFACE_SQLITE:
+    datasource_mgr->sqlite_ds = bgpstream_sqlite_datasource_create(
+      filter_mgr, datasource_mgr->sqlite_file);
+    ds = (void *)datasource_mgr->sqlite_ds;
+    break;
 #endif
 
 #ifdef WITH_DATA_INTERFACE_BROKER
-    case BGPSTREAM_DATA_INTERFACE_BROKER:
-      datasource_mgr->broker_ds =
-        bgpstream_broker_datasource_create(filter_mgr,
-                                           datasource_mgr->broker_url,
-                                           datasource_mgr->broker_params,
-                                           datasource_mgr->broker_params_cnt);
-      ds = (void *) datasource_mgr->broker_ds;
-      break;
+  case BGPSTREAM_DATA_INTERFACE_BROKER:
+    datasource_mgr->broker_ds = bgpstream_broker_datasource_create(
+      filter_mgr, datasource_mgr->broker_url, datasource_mgr->broker_params,
+      datasource_mgr->broker_params_cnt);
+    ds = (void *)datasource_mgr->broker_ds;
+    break;
 #endif
 
-    default:
-      ds = NULL;
-    }
+  default:
+    ds = NULL;
+  }
 
-  if(ds == NULL)
-    {
-      datasource_mgr->status = BGPSTREAM_DATASOURCE_STATUS_ERROR;
-    }
-    else {
-      datasource_mgr->status = BGPSTREAM_DATASOURCE_STATUS_ON;
-    }
+  if (ds == NULL) {
+    datasource_mgr->status = BGPSTREAM_DATASOURCE_STATUS_ERROR;
+  } else {
+    datasource_mgr->status = BGPSTREAM_DATASOURCE_STATUS_ON;
+  }
   bgpstream_debug("\tBSDS_MGR: init end");
 }
 
-
-void bgpstream_datasource_mgr_set_blocking(bgpstream_datasource_mgr_t *datasource_mgr){
+void bgpstream_datasource_mgr_set_blocking(
+  bgpstream_datasource_mgr_t *datasource_mgr)
+{
   bgpstream_debug("\tBSDS_MGR: set blocking start");
-  if(datasource_mgr == NULL) {
+  if (datasource_mgr == NULL) {
     return; // no manager
   }
   datasource_mgr->blocking = 1;
   bgpstream_debug("\tBSDS_MGR: set blocking end");
 }
 
-
-int bgpstream_datasource_mgr_update_input_queue(bgpstream_datasource_mgr_t *datasource_mgr,
-						bgpstream_input_mgr_t *input_mgr) {
+int bgpstream_datasource_mgr_update_input_queue(
+  bgpstream_datasource_mgr_t *datasource_mgr, bgpstream_input_mgr_t *input_mgr)
+{
   bgpstream_debug("\tBSDS_MGR: get data start");
-  if(datasource_mgr == NULL) {
+  if (datasource_mgr == NULL) {
     return -1; // no datasource manager
   }
   int results = -1;
 
-  do{
-    switch(datasource_mgr->datasource)
-      {
-#ifdef WITH_DATA_INTERFACE_SINGLEFILE
-      case BGPSTREAM_DATA_INTERFACE_SINGLEFILE:
-        results = bgpstream_singlefile_datasource_update_input_queue(datasource_mgr->singlefile_ds, input_mgr);
-        break;
-#endif
-
-#ifdef WITH_DATA_INTERFACE_CSVFILE
-      case BGPSTREAM_DATA_INTERFACE_CSVFILE:
-        results = bgpstream_csvfile_datasource_update_input_queue(datasource_mgr->csvfile_ds, input_mgr);
-        break;
-#endif
-
-#ifdef WITH_DATA_INTERFACE_SQLITE
-      case BGPSTREAM_DATA_INTERFACE_SQLITE:
-        results = bgpstream_sqlite_datasource_update_input_queue(datasource_mgr->sqlite_ds, input_mgr);
-        break;
-#endif
-
-#ifdef WITH_DATA_INTERFACE_BROKER
-      case BGPSTREAM_DATA_INTERFACE_BROKER:
-        results = bgpstream_broker_datasource_update_input_queue(datasource_mgr->broker_ds, input_mgr);
-        break;
-#endif
-
-      default:
-        fprintf(stderr, "Invalid data interface\n");
-        break;
-      }
-    if(results == 0 && datasource_mgr->blocking) {
-	// results = 0 => 2+ time and database did not give any error
-	sleep(datasource_mgr->backoff_time);
-	datasource_mgr->backoff_time = datasource_mgr->backoff_time * 2;
-	if(datasource_mgr->backoff_time > DATASOURCE_BLOCKING_MAX_WAIT) {
-	  datasource_mgr->backoff_time = DATASOURCE_BLOCKING_MAX_WAIT;
-	}
-    }
-    bgpstream_debug("\tBSDS_MGR: got %d (blocking: %d)", results,
-                    datasource_mgr->blocking);
-  } while(datasource_mgr->blocking && results == 0);
-
-  datasource_mgr->backoff_time = DATASOURCE_BLOCKING_MIN_WAIT;
-  
-  bgpstream_debug("\tBSDS_MGR: get data end");
-  return results; 
-}
-
-
-void bgpstream_datasource_mgr_close(bgpstream_datasource_mgr_t *datasource_mgr) {
-  bgpstream_debug("\tBSDS_MGR: close start");
-  if(datasource_mgr == NULL) {
-    return; // no manager to destroy
-  }
-  switch(datasource_mgr->datasource)
-    {
+  do {
+    switch (datasource_mgr->datasource) {
 #ifdef WITH_DATA_INTERFACE_SINGLEFILE
     case BGPSTREAM_DATA_INTERFACE_SINGLEFILE:
-      bgpstream_singlefile_datasource_destroy(datasource_mgr->singlefile_ds);
-      datasource_mgr->singlefile_ds = NULL;
+      results = bgpstream_singlefile_datasource_update_input_queue(
+        datasource_mgr->singlefile_ds, input_mgr);
       break;
 #endif
 
 #ifdef WITH_DATA_INTERFACE_CSVFILE
     case BGPSTREAM_DATA_INTERFACE_CSVFILE:
-      bgpstream_csvfile_datasource_destroy(datasource_mgr->csvfile_ds);
-      datasource_mgr->csvfile_ds = NULL;
+      results = bgpstream_csvfile_datasource_update_input_queue(
+        datasource_mgr->csvfile_ds, input_mgr);
       break;
 #endif
 
 #ifdef WITH_DATA_INTERFACE_SQLITE
     case BGPSTREAM_DATA_INTERFACE_SQLITE:
-      bgpstream_sqlite_datasource_destroy(datasource_mgr->sqlite_ds);
-      datasource_mgr->sqlite_ds = NULL;
+      results = bgpstream_sqlite_datasource_update_input_queue(
+        datasource_mgr->sqlite_ds, input_mgr);
       break;
 #endif
 
 #ifdef WITH_DATA_INTERFACE_BROKER
     case BGPSTREAM_DATA_INTERFACE_BROKER:
-      bgpstream_broker_datasource_destroy(datasource_mgr->broker_ds);
-      datasource_mgr->broker_ds = NULL;
+      results = bgpstream_broker_datasource_update_input_queue(
+        datasource_mgr->broker_ds, input_mgr);
       break;
 #endif
 
     default:
-      assert(0);
+      fprintf(stderr, "Invalid data interface\n");
       break;
     }
+    if (results == 0 && datasource_mgr->blocking) {
+      // results = 0 => 2+ time and database did not give any error
+      sleep(datasource_mgr->backoff_time);
+      datasource_mgr->backoff_time = datasource_mgr->backoff_time * 2;
+      if (datasource_mgr->backoff_time > DATASOURCE_BLOCKING_MAX_WAIT) {
+        datasource_mgr->backoff_time = DATASOURCE_BLOCKING_MAX_WAIT;
+      }
+    }
+    bgpstream_debug("\tBSDS_MGR: got %d (blocking: %d)", results,
+                    datasource_mgr->blocking);
+  } while (datasource_mgr->blocking && results == 0);
+
+  datasource_mgr->backoff_time = DATASOURCE_BLOCKING_MIN_WAIT;
+
+  bgpstream_debug("\tBSDS_MGR: get data end");
+  return results;
+}
+
+void bgpstream_datasource_mgr_close(bgpstream_datasource_mgr_t *datasource_mgr)
+{
+  bgpstream_debug("\tBSDS_MGR: close start");
+  if (datasource_mgr == NULL) {
+    return; // no manager to destroy
+  }
+  switch (datasource_mgr->datasource) {
+#ifdef WITH_DATA_INTERFACE_SINGLEFILE
+  case BGPSTREAM_DATA_INTERFACE_SINGLEFILE:
+    bgpstream_singlefile_datasource_destroy(datasource_mgr->singlefile_ds);
+    datasource_mgr->singlefile_ds = NULL;
+    break;
+#endif
+
+#ifdef WITH_DATA_INTERFACE_CSVFILE
+  case BGPSTREAM_DATA_INTERFACE_CSVFILE:
+    bgpstream_csvfile_datasource_destroy(datasource_mgr->csvfile_ds);
+    datasource_mgr->csvfile_ds = NULL;
+    break;
+#endif
+
+#ifdef WITH_DATA_INTERFACE_SQLITE
+  case BGPSTREAM_DATA_INTERFACE_SQLITE:
+    bgpstream_sqlite_datasource_destroy(datasource_mgr->sqlite_ds);
+    datasource_mgr->sqlite_ds = NULL;
+    break;
+#endif
+
+#ifdef WITH_DATA_INTERFACE_BROKER
+  case BGPSTREAM_DATA_INTERFACE_BROKER:
+    bgpstream_broker_datasource_destroy(datasource_mgr->broker_ds);
+    datasource_mgr->broker_ds = NULL;
+    break;
+#endif
+
+  default:
+    assert(0);
+    break;
+  }
   datasource_mgr->status = BGPSTREAM_DATASOURCE_STATUS_OFF;
   bgpstream_debug("\tBSDS_MGR: close end");
 }
 
-
-void bgpstream_datasource_mgr_destroy(bgpstream_datasource_mgr_t *datasource_mgr) {
+void bgpstream_datasource_mgr_destroy(
+  bgpstream_datasource_mgr_t *datasource_mgr)
+{
   bgpstream_debug("\tBSDS_MGR: destroy start");
-  if(datasource_mgr == NULL) {
+  if (datasource_mgr == NULL) {
     return; // no manager to destroy
   }
-  // destroy any active datasource (if they have not been destroyed before)
+// destroy any active datasource (if they have not been destroyed before)
 #ifdef WITH_DATA_INTERFACE_SINGLEFILE
   bgpstream_singlefile_datasource_destroy(datasource_mgr->singlefile_ds);
   datasource_mgr->singlefile_ds = NULL;
@@ -425,11 +406,10 @@ void bgpstream_datasource_mgr_destroy(bgpstream_datasource_mgr_t *datasource_mgr
   datasource_mgr->broker_ds = NULL;
   free(datasource_mgr->broker_url);
   int i;
-  for(i=0; i<datasource_mgr->broker_params_cnt; i++)
-    {
-      free(datasource_mgr->broker_params[i]);
-      datasource_mgr->broker_params[i] = NULL;
-    }
+  for (i = 0; i < datasource_mgr->broker_params_cnt; i++) {
+    free(datasource_mgr->broker_params[i]);
+    datasource_mgr->broker_params[i] = NULL;
+  }
   free(datasource_mgr->broker_params);
   datasource_mgr->broker_params = NULL;
   datasource_mgr->broker_params_cnt = 0;
@@ -438,4 +418,3 @@ void bgpstream_datasource_mgr_destroy(bgpstream_datasource_mgr_t *datasource_mgr
   free(datasource_mgr);
   bgpstream_debug("\tBSDS_MGR: destroy end");
 }
-

--- a/lib/bgpstream_datasource.h
+++ b/lib/bgpstream_datasource.h
@@ -24,6 +24,7 @@
 #ifndef _BGPSTREAM_DATASOURCE_H
 #define _BGPSTREAM_DATASOURCE_H
 
+#include "config.h"
 #include "bgpstream_constants.h"
 #include "bgpstream_filter.h"
 #include "bgpstream_input.h"

--- a/lib/bgpstream_datasource.h
+++ b/lib/bgpstream_datasource.h
@@ -25,11 +25,11 @@
 #define _BGPSTREAM_DATASOURCE_H
 
 #include "bgpstream_constants.h"
-#include "bgpstream_input.h"
 #include "bgpstream_filter.h"
+#include "bgpstream_input.h"
 
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #ifdef WITH_DATA_INTERFACE_SINGLEFILE
 #include "bgpstream_datasource_singlefile.h"
@@ -47,19 +47,15 @@
 #include "bgpstream_datasource_broker.h"
 #endif
 
-
-
 typedef enum {
-  BGPSTREAM_DATASOURCE_STATUS_ON,    /* current data source is on */
-  BGPSTREAM_DATASOURCE_STATUS_OFF,   /* current data source is off */
-  BGPSTREAM_DATASOURCE_STATUS_ERROR  /* current data source generated an error */
+  BGPSTREAM_DATASOURCE_STATUS_ON,   /* current data source is on */
+  BGPSTREAM_DATASOURCE_STATUS_OFF,  /* current data source is off */
+  BGPSTREAM_DATASOURCE_STATUS_ERROR /* current data source generated an error */
 } bgpstream_datasource_status_t;
 
-
-
-typedef struct struct_bgpstream_datasource_mgr_t {  
+typedef struct struct_bgpstream_datasource_mgr_t {
   bgpstream_data_interface_id_t datasource;
-  // datasources available
+// datasources available
 #ifdef WITH_DATA_INTERFACE_SINGLEFILE
   bgpstream_singlefile_datasource_t *singlefile_ds;
   char *singlefile_rib_mrtfile;
@@ -89,33 +85,33 @@ typedef struct struct_bgpstream_datasource_mgr_t {
   bgpstream_datasource_status_t status;
 } bgpstream_datasource_mgr_t;
 
-
 /* allocates memory for datasource_mgr */
 bgpstream_datasource_mgr_t *bgpstream_datasource_mgr_create();
 
-void bgpstream_datasource_mgr_set_data_interface(bgpstream_datasource_mgr_t *datasource_mgr,
-						 const bgpstream_data_interface_id_t datasource);
+void bgpstream_datasource_mgr_set_data_interface(
+  bgpstream_datasource_mgr_t *datasource_mgr,
+  const bgpstream_data_interface_id_t datasource);
 
-int bgpstream_datasource_mgr_set_data_interface_option(bgpstream_datasource_mgr_t *datasource_mgr,
-							const bgpstream_data_interface_option_t *option_type,
-							const char *option_value);
+int bgpstream_datasource_mgr_set_data_interface_option(
+  bgpstream_datasource_mgr_t *datasource_mgr,
+  const bgpstream_data_interface_option_t *option_type,
+  const char *option_value);
 
 /* init the datasource_mgr and start/init the selected datasource */
 void bgpstream_datasource_mgr_init(bgpstream_datasource_mgr_t *datasource_mgr,
-				   bgpstream_filter_mgr_t *filter_mgr);
+                                   bgpstream_filter_mgr_t *filter_mgr);
 
-void bgpstream_datasource_mgr_set_blocking(bgpstream_datasource_mgr_t *datasource_mgr);
+void bgpstream_datasource_mgr_set_blocking(
+  bgpstream_datasource_mgr_t *datasource_mgr);
 
-int bgpstream_datasource_mgr_update_input_queue(bgpstream_datasource_mgr_t *datasource_mgr,
-						bgpstream_input_mgr_t *input_mgr);
+int bgpstream_datasource_mgr_update_input_queue(
+  bgpstream_datasource_mgr_t *datasource_mgr, bgpstream_input_mgr_t *input_mgr);
 
 /* stop the active data source */
 void bgpstream_datasource_mgr_close(bgpstream_datasource_mgr_t *datasource_mgr);
 
 /* destroy the memory allocated for the datasource_mgr */
-void bgpstream_datasource_mgr_destroy(bgpstream_datasource_mgr_t *datasource_mgr);
-
-
-
+void bgpstream_datasource_mgr_destroy(
+  bgpstream_datasource_mgr_t *datasource_mgr);
 
 #endif /* _BGPSTREAM_DATASOURCE */

--- a/lib/bgpstream_debug.h
+++ b/lib/bgpstream_debug.h
@@ -26,42 +26,71 @@
 #ifndef _BGPSTREAM_DEBUG_H
 #define _BGPSTREAM_DEBUG_H
 
-#include <stdio.h>
 #include <errno.h>
+#include <stdio.h>
 #include <string.h>
 #include <time.h>
 
-
-#define NDEBUG 
+#define NDEBUG
 
 // compile with NDEBUG defined -> then "no debug" messages will remain.
-#ifdef NDEBUG 
+#ifdef NDEBUG
 #define bgpstream_debug(M, ...)
 #else
-#define bgpstream_debug(M, ...) fprintf(stderr, "DEBUG %s:%d: " M "\n", __FILE__, __LINE__, ##__VA_ARGS__)
+#define bgpstream_debug(M, ...)                                                \
+  fprintf(stderr, "DEBUG %s:%d: " M "\n", __FILE__, __LINE__, ##__VA_ARGS__)
 #endif
 
 // get a safe readable version of errno.
 #define bgpstream_clean_errno() (errno == 0 ? "None" : strerror(errno))
 
 // macros for logging messages meant for the end use
-#define bgpstream_log_err(M, ...) fprintf(stderr, "[ERROR] (%s:%d: errno: %s) " M "\n", __FILE__, __LINE__, bgpstream_clean_errno(), ##__VA_ARGS__)
+#define bgpstream_log_err(M, ...)                                              \
+  fprintf(stderr, "[ERROR] (%s:%d: errno: %s) " M "\n", __FILE__, __LINE__,    \
+          bgpstream_clean_errno(), ##__VA_ARGS__)
 
-#define bgpstream_log_warn(M, ...) fprintf(stderr, "[WARN] (%s:%d: errno: %s) " M "\n", __FILE__, __LINE__, bgpstream_clean_errno(), ##__VA_ARGS__)
+#define bgpstream_log_warn(M, ...)                                             \
+  fprintf(stderr, "[WARN] (%s:%d: errno: %s) " M "\n", __FILE__, __LINE__,     \
+          bgpstream_clean_errno(), ##__VA_ARGS__)
 
-#define bgpstream_log_info(M, ...) fprintf(stderr, "[INFO] (%s:%d) " M "\n", __FILE__, __LINE__, ##__VA_ARGS__)
+#define bgpstream_log_info(M, ...)                                             \
+  fprintf(stderr, "[INFO] (%s:%d) " M "\n", __FILE__, __LINE__, ##__VA_ARGS__)
 
-// check will make sure the condition A is true, and if not logs the error M (with variable arguments for log_err), then jumps to the function's error: for cleanup.
-#define bgpstream_check(A, M, ...) if(!(A)) { bgpstream_log_err(M, ##__VA_ARGS__); errno=0; goto error; }
+// check will make sure the condition A is true, and if not logs the error M
+// (with variable arguments for log_err), then jumps to the function's error:
+// for cleanup.
+#define bgpstream_check(A, M, ...)                                             \
+  if (!(A)) {                                                                  \
+    bgpstream_log_err(M, ##__VA_ARGS__);                                       \
+    errno = 0;                                                                 \
+    goto error;                                                                \
+  }
 
-// sentinel is placed in any part of a function that shouldn't run, and if it does prints an error message then jumps to the error: label. You put this in if-statements and switch-statements to catch conditions that shouldn't happen, like the default:.
-#define bgpstream_sentinel(M, ...)  { bgpstream_log_err(M, ##__VA_ARGS__); errno=0; goto error; }
+// sentinel is placed in any part of a function that shouldn't run, and if it
+// does prints an error message then jumps to the error: label. You put this in
+// if-statements and switch-statements to catch conditions that shouldn't
+// happen, like the default:.
+#define bgpstream_sentinel(M, ...)                                             \
+  {                                                                            \
+    bgpstream_log_err(M, ##__VA_ARGS__);                                       \
+    errno = 0;                                                                 \
+    goto error;                                                                \
+  }
 
-// check_mem that makes sure a pointer is valid, and if it isn't reports it as an error with "Out of memory."
+// check_mem that makes sure a pointer is valid, and if it isn't reports it as
+// an error with "Out of memory."
 #define bgpstream_check_mem(A) bgpstream_check((A), "Out of memory.")
 
-// An alternative macro check_debug that still checks and handles an error, but if the error is common then you don't want to bother reporting it. In this one it will use debug instead of log_err to report the message, so when you define NDEBUG the check still happens, the error jump goes off, but the message isn't printed.
-#define bgpstream_check_debug(A, M, ...) if(!(A)) { bgpstream_debug(M, ##__VA_ARGS__); errno=0; goto error; }
-
+// An alternative macro check_debug that still checks and handles an error, but
+// if the error is common then you don't want to bother reporting it. In this
+// one it will use debug instead of log_err to report the message, so when you
+// define NDEBUG the check still happens, the error jump goes off, but the
+// message isn't printed.
+#define bgpstream_check_debug(A, M, ...)                                       \
+  if (!(A)) {                                                                  \
+    bgpstream_debug(M, ##__VA_ARGS__);                                         \
+    errno = 0;                                                                 \
+    goto error;                                                                \
+  }
 
 #endif /* _BGPSTREAM_DEBUG_H */

--- a/lib/bgpstream_elem.c
+++ b/lib/bgpstream_elem.c
@@ -24,9 +24,9 @@
 #include "config.h"
 
 #include <assert.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
-#include <inttypes.h>
 
 #include "bgpdump_lib.h"
 #include "utils.h"
@@ -42,36 +42,38 @@
 
 /* ==================== PUBLIC FUNCTIONS ==================== */
 
-bgpstream_elem_t *bgpstream_elem_create() {
+bgpstream_elem_t *bgpstream_elem_create()
+{
   // allocate memory for new element
   bgpstream_elem_t *ri = NULL;
 
-  if((ri =
-      (bgpstream_elem_t *) malloc_zero(sizeof(bgpstream_elem_t))) == NULL) {
+  if ((ri = (bgpstream_elem_t *)malloc_zero(sizeof(bgpstream_elem_t))) ==
+      NULL) {
     goto err;
   }
   // all fields are initialized to zero
 
   // need to create as path
-  if((ri->aspath = bgpstream_as_path_create()) == NULL) {
+  if ((ri->aspath = bgpstream_as_path_create()) == NULL) {
     goto err;
   }
 
   // and a community set
-  if((ri->communities = bgpstream_community_set_create()) == NULL) {
+  if ((ri->communities = bgpstream_community_set_create()) == NULL) {
     goto err;
   }
 
   return ri;
 
- err:
+err:
   bgpstream_elem_destroy(ri);
   return NULL;
 }
 
-void bgpstream_elem_destroy(bgpstream_elem_t *elem) {
+void bgpstream_elem_destroy(bgpstream_elem_t *elem)
+{
 
-  if(elem == NULL) {
+  if (elem == NULL) {
     return;
   }
 
@@ -84,7 +86,8 @@ void bgpstream_elem_destroy(bgpstream_elem_t *elem) {
   free(elem);
 }
 
-void bgpstream_elem_clear(bgpstream_elem_t *elem) {
+void bgpstream_elem_clear(bgpstream_elem_t *elem)
+{
   bgpstream_as_path_clear(elem->aspath);
   bgpstream_community_set_clear(elem->communities);
 }
@@ -103,53 +106,49 @@ bgpstream_elem_t *bgpstream_elem_copy(bgpstream_elem_t *dst,
   dst->aspath = dst_aspath;
   dst->communities = dst_comms;
 
-  if(bgpstream_as_path_copy(dst->aspath, src->aspath) != 0)
-    {
-      return NULL;
-    }
+  if (bgpstream_as_path_copy(dst->aspath, src->aspath) != 0) {
+    return NULL;
+  }
 
-  if(bgpstream_community_set_copy(dst->communities, src->communities) != 0)
-    {
-      return NULL;
-    }
+  if (bgpstream_community_set_copy(dst->communities, src->communities) != 0) {
+    return NULL;
+  }
 
   return dst;
 }
-
 
 int bgpstream_elem_type_snprintf(char *buf, size_t len,
                                  bgpstream_elem_type_t type)
 {
   /* ensure we have enough bytes to write our single character */
-  if(len == 0) {
+  if (len == 0) {
     return 1;
-  } else if(len == 1) {
+  } else if (len == 1) {
     buf[0] = '\0';
     return 1;
   }
 
-  switch(type)
-    {
-    case BGPSTREAM_ELEM_TYPE_RIB:
-      buf[0] = 'R';
-      break;
+  switch (type) {
+  case BGPSTREAM_ELEM_TYPE_RIB:
+    buf[0] = 'R';
+    break;
 
-    case BGPSTREAM_ELEM_TYPE_ANNOUNCEMENT:
-      buf[0] = 'A';
-      break;
+  case BGPSTREAM_ELEM_TYPE_ANNOUNCEMENT:
+    buf[0] = 'A';
+    break;
 
-    case BGPSTREAM_ELEM_TYPE_WITHDRAWAL:
-      buf[0] = 'W';
-      break;
+  case BGPSTREAM_ELEM_TYPE_WITHDRAWAL:
+    buf[0] = 'W';
+    break;
 
-    case BGPSTREAM_ELEM_TYPE_PEERSTATE:
-      buf[0] = 'S';
-      break;
+  case BGPSTREAM_ELEM_TYPE_PEERSTATE:
+    buf[0] = 'S';
+    break;
 
-    default:
-      buf[0] = '\0';
-      break;
-    }
+  default:
+    buf[0] = '\0';
+    break;
+  }
 
   buf[1] = '\0';
   return 1;
@@ -160,96 +159,92 @@ int bgpstream_elem_peerstate_snprintf(char *buf, size_t len,
 {
   size_t written = 0;
 
-  switch(state)
-    {
-    case BGPSTREAM_ELEM_PEERSTATE_IDLE:
-      strncpy(buf, "IDLE", len);
-      written = strlen("IDLE");
-      break;
+  switch (state) {
+  case BGPSTREAM_ELEM_PEERSTATE_IDLE:
+    strncpy(buf, "IDLE", len);
+    written = strlen("IDLE");
+    break;
 
-    case BGPSTREAM_ELEM_PEERSTATE_CONNECT:
-      strncpy(buf, "CONNECT", len);
-      written = strlen("CONNECT");
-      break;
+  case BGPSTREAM_ELEM_PEERSTATE_CONNECT:
+    strncpy(buf, "CONNECT", len);
+    written = strlen("CONNECT");
+    break;
 
-    case BGPSTREAM_ELEM_PEERSTATE_ACTIVE:
-      strncpy(buf, "ACTIVE", len);
-      written = strlen("ACTIVE");
-      break;
+  case BGPSTREAM_ELEM_PEERSTATE_ACTIVE:
+    strncpy(buf, "ACTIVE", len);
+    written = strlen("ACTIVE");
+    break;
 
-    case BGPSTREAM_ELEM_PEERSTATE_OPENSENT:
-      strncpy(buf, "OPENSENT", len);
-      written = strlen("OPENSENT");
-      break;
+  case BGPSTREAM_ELEM_PEERSTATE_OPENSENT:
+    strncpy(buf, "OPENSENT", len);
+    written = strlen("OPENSENT");
+    break;
 
-    case BGPSTREAM_ELEM_PEERSTATE_OPENCONFIRM:
-      strncpy(buf, "OPENCONFIRM", len);
-      written = strlen("OPENCONFIRM");
-      break;
+  case BGPSTREAM_ELEM_PEERSTATE_OPENCONFIRM:
+    strncpy(buf, "OPENCONFIRM", len);
+    written = strlen("OPENCONFIRM");
+    break;
 
-    case BGPSTREAM_ELEM_PEERSTATE_ESTABLISHED:
-      strncpy(buf, "ESTABLISHED", len);
-      written = strlen("ESTABLISHED");
-      break;
+  case BGPSTREAM_ELEM_PEERSTATE_ESTABLISHED:
+    strncpy(buf, "ESTABLISHED", len);
+    written = strlen("ESTABLISHED");
+    break;
 
-    case BGPSTREAM_ELEM_PEERSTATE_CLEARING:
-      strncpy(buf, "CLEARING", len);
-      written = strlen("CLEARING");
-      break;
+  case BGPSTREAM_ELEM_PEERSTATE_CLEARING:
+    strncpy(buf, "CLEARING", len);
+    written = strlen("CLEARING");
+    break;
 
-    case BGPSTREAM_ELEM_PEERSTATE_DELETED:
-      strncpy(buf, "DELETED", len);
-      written = strlen("DELETED");
-      break;
+  case BGPSTREAM_ELEM_PEERSTATE_DELETED:
+    strncpy(buf, "DELETED", len);
+    written = strlen("DELETED");
+    break;
 
-    default:
-      if(len > 0) {
-        buf[0] = '\0';
-      }
-      break;
+  default:
+    if (len > 0) {
+      buf[0] = '\0';
     }
+    break;
+  }
 
   /* we promise to always nul-terminate */
-  if(written > len) {
-    buf[len-1] = '\0';
+  if (written > len) {
+    buf[len - 1] = '\0';
   }
 
   return written;
 }
 
-#define B_REMAIN (len-written)
-#define B_FULL   (written >= len)
-#define ADD_PIPE                                \
-  do {                                          \
-  if(B_REMAIN > 1)                              \
-    {                                           \
-      *buf_p = '|';                             \
-      buf_p++;                                  \
-      *buf_p = '\0';                            \
-      written++;                                \
-    }                                           \
-  else                                          \
-    {                                           \
-      return NULL;                              \
-    }                                           \
-  } while(0)
+#define B_REMAIN (len - written)
+#define B_FULL (written >= len)
+#define ADD_PIPE                                                               \
+  do {                                                                         \
+    if (B_REMAIN > 1) {                                                        \
+      *buf_p = '|';                                                            \
+      buf_p++;                                                                 \
+      *buf_p = '\0';                                                           \
+      written++;                                                               \
+    } else {                                                                   \
+      return NULL;                                                             \
+    }                                                                          \
+  } while (0)
 
-#define SEEK_STR_END                            \
-  do {                                          \
-    while(*buf_p != '\0')                       \
-      {                                         \
-        written++;                              \
-        buf_p++;                                \
-      }                                         \
- } while(0)
+#define SEEK_STR_END                                                           \
+  do {                                                                         \
+    while (*buf_p != '\0') {                                                   \
+      written++;                                                               \
+      buf_p++;                                                                 \
+    }                                                                          \
+  } while (0)
 
 char *bgpstream_elem_custom_snprintf(char *buf, size_t len,
-                                     bgpstream_elem_t const *elem, int print_type)
+                                     bgpstream_elem_t const *elem,
+                                     int print_type)
 {
   assert(elem);
 
   size_t written = 0; /* < how many bytes we wanted to write */
-  size_t c = 0; /* < how many chars were written */
+  size_t c = 0;       /* < how many chars were written */
   char *buf_p = buf;
 
   bgpstream_as_path_seg_t *seg;
@@ -258,161 +253,154 @@ char *bgpstream_elem_custom_snprintf(char *buf, size_t len,
 
   /* [message_type|]peer_asn|peer_ip| */
 
-  if(print_type)
-    {
-      /* MESSAGE TYPE */
-      c = bgpstream_elem_type_snprintf(buf_p, B_REMAIN, elem->type);
-      written += c;
-      buf_p += c;
+  if (print_type) {
+    /* MESSAGE TYPE */
+    c = bgpstream_elem_type_snprintf(buf_p, B_REMAIN, elem->type);
+    written += c;
+    buf_p += c;
 
-      if(B_FULL)
-        return NULL;
+    if (B_FULL)
+      return NULL;
 
-      ADD_PIPE;
-    }
+    ADD_PIPE;
+  }
 
   /* PEER ASN */
-  c = snprintf(buf_p, B_REMAIN, "%"PRIu32, elem->peer_asnumber);
+  c = snprintf(buf_p, B_REMAIN, "%" PRIu32, elem->peer_asnumber);
   written += c;
   buf_p += c;
   ADD_PIPE;
 
   /* PEER IP */
-  if(bgpstream_addr_ntop(buf_p, B_REMAIN, &elem->peer_address) == NULL)
+  if (bgpstream_addr_ntop(buf_p, B_REMAIN, &elem->peer_address) == NULL)
     return NULL;
   SEEK_STR_END;
   ADD_PIPE;
 
-  if(B_FULL)
+  if (B_FULL)
     return NULL;
 
   /* conditional fields */
-  switch(elem->type)
-    {
-    case BGPSTREAM_ELEM_TYPE_RIB:
-    case BGPSTREAM_ELEM_TYPE_ANNOUNCEMENT:
+  switch (elem->type) {
+  case BGPSTREAM_ELEM_TYPE_RIB:
+  case BGPSTREAM_ELEM_TYPE_ANNOUNCEMENT:
 
-      /* PREFIX */
-      if(bgpstream_pfx_snprintf(buf_p, B_REMAIN,
-                                (bgpstream_pfx_t*)&(elem->prefix)) == NULL)
-        {
-          return NULL;
-        }
-      SEEK_STR_END;
-      ADD_PIPE;
-
-      /* NEXT HOP */
-      if(bgpstream_addr_ntop(buf_p, B_REMAIN, &elem->nexthop) == NULL)
-        {
-          return NULL;
-        }
-      SEEK_STR_END;
-      ADD_PIPE;
-
-      /* AS PATH */
-      c = bgpstream_as_path_snprintf(buf_p, B_REMAIN, elem->aspath);
-      written += c;
-      buf_p += c;
-
-      if(B_FULL)
-        return NULL;
-
-      ADD_PIPE;
-
-      /* ORIGIN AS */
-      if((seg = bgpstream_as_path_get_origin_seg(elem->aspath)) != NULL)
-        {
-          c = bgpstream_as_path_seg_snprintf(buf_p, B_REMAIN, seg);
-          written += c;
-          buf_p += c;
-        }
-
-      ADD_PIPE;
-
-      /* COMMUNITIES */
-      c = bgpstream_community_set_snprintf(buf_p, B_REMAIN, elem->communities);
-      written += c;
-      buf_p += c;
-
-      if(B_FULL)
-        return NULL;
-
-      ADD_PIPE;
-
-      /* OLD STATE (empty) */
-      ADD_PIPE;
-
-      /* NEW STATE (empty) */
-      if(B_FULL)
-        return NULL;
-
-      /* END OF LINE */
-      break;
-
-    case BGPSTREAM_ELEM_TYPE_WITHDRAWAL:
-
-      /* PREFIX */
-      if(bgpstream_pfx_snprintf(buf_p, B_REMAIN,
-                                (bgpstream_pfx_t*)&(elem->prefix)) == NULL)
-        {
-          return NULL;
-        }
-      SEEK_STR_END;
-      ADD_PIPE;
-      /* NEXT HOP (empty) */
-      ADD_PIPE;
-      /* AS PATH (empty) */
-      ADD_PIPE;
-      /* ORIGIN AS (empty) */
-      ADD_PIPE;
-      /* COMMUNITIES (empty) */
-      ADD_PIPE;
-      /* OLD STATE (empty) */
-      ADD_PIPE;
-      /* NEW STATE (empty) */
-      if(B_FULL)
-        return NULL;
-      /* END OF LINE */
-      break;
-
-    case BGPSTREAM_ELEM_TYPE_PEERSTATE:
-
-      /* PREFIX (empty) */
-      ADD_PIPE;
-      /* NEXT HOP (empty) */
-      ADD_PIPE;
-      /* AS PATH (empty) */
-      ADD_PIPE;
-      /* ORIGIN AS (empty) */
-      ADD_PIPE;
-      /* COMMUNITIES (empty) */
-      ADD_PIPE;
-
-      /* OLD STATE */
-      c = bgpstream_elem_peerstate_snprintf(buf_p, B_REMAIN,
-                                            elem->old_state);
-      written += c;
-      buf_p += c;
-
-      if(B_FULL)
-        return NULL;
-
-      ADD_PIPE;
-
-      /* NEW STATE (empty) */
-      c = bgpstream_elem_peerstate_snprintf(buf_p, B_REMAIN, elem->new_state);
-      written += c;
-      buf_p += c;
-
-      if(B_FULL)
-        return NULL;
-      /* END OF LINE */
-      break;
-
-    default:
-      fprintf(stderr, "Error during elem processing\n");
+    /* PREFIX */
+    if (bgpstream_pfx_snprintf(buf_p, B_REMAIN,
+                               (bgpstream_pfx_t *)&(elem->prefix)) == NULL) {
       return NULL;
     }
+    SEEK_STR_END;
+    ADD_PIPE;
+
+    /* NEXT HOP */
+    if (bgpstream_addr_ntop(buf_p, B_REMAIN, &elem->nexthop) == NULL) {
+      return NULL;
+    }
+    SEEK_STR_END;
+    ADD_PIPE;
+
+    /* AS PATH */
+    c = bgpstream_as_path_snprintf(buf_p, B_REMAIN, elem->aspath);
+    written += c;
+    buf_p += c;
+
+    if (B_FULL)
+      return NULL;
+
+    ADD_PIPE;
+
+    /* ORIGIN AS */
+    if ((seg = bgpstream_as_path_get_origin_seg(elem->aspath)) != NULL) {
+      c = bgpstream_as_path_seg_snprintf(buf_p, B_REMAIN, seg);
+      written += c;
+      buf_p += c;
+    }
+
+    ADD_PIPE;
+
+    /* COMMUNITIES */
+    c = bgpstream_community_set_snprintf(buf_p, B_REMAIN, elem->communities);
+    written += c;
+    buf_p += c;
+
+    if (B_FULL)
+      return NULL;
+
+    ADD_PIPE;
+
+    /* OLD STATE (empty) */
+    ADD_PIPE;
+
+    /* NEW STATE (empty) */
+    if (B_FULL)
+      return NULL;
+
+    /* END OF LINE */
+    break;
+
+  case BGPSTREAM_ELEM_TYPE_WITHDRAWAL:
+
+    /* PREFIX */
+    if (bgpstream_pfx_snprintf(buf_p, B_REMAIN,
+                               (bgpstream_pfx_t *)&(elem->prefix)) == NULL) {
+      return NULL;
+    }
+    SEEK_STR_END;
+    ADD_PIPE;
+    /* NEXT HOP (empty) */
+    ADD_PIPE;
+    /* AS PATH (empty) */
+    ADD_PIPE;
+    /* ORIGIN AS (empty) */
+    ADD_PIPE;
+    /* COMMUNITIES (empty) */
+    ADD_PIPE;
+    /* OLD STATE (empty) */
+    ADD_PIPE;
+    /* NEW STATE (empty) */
+    if (B_FULL)
+      return NULL;
+    /* END OF LINE */
+    break;
+
+  case BGPSTREAM_ELEM_TYPE_PEERSTATE:
+
+    /* PREFIX (empty) */
+    ADD_PIPE;
+    /* NEXT HOP (empty) */
+    ADD_PIPE;
+    /* AS PATH (empty) */
+    ADD_PIPE;
+    /* ORIGIN AS (empty) */
+    ADD_PIPE;
+    /* COMMUNITIES (empty) */
+    ADD_PIPE;
+
+    /* OLD STATE */
+    c = bgpstream_elem_peerstate_snprintf(buf_p, B_REMAIN, elem->old_state);
+    written += c;
+    buf_p += c;
+
+    if (B_FULL)
+      return NULL;
+
+    ADD_PIPE;
+
+    /* NEW STATE (empty) */
+    c = bgpstream_elem_peerstate_snprintf(buf_p, B_REMAIN, elem->new_state);
+    written += c;
+    buf_p += c;
+
+    if (B_FULL)
+      return NULL;
+    /* END OF LINE */
+    break;
+
+  default:
+    fprintf(stderr, "Error during elem processing\n");
+    return NULL;
+  }
 
   return buf;
 }

--- a/lib/bgpstream_elem.h
+++ b/lib/bgpstream_elem.h
@@ -56,19 +56,19 @@
 typedef enum {
 
   /** Peer state unknown */
-  BGPSTREAM_ELEM_PEERSTATE_UNKNOWN     = 0,
+  BGPSTREAM_ELEM_PEERSTATE_UNKNOWN = 0,
 
   /** Peer state idle */
-  BGPSTREAM_ELEM_PEERSTATE_IDLE        = 1,
+  BGPSTREAM_ELEM_PEERSTATE_IDLE = 1,
 
   /** Peer state connect */
-  BGPSTREAM_ELEM_PEERSTATE_CONNECT     = 2,
+  BGPSTREAM_ELEM_PEERSTATE_CONNECT = 2,
 
   /** Peer state active */
-  BGPSTREAM_ELEM_PEERSTATE_ACTIVE      = 3,
+  BGPSTREAM_ELEM_PEERSTATE_ACTIVE = 3,
 
   /** Peer state open-sent */
-  BGPSTREAM_ELEM_PEERSTATE_OPENSENT    = 4,
+  BGPSTREAM_ELEM_PEERSTATE_OPENSENT = 4,
 
   /** Peer state open-confirm */
   BGPSTREAM_ELEM_PEERSTATE_OPENCONFIRM = 5,
@@ -77,31 +77,30 @@ typedef enum {
   BGPSTREAM_ELEM_PEERSTATE_ESTABLISHED = 6,
 
   /** Peer state clearing */
-  BGPSTREAM_ELEM_PEERSTATE_CLEARING    = 7,
+  BGPSTREAM_ELEM_PEERSTATE_CLEARING = 7,
 
   /** Peer state clearing */
-  BGPSTREAM_ELEM_PEERSTATE_DELETED     = 8,
+  BGPSTREAM_ELEM_PEERSTATE_DELETED = 8,
 
 } bgpstream_elem_peerstate_t;
-
 
 /** Elem types */
 typedef enum {
 
   /** Unknown */
-  BGPSTREAM_ELEM_TYPE_UNKNOWN      = 0,
+  BGPSTREAM_ELEM_TYPE_UNKNOWN = 0,
 
   /** RIB Entry */
-  BGPSTREAM_ELEM_TYPE_RIB          = 1,
+  BGPSTREAM_ELEM_TYPE_RIB = 1,
 
   /** Announcement */
   BGPSTREAM_ELEM_TYPE_ANNOUNCEMENT = 2,
 
   /** Withdrawal */
-  BGPSTREAM_ELEM_TYPE_WITHDRAWAL   = 3,
+  BGPSTREAM_ELEM_TYPE_WITHDRAWAL = 3,
 
   /** Peer state change */
-  BGPSTREAM_ELEM_TYPE_PEERSTATE    = 4,
+  BGPSTREAM_ELEM_TYPE_PEERSTATE = 4,
 
 } bgpstream_elem_type_t;
 

--- a/lib/bgpstream_elem_generator.c
+++ b/lib/bgpstream_elem_generator.c
@@ -50,9 +50,9 @@
 */
 
 #include <assert.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
-#include <inttypes.h>
 
 #include "bgpdump_lib.h"
 #include "utils.h"
@@ -60,8 +60,8 @@
 #include "bgpstream_utils_as_path_int.h"
 #include "bgpstream_utils_community_int.h"
 
-#include "bgpstream_debug.h"
 #include "bgpstream_elem_int.h"
+#include "bgpstream_debug.h"
 #include "bgpstream_elem_generator.h"
 
 struct bgpstream_elem_generator {
@@ -86,25 +86,23 @@ static bgpstream_elem_t *get_new_elem(bgpstream_elem_generator_t *self)
   bgpstream_elem_t *elem = NULL;
 
   /* check if we need to alloc more elems */
-  if(self->elems_cnt+1 >= self->elems_alloc_cnt)
-    {
+  if (self->elems_cnt + 1 >= self->elems_alloc_cnt) {
 
-      /* alloc more memory */
-      if((self->elems =
-            realloc(self->elems, sizeof(bgpstream_elem_t*) *
-                      (self->elems_alloc_cnt+1))) == NULL)
-        {
-          return NULL;
-        }
-
-      /* create an elem */
-      if((self->elems[self->elems_alloc_cnt] = bgpstream_elem_create()) == NULL)
-        {
-          return NULL;
-        }
-
-      self->elems_alloc_cnt++;
+    /* alloc more memory */
+    if ((self->elems = realloc(self->elems, sizeof(bgpstream_elem_t *) *
+                                              (self->elems_alloc_cnt + 1))) ==
+        NULL) {
+      return NULL;
     }
+
+    /* create an elem */
+    if ((self->elems[self->elems_alloc_cnt] = bgpstream_elem_create()) ==
+        NULL) {
+      return NULL;
+    }
+
+    self->elems_alloc_cnt++;
+  }
 
   elem = self->elems[self->elems_cnt++];
   bgpstream_elem_clear(elem);
@@ -186,98 +184,88 @@ static void get_aspath_struct(struct aspath *ap,
 
 /* ribs related functions */
 static int table_line_mrtd_route(bgpstream_elem_generator_t *self,
-                                 BGPDUMP_ENTRY *entry) {
+                                 BGPDUMP_ENTRY *entry)
+{
 
   bgpstream_elem_t *ri;
-  if((ri = get_new_elem(self)) == NULL)
-    {
-      return -1;
-    }
+  if ((ri = get_new_elem(self)) == NULL) {
+    return -1;
+  }
 
   // general
   ri->type = BGPSTREAM_ELEM_TYPE_RIB;
   ri->timestamp = entry->time;
 
   // peer and prefix
-  if (entry->subtype == AFI_IP6)
-    {
-      ri->peer_address.version = BGPSTREAM_ADDR_VERSION_IPV6;
-      ri->peer_address.ipv6 = entry->body.mrtd_table_dump.peer_ip.v6_addr;
-      ri->prefix.address.version = BGPSTREAM_ADDR_VERSION_IPV6;
-      ri->prefix.address.ipv6 = entry->body.mrtd_table_dump.prefix.v6_addr;
-    }
-  else
-    {
-      ri->peer_address.version = BGPSTREAM_ADDR_VERSION_IPV4;
-      ri->peer_address.ipv4 = entry->body.mrtd_table_dump.peer_ip.v4_addr;
-      ri->prefix.address.version = BGPSTREAM_ADDR_VERSION_IPV4;
-      ri->prefix.address.ipv4 = entry->body.mrtd_table_dump.prefix.v4_addr;
-    }
+  if (entry->subtype == AFI_IP6) {
+    ri->peer_address.version = BGPSTREAM_ADDR_VERSION_IPV6;
+    ri->peer_address.ipv6 = entry->body.mrtd_table_dump.peer_ip.v6_addr;
+    ri->prefix.address.version = BGPSTREAM_ADDR_VERSION_IPV6;
+    ri->prefix.address.ipv6 = entry->body.mrtd_table_dump.prefix.v6_addr;
+  } else {
+    ri->peer_address.version = BGPSTREAM_ADDR_VERSION_IPV4;
+    ri->peer_address.ipv4 = entry->body.mrtd_table_dump.peer_ip.v4_addr;
+    ri->prefix.address.version = BGPSTREAM_ADDR_VERSION_IPV4;
+    ri->prefix.address.ipv4 = entry->body.mrtd_table_dump.prefix.v4_addr;
+  }
   ri->prefix.mask_len = entry->body.mrtd_table_dump.mask;
   ri->peer_asnumber = entry->body.mrtd_table_dump.peer_as;
 
   // as path
-  if(entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_AS_PATH) &&
-     entry->attr->aspath)
-    {
-      bgpstream_as_path_populate(ri->aspath, entry->attr->aspath);
-    }
+  if (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_AS_PATH) &&
+      entry->attr->aspath) {
+    bgpstream_as_path_populate(ri->aspath, entry->attr->aspath);
+  }
 
   // communities
-  if(entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES) &&
-     entry->attr->community)
-    {
-      bgpstream_community_set_populate(ri->communities, entry->attr->community);
-    }
+  if (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES) &&
+      entry->attr->community) {
+    bgpstream_community_set_populate(ri->communities, entry->attr->community);
+  }
 
   // nextop
-    if((entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MP_REACH_NLRI)) &&
-	entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST])
-      {
-        ri->nexthop.version = BGPSTREAM_ADDR_VERSION_IPV6;
-        ri->nexthop.ipv6 =
-          entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]->nexthop.v6_addr;
-      }
-    else
-      {
-	ri->nexthop.version = BGPSTREAM_ADDR_VERSION_IPV4;
-	ri->nexthop.ipv4 = entry->attr->nexthop;
-      }
+  if ((entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MP_REACH_NLRI)) &&
+      entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]) {
+    ri->nexthop.version = BGPSTREAM_ADDR_VERSION_IPV6;
+    ri->nexthop.ipv6 =
+      entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]->nexthop.v6_addr;
+  } else {
+    ri->nexthop.version = BGPSTREAM_ADDR_VERSION_IPV4;
+    ri->nexthop.ipv4 = entry->attr->nexthop;
+  }
   return 0;
 }
 
 int table_line_dump_v2_prefix(bgpstream_elem_generator_t *self,
-                              BGPDUMP_ENTRY *entry) {
+                              BGPDUMP_ENTRY *entry)
+{
   bgpstream_elem_t *ri;
 
   BGPDUMP_TABLE_DUMP_V2_PREFIX *e = &(entry->body.mrtd_table_dump_v2_prefix);
   int i;
 
-  for(i = 0; i < e->entry_count; i++) {
+  for (i = 0; i < e->entry_count; i++) {
     attributes_t *attr = e->entries[i].attr;
-    if(! attr)
+    if (!attr)
       continue;
 
-    if((ri = get_new_elem(self)) == NULL)
-      {
-        return -1;
-      }
+    if ((ri = get_new_elem(self)) == NULL) {
+      return -1;
+    }
 
     // general info
     ri->type = BGPSTREAM_ELEM_TYPE_RIB;
     ri->timestamp = entry->time;
 
     // peer
-    if(e->entries[i].peer.afi == AFI_IP){
+    if (e->entries[i].peer.afi == AFI_IP) {
       ri->peer_address.version = BGPSTREAM_ADDR_VERSION_IPV4;
       ri->peer_address.ipv4 = e->entries[i].peer.peer_ip.v4_addr;
-    }
-    else {
-      if(e->entries[i].peer.afi == AFI_IP6){
-	ri->peer_address.version = BGPSTREAM_ADDR_VERSION_IPV6;
-	ri->peer_address.ipv6 = e->entries[i].peer.peer_ip.v6_addr;
-      }
-      else {
+    } else {
+      if (e->entries[i].peer.afi == AFI_IP6) {
+        ri->peer_address.version = BGPSTREAM_ADDR_VERSION_IPV6;
+        ri->peer_address.ipv6 = e->entries[i].peer.peer_ip.v6_addr;
+      } else {
         return -1;
       }
     }
@@ -285,14 +273,13 @@ int table_line_dump_v2_prefix(bgpstream_elem_generator_t *self,
     ri->peer_asnumber = e->entries[i].peer.peer_as;
 
     // prefix
-    if(e->afi == AFI_IP) {
+    if (e->afi == AFI_IP) {
       ri->prefix.address.version = BGPSTREAM_ADDR_VERSION_IPV4;
       ri->prefix.address.ipv4 = e->prefix.v4_addr;
-    }
-    else{
-      if(e->afi == AFI_IP6) {
-	ri->prefix.address.version = BGPSTREAM_ADDR_VERSION_IPV6;
-	ri->prefix.address.ipv6 = e->prefix.v6_addr;
+    } else {
+      if (e->afi == AFI_IP6) {
+        ri->prefix.address.version = BGPSTREAM_ADDR_VERSION_IPV6;
+        ri->prefix.address.ipv6 = e->prefix.v6_addr;
       }
     }
     ri->prefix.mask_len = e->prefix_length;
@@ -306,40 +293,38 @@ int table_line_dump_v2_prefix(bgpstream_elem_generator_t *self,
     }
     // next hop
     if ((attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MP_REACH_NLRI)) &&
-	attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]) {
+        attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]) {
       ri->nexthop.version = BGPSTREAM_ADDR_VERSION_IPV6;
-      ri->nexthop.ipv6 = attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]->nexthop.v6_addr;
+      ri->nexthop.ipv6 =
+        attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]->nexthop.v6_addr;
+    } else {
+      ri->nexthop.version = BGPSTREAM_ADDR_VERSION_IPV4;
+      ri->nexthop.ipv4 = attr->nexthop;
     }
-    else
-      {
-        ri->nexthop.version = BGPSTREAM_ADDR_VERSION_IPV4;
-        ri->nexthop.ipv4 = attr->nexthop;
-      }
-
   }
   return 0;
 }
 
 static int table_line_announce(bgpstream_elem_generator_t *self,
                                struct prefix *prefix, int count,
-                               BGPDUMP_ENTRY *entry){
-  bgpstream_elem_t * ri;
+                               BGPDUMP_ENTRY *entry)
+{
+  bgpstream_elem_t *ri;
   int idx;
-  for (idx=0;idx<count;idx++) {
-    if((ri = get_new_elem(self)) == NULL)
-      {
-        return -1;
-      }
+  for (idx = 0; idx < count; idx++) {
+    if ((ri = get_new_elem(self)) == NULL) {
+      return -1;
+    }
 
     // general info
     ri->type = BGPSTREAM_ELEM_TYPE_ANNOUNCEMENT;
     ri->timestamp = entry->time;
     // peer
-    if(entry->body.zebra_message.address_family == AFI_IP6) {
+    if (entry->body.zebra_message.address_family == AFI_IP6) {
       ri->peer_address.version = BGPSTREAM_ADDR_VERSION_IPV6;
       ri->peer_address.ipv6 = entry->body.zebra_message.source_ip.v6_addr;
     }
-    if(entry->body.zebra_message.address_family == AFI_IP) {
+    if (entry->body.zebra_message.address_family == AFI_IP) {
       ri->peer_address.version = BGPSTREAM_ADDR_VERSION_IPV4;
       ri->peer_address.ipv4 = entry->body.zebra_message.source_ip.v4_addr;
     }
@@ -352,13 +337,13 @@ static int table_line_announce(bgpstream_elem_generator_t *self,
     ri->nexthop.version = BGPSTREAM_ADDR_VERSION_IPV4;
     ri->nexthop.ipv4 = entry->attr->nexthop;
     // as path
-    if(entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_AS_PATH) &&
-       entry->attr->aspath) {
+    if (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_AS_PATH) &&
+        entry->attr->aspath) {
       bgpstream_as_path_populate(ri->aspath, entry->attr->aspath);
     }
     // communities
-    if(entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES) &&
-       entry->attr->community) {
+    if (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES) &&
+        entry->attr->community) {
       bgpstream_community_set_populate(ri->communities, entry->attr->community);
     }
   }
@@ -366,45 +351,44 @@ static int table_line_announce(bgpstream_elem_generator_t *self,
 }
 
 static int table_line_announce_1(bgpstream_elem_generator_t *self,
-                                 struct mp_nlri *prefix,
-                                 int count,
-                                 BGPDUMP_ENTRY *entry) {
-  bgpstream_elem_t * ri;
+                                 struct mp_nlri *prefix, int count,
+                                 BGPDUMP_ENTRY *entry)
+{
+  bgpstream_elem_t *ri;
   int idx;
-  for (idx=0;idx<count;idx++) {
-    if((ri = get_new_elem(self)) == NULL)
-      {
-        return -1;
-      }
+  for (idx = 0; idx < count; idx++) {
+    if ((ri = get_new_elem(self)) == NULL) {
+      return -1;
+    }
 
     // general info
     ri->type = BGPSTREAM_ELEM_TYPE_ANNOUNCEMENT;
     ri->timestamp = entry->time;
     // peer
-    if(entry->body.zebra_message.address_family == AFI_IP6) {
+    if (entry->body.zebra_message.address_family == AFI_IP6) {
       ri->peer_address.version = BGPSTREAM_ADDR_VERSION_IPV6;
       ri->peer_address.ipv6 = entry->body.zebra_message.source_ip.v6_addr;
     }
-    if(entry->body.zebra_message.address_family == AFI_IP) {
+    if (entry->body.zebra_message.address_family == AFI_IP) {
       ri->peer_address.version = BGPSTREAM_ADDR_VERSION_IPV4;
       ri->peer_address.ipv4 = entry->body.zebra_message.source_ip.v4_addr;
     }
     ri->peer_asnumber = entry->body.zebra_message.source_as;
-      // prefix (ipv4)
+    // prefix (ipv4)
     ri->prefix.address.version = BGPSTREAM_ADDR_VERSION_IPV4;
     ri->prefix.address.ipv4 = prefix->nlri[idx].address.v4_addr;
     ri->prefix.mask_len = prefix->nlri[idx].len;
-      // nexthop (ipv4)
+    // nexthop (ipv4)
     ri->nexthop.version = BGPSTREAM_ADDR_VERSION_IPV4;
     ri->nexthop.ipv4 = entry->attr->nexthop;
     // as path
-    if(entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_AS_PATH) &&
-       entry->attr->aspath) {
+    if (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_AS_PATH) &&
+        entry->attr->aspath) {
       bgpstream_as_path_populate(ri->aspath, entry->attr->aspath);
     }
     // communities
-    if(entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES) &&
-       entry->attr->community) {
+    if (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES) &&
+        entry->attr->community) {
       bgpstream_community_set_populate(ri->communities, entry->attr->community);
     }
   }
@@ -412,26 +396,25 @@ static int table_line_announce_1(bgpstream_elem_generator_t *self,
 }
 
 static int table_line_announce6(bgpstream_elem_generator_t *self,
-                                struct mp_nlri *prefix,
-                                int count,
-                                BGPDUMP_ENTRY *entry) {
-  bgpstream_elem_t * ri;
+                                struct mp_nlri *prefix, int count,
+                                BGPDUMP_ENTRY *entry)
+{
+  bgpstream_elem_t *ri;
   int idx;
-  for (idx=0;idx<count;idx++) {
-    if((ri = get_new_elem(self)) == NULL)
-      {
-        return -1;
-      }
+  for (idx = 0; idx < count; idx++) {
+    if ((ri = get_new_elem(self)) == NULL) {
+      return -1;
+    }
 
     // general info
     ri->type = BGPSTREAM_ELEM_TYPE_ANNOUNCEMENT;
     ri->timestamp = entry->time;
     // peer
-    if(entry->body.zebra_message.address_family == AFI_IP6) {
+    if (entry->body.zebra_message.address_family == AFI_IP6) {
       ri->peer_address.version = BGPSTREAM_ADDR_VERSION_IPV6;
       ri->peer_address.ipv6 = entry->body.zebra_message.source_ip.v6_addr;
     }
-    if(entry->body.zebra_message.address_family == AFI_IP) {
+    if (entry->body.zebra_message.address_family == AFI_IP) {
       ri->peer_address.version = BGPSTREAM_ADDR_VERSION_IPV4;
       ri->peer_address.ipv4 = entry->body.zebra_message.source_ip.v4_addr;
     }
@@ -440,17 +423,17 @@ static int table_line_announce6(bgpstream_elem_generator_t *self,
     ri->prefix.address.version = BGPSTREAM_ADDR_VERSION_IPV6;
     ri->prefix.address.ipv6 = prefix->nlri[idx].address.v6_addr;
     ri->prefix.mask_len = prefix->nlri[idx].len;
-    //nexthop (ipv6)
+    // nexthop (ipv6)
     ri->nexthop.version = BGPSTREAM_ADDR_VERSION_IPV6;
     ri->nexthop.ipv6 = prefix->nexthop.v6_addr;
     // aspath
-    if(entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_AS_PATH) &&
-       entry->attr->aspath) {
+    if (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_AS_PATH) &&
+        entry->attr->aspath) {
       bgpstream_as_path_populate(ri->aspath, entry->attr->aspath);
     }
     // communities
-    if(entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES) &&
-       entry->attr->community) {
+    if (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES) &&
+        entry->attr->community) {
       bgpstream_community_set_populate(ri->communities, entry->attr->community);
     }
   }
@@ -458,26 +441,25 @@ static int table_line_announce6(bgpstream_elem_generator_t *self,
 }
 
 static int table_line_withdraw(bgpstream_elem_generator_t *self,
-                               struct prefix *prefix,
-                               int count,
-                               BGPDUMP_ENTRY *entry) {
-  bgpstream_elem_t * ri;
+                               struct prefix *prefix, int count,
+                               BGPDUMP_ENTRY *entry)
+{
+  bgpstream_elem_t *ri;
   int idx;
-  for(idx=0;idx<count;idx++) {
-    if((ri = get_new_elem(self)) == NULL)
-      {
-        return -1;
-      }
+  for (idx = 0; idx < count; idx++) {
+    if ((ri = get_new_elem(self)) == NULL) {
+      return -1;
+    }
 
     // general info
     ri->type = BGPSTREAM_ELEM_TYPE_WITHDRAWAL;
     ri->timestamp = entry->time;
     // peer
-    if(entry->body.zebra_message.address_family == AFI_IP6) {
+    if (entry->body.zebra_message.address_family == AFI_IP6) {
       ri->peer_address.version = BGPSTREAM_ADDR_VERSION_IPV6;
       ri->peer_address.ipv6 = entry->body.zebra_message.source_ip.v6_addr;
     }
-    if(entry->body.zebra_message.address_family == AFI_IP) {
+    if (entry->body.zebra_message.address_family == AFI_IP) {
       ri->peer_address.version = BGPSTREAM_ADDR_VERSION_IPV4;
       ri->peer_address.ipv4 = entry->body.zebra_message.source_ip.v4_addr;
     }
@@ -491,26 +473,25 @@ static int table_line_withdraw(bgpstream_elem_generator_t *self,
 }
 
 static int table_line_withdraw6(bgpstream_elem_generator_t *self,
-                                struct prefix *prefix,
-                                int count,
-                                BGPDUMP_ENTRY *entry) {
-  bgpstream_elem_t * ri;
+                                struct prefix *prefix, int count,
+                                BGPDUMP_ENTRY *entry)
+{
+  bgpstream_elem_t *ri;
   int idx;
-  for (idx=0;idx<count;idx++) {
-    if((ri = get_new_elem(self)) == NULL)
-      {
-        return -1;
-      }
+  for (idx = 0; idx < count; idx++) {
+    if ((ri = get_new_elem(self)) == NULL) {
+      return -1;
+    }
 
     // general info
     ri->type = BGPSTREAM_ELEM_TYPE_WITHDRAWAL;
     ri->timestamp = entry->time;
     // peer
-    if(entry->body.zebra_message.address_family == AFI_IP6) {
+    if (entry->body.zebra_message.address_family == AFI_IP6) {
       ri->peer_address.version = BGPSTREAM_ADDR_VERSION_IPV6;
       ri->peer_address.ipv6 = entry->body.zebra_message.source_ip.v6_addr;
     }
-    if(entry->body.zebra_message.address_family == AFI_IP) {
+    if (entry->body.zebra_message.address_family == AFI_IP) {
       ri->peer_address.version = BGPSTREAM_ADDR_VERSION_IPV4;
       ri->peer_address.ipv4 = entry->body.zebra_message.source_ip.v4_addr;
     }
@@ -524,47 +505,48 @@ static int table_line_withdraw6(bgpstream_elem_generator_t *self,
 }
 
 static int table_line_update(bgpstream_elem_generator_t *self,
-                             BGPDUMP_ENTRY *entry) {
+                             BGPDUMP_ENTRY *entry)
+{
   struct prefix *prefix;
   struct mp_nlri *prefix_mp;
   int count;
 
   // withdrawals (IPv4)
   if ((entry->body.zebra_message.withdraw_count) ||
-      (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MP_UNREACH_NLRI)))  {
+      (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MP_UNREACH_NLRI))) {
     prefix = entry->body.zebra_message.withdraw;
     count = entry->body.zebra_message.withdraw_count;
-    if(table_line_withdraw(self, prefix, count, entry) != 0)
-      {
-        return -1;
-      }
+    if (table_line_withdraw(self, prefix, count, entry) != 0) {
+      return -1;
+    }
   }
   if (entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST] &&
-      entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST]->prefix_count){
+      entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST]->prefix_count) {
     prefix = entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST]->nlri;
     count = entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST]->prefix_count;
-    if(table_line_withdraw(self, prefix, count, entry) != 0)
-      {
-        return -1;
-      }
+    if (table_line_withdraw(self, prefix, count, entry) != 0) {
+      return -1;
+    }
   }
   if (entry->attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST] &&
       entry->attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST]->prefix_count) {
     prefix = entry->attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST]->nlri;
-    count = entry->attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST]->prefix_count;
-    if(table_line_withdraw(self, prefix, count, entry) != 0)
-      {
-        return -1;
-      }
+    count =
+      entry->attr->mp_info->withdraw[AFI_IP][SAFI_MULTICAST]->prefix_count;
+    if (table_line_withdraw(self, prefix, count, entry) != 0) {
+      return -1;
+    }
   }
   if (entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST] &&
-      entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST]->prefix_count) {
-    prefix = entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST]->nlri;
-    count = entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST]->prefix_count;
-    if(table_line_withdraw(self, prefix, count, entry) != 0)
-      {
-        return -1;
-      }
+      entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST]
+        ->prefix_count) {
+    prefix =
+      entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST]->nlri;
+    count = entry->attr->mp_info->withdraw[AFI_IP][SAFI_UNICAST_MULTICAST]
+              ->prefix_count;
+    if (table_line_withdraw(self, prefix, count, entry) != 0) {
+      return -1;
+    }
   }
 
   // withdrawals (IPv6)
@@ -572,39 +554,39 @@ static int table_line_update(bgpstream_elem_generator_t *self,
       entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST]->prefix_count) {
     prefix = entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST]->nlri;
     count = entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST]->prefix_count;
-    if(table_line_withdraw6(self, prefix, count, entry) != 0)
-      {
-        return -1;
-      }
+    if (table_line_withdraw6(self, prefix, count, entry) != 0) {
+      return -1;
+    }
   }
   if (entry->attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST] &&
       entry->attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST]->prefix_count) {
     prefix = entry->attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST]->nlri;
-    count = entry->attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST]->prefix_count;
-    if(table_line_withdraw6(self, prefix, count, entry) != 0)
-      {
-        return -1;
-      }
+    count =
+      entry->attr->mp_info->withdraw[AFI_IP6][SAFI_MULTICAST]->prefix_count;
+    if (table_line_withdraw6(self, prefix, count, entry) != 0) {
+      return -1;
+    }
   }
   if (entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST] &&
-      entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST]->prefix_count) {
-    prefix =  entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST]->nlri;
-    count = entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST]->prefix_count;
-    if(table_line_withdraw6(self, prefix, count, entry) != 0)
-      {
-        return -1;
-      }
+      entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST]
+        ->prefix_count) {
+    prefix =
+      entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST]->nlri;
+    count = entry->attr->mp_info->withdraw[AFI_IP6][SAFI_UNICAST_MULTICAST]
+              ->prefix_count;
+    if (table_line_withdraw6(self, prefix, count, entry) != 0) {
+      return -1;
+    }
   }
 
   // announce
-  if ( (entry->body.zebra_message.announce_count) ||
-       (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MP_REACH_NLRI))) {
+  if ((entry->body.zebra_message.announce_count) ||
+      (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MP_REACH_NLRI))) {
     prefix = entry->body.zebra_message.announce;
     count = entry->body.zebra_message.announce_count;
-    if(table_line_announce(self, prefix, count, entry) != 0)
-      {
-        return -1;
-      }
+    if (table_line_announce(self, prefix, count, entry) != 0) {
+      return -1;
+    }
   }
 
   // announce 1
@@ -612,28 +594,28 @@ static int table_line_update(bgpstream_elem_generator_t *self,
       entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST]->prefix_count) {
     prefix_mp = entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST];
     count = entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST]->prefix_count;
-    if(table_line_announce_1(self, prefix_mp, count, entry) != 0)
-      {
-        return -1;
-      }
+    if (table_line_announce_1(self, prefix_mp, count, entry) != 0) {
+      return -1;
+    }
   }
   if (entry->attr->mp_info->announce[AFI_IP][SAFI_MULTICAST] &&
       entry->attr->mp_info->announce[AFI_IP][SAFI_MULTICAST]->prefix_count) {
     prefix_mp = entry->attr->mp_info->announce[AFI_IP][SAFI_MULTICAST];
-    count = entry->attr->mp_info->announce[AFI_IP][SAFI_MULTICAST]->prefix_count;
-    if(table_line_announce_1(self, prefix_mp, count, entry) != 0)
-      {
-        return -1;
-      }
+    count =
+      entry->attr->mp_info->announce[AFI_IP][SAFI_MULTICAST]->prefix_count;
+    if (table_line_announce_1(self, prefix_mp, count, entry) != 0) {
+      return -1;
+    }
   }
   if (entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST] &&
-      entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST]->prefix_count) {
+      entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST]
+        ->prefix_count) {
     prefix_mp = entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST];
-    count = entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST]->prefix_count;
-    if(table_line_announce_1(self, prefix_mp, count, entry) != 0)
-      {
-        return -1;
-      }
+    count = entry->attr->mp_info->announce[AFI_IP][SAFI_UNICAST_MULTICAST]
+              ->prefix_count;
+    if (table_line_announce_1(self, prefix_mp, count, entry) != 0) {
+      return -1;
+    }
   }
 
   // announce ipv6
@@ -641,50 +623,50 @@ static int table_line_update(bgpstream_elem_generator_t *self,
       entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]->prefix_count) {
     prefix_mp = entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST];
     count = entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST]->prefix_count;
-    if(table_line_announce6(self, prefix_mp, count, entry) != 0)
-      {
-        return -1;
-      }
+    if (table_line_announce6(self, prefix_mp, count, entry) != 0) {
+      return -1;
+    }
   }
   if (entry->attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST] &&
       entry->attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST]->prefix_count) {
     prefix_mp = entry->attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST];
-    count = entry->attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST]->prefix_count;
-    if(table_line_announce6(self, prefix_mp, count, entry) != 0)
-      {
-        return -1;
-      }
+    count =
+      entry->attr->mp_info->announce[AFI_IP6][SAFI_MULTICAST]->prefix_count;
+    if (table_line_announce6(self, prefix_mp, count, entry) != 0) {
+      return -1;
+    }
   }
   if (entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST] &&
-      entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST]->prefix_count) {
+      entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST]
+        ->prefix_count) {
     prefix_mp = entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST];
-    count = entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST]->prefix_count;
-    if(table_line_announce6(self, prefix_mp, count, entry) != 0)
-      {
-        return -1;
-      }
+    count = entry->attr->mp_info->announce[AFI_IP6][SAFI_UNICAST_MULTICAST]
+              ->prefix_count;
+    if (table_line_announce6(self, prefix_mp, count, entry) != 0) {
+      return -1;
+    }
   }
 
   return 0;
 }
 
 static int bgp_state_change(bgpstream_elem_generator_t *self,
-                            BGPDUMP_ENTRY *entry) {
-  bgpstream_elem_t * ri;
-  if((ri = get_new_elem(self)) == NULL)
-    {
-      return -1;
-    }
+                            BGPDUMP_ENTRY *entry)
+{
+  bgpstream_elem_t *ri;
+  if ((ri = get_new_elem(self)) == NULL) {
+    return -1;
+  }
 
   // general information
   ri->type = BGPSTREAM_ELEM_TYPE_PEERSTATE;
   ri->timestamp = entry->time;
   // peer
-  if(entry->body.zebra_message.address_family == AFI_IP6) {
+  if (entry->body.zebra_message.address_family == AFI_IP6) {
     ri->peer_address.version = BGPSTREAM_ADDR_VERSION_IPV6;
     ri->peer_address.ipv6 = entry->body.zebra_state_change.source_ip.v6_addr;
   }
-  if(entry->body.zebra_message.address_family == AFI_IP) {
+  if (entry->body.zebra_message.address_family == AFI_IP) {
     ri->peer_address.version = BGPSTREAM_ADDR_VERSION_IPV4;
     ri->peer_address.ipv4 = entry->body.zebra_state_change.source_ip.v4_addr;
   }
@@ -700,10 +682,9 @@ bgpstream_elem_generator_t *bgpstream_elem_generator_create()
 {
   bgpstream_elem_generator_t *self;
 
-  if((self = malloc_zero(sizeof(bgpstream_elem_generator_t))) == NULL)
-    {
-      return NULL;
-    }
+  if ((self = malloc_zero(sizeof(bgpstream_elem_generator_t))) == NULL) {
+    return NULL;
+  }
 
   /* indicates not populated */
   self->elems_cnt = -1;
@@ -714,17 +695,15 @@ bgpstream_elem_generator_t *bgpstream_elem_generator_create()
 void bgpstream_elem_generator_destroy(bgpstream_elem_generator_t *self)
 {
   int i;
-  if(self == NULL)
-    {
-      return;
-    }
+  if (self == NULL) {
+    return;
+  }
 
   /* free all the alloc'd elems */
-  for(i=0; i<self->elems_alloc_cnt; i++)
-    {
-      bgpstream_elem_destroy(self->elems[i]);
-      self->elems[i] = NULL;
-    }
+  for (i = 0; i < self->elems_alloc_cnt; i++) {
+    bgpstream_elem_destroy(self->elems[i]);
+    self->elems[i] = NULL;
+  }
 
   free(self->elems);
 
@@ -757,41 +736,37 @@ int bgpstream_elem_generator_populate(bgpstream_elem_generator_t *self,
   /* start with an empty set */
   self->elems_cnt = 0;
 
-  if(record->bd_entry == NULL ||
-     record->status != BGPSTREAM_RECORD_STATUS_VALID_RECORD)
-    {
-      return 0;
-    }
+  if (record->bd_entry == NULL ||
+      record->status != BGPSTREAM_RECORD_STATUS_VALID_RECORD) {
+    return 0;
+  }
 
-  switch(record->bd_entry->type)
-    {
-    case BGPDUMP_TYPE_MRTD_TABLE_DUMP:
-      return table_line_mrtd_route(self, record->bd_entry);
+  switch (record->bd_entry->type) {
+  case BGPDUMP_TYPE_MRTD_TABLE_DUMP:
+    return table_line_mrtd_route(self, record->bd_entry);
+    break;
+
+  case BGPDUMP_TYPE_TABLE_DUMP_V2:
+    return table_line_dump_v2_prefix(self, record->bd_entry);
+    break;
+
+  case BGPDUMP_TYPE_ZEBRA_BGP:
+    switch (record->bd_entry->subtype) {
+    case BGPDUMP_SUBTYPE_ZEBRA_BGP_MESSAGE:
+    case BGPDUMP_SUBTYPE_ZEBRA_BGP_MESSAGE_AS4:
+      switch (record->bd_entry->body.zebra_message.type) {
+      case BGP_MSG_UPDATE:
+        return table_line_update(self, record->bd_entry);
+        break;
+      }
       break;
 
-    case BGPDUMP_TYPE_TABLE_DUMP_V2:
-      return table_line_dump_v2_prefix(self, record->bd_entry);
+    case BGPDUMP_SUBTYPE_ZEBRA_BGP_STATE_CHANGE: // state messages
+    case BGPDUMP_SUBTYPE_ZEBRA_BGP_STATE_CHANGE_AS4:
+      return bgp_state_change(self, record->bd_entry);
       break;
-
-    case BGPDUMP_TYPE_ZEBRA_BGP:
-      switch(record->bd_entry->subtype)
-        {
-        case BGPDUMP_SUBTYPE_ZEBRA_BGP_MESSAGE:
-        case BGPDUMP_SUBTYPE_ZEBRA_BGP_MESSAGE_AS4:
-          switch(record->bd_entry->body.zebra_message.type)
-            {
-            case BGP_MSG_UPDATE:
-              return table_line_update(self, record->bd_entry);
-              break;
-            }
-          break;
-
-        case BGPDUMP_SUBTYPE_ZEBRA_BGP_STATE_CHANGE:        // state messages
-        case BGPDUMP_SUBTYPE_ZEBRA_BGP_STATE_CHANGE_AS4:
-          return bgp_state_change(self, record->bd_entry);
-          break;
-        }
     }
+  }
   return -1;
 }
 
@@ -800,12 +775,10 @@ bgpstream_elem_generator_get_next_elem(bgpstream_elem_generator_t *self)
 {
   bgpstream_elem_t *elem = NULL;
 
-  if(self->iter < self->elems_cnt)
-    {
-      elem = self->elems[self->iter];
-      self->iter++;
-    }
+  if (self->iter < self->elems_cnt) {
+    elem = self->elems[self->iter];
+    self->iter++;
+  }
 
   return elem;
 }
-

--- a/lib/bgpstream_elem_generator.h
+++ b/lib/bgpstream_elem_generator.h
@@ -77,7 +77,8 @@ void bgpstream_elem_generator_clear(bgpstream_elem_generator_t *generator);
  * @param generator     pointer to the generator
  * @return 1 if the generator is ready for use, 0 otherwise
  */
-int bgpstream_elem_generator_is_populated(bgpstream_elem_generator_t *generator);
+int bgpstream_elem_generator_is_populated(
+  bgpstream_elem_generator_t *generator);
 
 /** Populate a generator with elems from the given record
  *
@@ -100,7 +101,6 @@ int bgpstream_elem_generator_populate(bgpstream_elem_generator_t *generator,
  */
 bgpstream_elem_t *
 bgpstream_elem_generator_get_next_elem(bgpstream_elem_generator_t *generator);
-
 
 /** @} */
 

--- a/lib/bgpstream_elem_int.h
+++ b/lib/bgpstream_elem_int.h
@@ -49,8 +49,8 @@
  * @return pointer to the start of the buffer if successful, NULL otherwise
  */
 char *bgpstream_elem_custom_snprintf(char *buf, size_t len,
-                                     const bgpstream_elem_t *elem, int print_type);
-
+                                     const bgpstream_elem_t *elem,
+                                     int print_type);
 
 /** @} */
 

--- a/lib/bgpstream_filter.c
+++ b/lib/bgpstream_filter.c
@@ -31,11 +31,12 @@
 #include <stdio.h>
 
 /* allocate memory for a new bgpstream filter */
-bgpstream_filter_mgr_t *bgpstream_filter_mgr_create() {
+bgpstream_filter_mgr_t *bgpstream_filter_mgr_create()
+{
   bgpstream_debug("\tBSF_MGR: create start");
   bgpstream_filter_mgr_t *bs_filter_mgr =
-    (bgpstream_filter_mgr_t*) malloc_zero(sizeof(bgpstream_filter_mgr_t));
-  if(bs_filter_mgr == NULL) {
+    (bgpstream_filter_mgr_t *)malloc_zero(sizeof(bgpstream_filter_mgr_t));
+  if (bs_filter_mgr == NULL) {
     return NULL; // can't allocate memory
   }
   bgpstream_debug("\tBSF_MGR: create end");
@@ -43,91 +44,88 @@ bgpstream_filter_mgr_t *bgpstream_filter_mgr_create() {
 }
 
 void bgpstream_filter_mgr_filter_add(bgpstream_filter_mgr_t *bs_filter_mgr,
-				     bgpstream_filter_type_t filter_type,
-				     const char* filter_value) {
+                                     bgpstream_filter_type_t filter_type,
+                                     const char *filter_value)
+{
   bgpstream_debug("\tBSF_MGR:: add_filter start");
-  if(bs_filter_mgr == NULL) {
+  if (bs_filter_mgr == NULL) {
     return; // nothing to customize
   }
 
-  if(filter_type == BGPSTREAM_FILTER_TYPE_ELEM_PEER_ASN)
-    {
-      if(bs_filter_mgr->peer_asns == NULL)
-        {
-          if((bs_filter_mgr->peer_asns = bgpstream_id_set_create()) == NULL)
-            {
-              bgpstream_debug("\tBSF_MGR:: add_filter malloc failed");
-              bgpstream_log_warn("\tBSF_MGR: can't allocate memory");
-              return;
-            }
-        }
-      bgpstream_id_set_insert(bs_filter_mgr->peer_asns, (uint32_t) strtoul(filter_value, NULL, 10));
-      return;
+  if (filter_type == BGPSTREAM_FILTER_TYPE_ELEM_PEER_ASN) {
+    if (bs_filter_mgr->peer_asns == NULL) {
+      if ((bs_filter_mgr->peer_asns = bgpstream_id_set_create()) == NULL) {
+        bgpstream_debug("\tBSF_MGR:: add_filter malloc failed");
+        bgpstream_log_warn("\tBSF_MGR: can't allocate memory");
+        return;
+      }
     }
+    bgpstream_id_set_insert(bs_filter_mgr->peer_asns,
+                            (uint32_t)strtoul(filter_value, NULL, 10));
+    return;
+  }
 
-  if(filter_type == BGPSTREAM_FILTER_TYPE_ELEM_PREFIX)
-    {
-      bgpstream_pfx_storage_t pfx;
-      if(bs_filter_mgr->prefixes == NULL)
-        {
-          if((bs_filter_mgr->prefixes = bgpstream_patricia_tree_create(NULL)) == NULL)
-            {
-              bgpstream_debug("\tBSF_MGR:: add_filter malloc failed");
-              bgpstream_log_warn("\tBSF_MGR: can't allocate memory");
-              return;
-            }
-        }
-      bgpstream_str2pfx(filter_value, &pfx);
-      if(bgpstream_patricia_tree_insert(bs_filter_mgr->prefixes, (bgpstream_pfx_t *) &pfx) == NULL)
-        {
-          bgpstream_debug("\tBSF_MGR:: add_filter malloc failed");
-          bgpstream_log_warn("\tBSF_MGR: can't add prefix");
-          return;
-        }
+  if (filter_type == BGPSTREAM_FILTER_TYPE_ELEM_PREFIX) {
+    bgpstream_pfx_storage_t pfx;
+    if (bs_filter_mgr->prefixes == NULL) {
+      if ((bs_filter_mgr->prefixes = bgpstream_patricia_tree_create(NULL)) ==
+          NULL) {
+        bgpstream_debug("\tBSF_MGR:: add_filter malloc failed");
+        bgpstream_log_warn("\tBSF_MGR: can't allocate memory");
+        return;
+      }
+    }
+    bgpstream_str2pfx(filter_value, &pfx);
+    if (bgpstream_patricia_tree_insert(bs_filter_mgr->prefixes,
+                                       (bgpstream_pfx_t *)&pfx) == NULL) {
+      bgpstream_debug("\tBSF_MGR:: add_filter malloc failed");
+      bgpstream_log_warn("\tBSF_MGR: can't add prefix");
       return;
     }
+    return;
+  }
 
   int mask = 0;
   khiter_t k;
   int khret;
 
-  if(filter_type == BGPSTREAM_FILTER_TYPE_ELEM_COMMUNITY)
-    {
-      bgpstream_community_t comm;
-      if(bs_filter_mgr->communities == NULL)
-        {
-          if((bs_filter_mgr->communities = kh_init(bgpstream_community_filter)) == NULL)
-            {
-              bgpstream_debug("\tBSF_MGR:: add_filter malloc failed");
-              bgpstream_log_warn("\tBSF_MGR: can't allocate memory");
-              return;
-            }
-        }
-      if((mask = bgpstream_str2community(filter_value, &comm)) < 0)
-        {
-          bgpstream_debug("\tBSF_MGR:: can't convert community");
-          return;
-        }
-
-      if((k = kh_get(bgpstream_community_filter, bs_filter_mgr->communities, comm)) ==
-         kh_end(bs_filter_mgr->communities))
-        {
-          k = kh_put(bgpstream_community_filter, bs_filter_mgr->communities, comm, &khret);
-          kh_value(bs_filter_mgr->communities, k) = mask;
-        }
-
-      /* we use the AND because the less restrictive filter wins over the more restrictive:
-       * e.g. 10:0, 10:* is equivalent to 10:*
-       */
-      kh_value(bs_filter_mgr->communities, k) = kh_value(bs_filter_mgr->communities, k) & mask;
-      /* DEBUG: fprintf(stderr, "%s - %d\n",
-       *                filter_value, kh_value(bs_filter_mgr->communities, k) ); */
+  if (filter_type == BGPSTREAM_FILTER_TYPE_ELEM_COMMUNITY) {
+    bgpstream_community_t comm;
+    if (bs_filter_mgr->communities == NULL) {
+      if ((bs_filter_mgr->communities = kh_init(bgpstream_community_filter)) ==
+          NULL) {
+        bgpstream_debug("\tBSF_MGR:: add_filter malloc failed");
+        bgpstream_log_warn("\tBSF_MGR: can't allocate memory");
+        return;
+      }
+    }
+    if ((mask = bgpstream_str2community(filter_value, &comm)) < 0) {
+      bgpstream_debug("\tBSF_MGR:: can't convert community");
       return;
     }
 
+    if ((k = kh_get(bgpstream_community_filter, bs_filter_mgr->communities,
+                    comm)) == kh_end(bs_filter_mgr->communities)) {
+      k = kh_put(bgpstream_community_filter, bs_filter_mgr->communities, comm,
+                 &khret);
+      kh_value(bs_filter_mgr->communities, k) = mask;
+    }
+
+    /* we use the AND because the less restrictive filter wins over the more
+     * restrictive:
+     * e.g. 10:0, 10:* is equivalent to 10:*
+     */
+    kh_value(bs_filter_mgr->communities, k) =
+      kh_value(bs_filter_mgr->communities, k) & mask;
+    /* DEBUG: fprintf(stderr, "%s - %d\n",
+     *                filter_value, kh_value(bs_filter_mgr->communities, k) );
+     */
+    return;
+  }
+
   /* add filter to the appropriate list */
   bgpstream_str_set_t **v = NULL;
-  switch(filter_type) {
+  switch (filter_type) {
   case BGPSTREAM_FILTER_TYPE_PROJECT:
     v = &bs_filter_mgr->projects;
     break;
@@ -142,50 +140,45 @@ void bgpstream_filter_mgr_filter_add(bgpstream_filter_mgr_t *bs_filter_mgr,
     return;
   }
 
-  if(*v == NULL)
-    {
-      if((*v = bgpstream_str_set_create()) == NULL)
-        {
-          bgpstream_debug("\tBSF_MGR:: add_filter malloc failed");
-          bgpstream_log_warn("\tBSF_MGR: can't allocate memory");
-          return;
-        }
+  if (*v == NULL) {
+    if ((*v = bgpstream_str_set_create()) == NULL) {
+      bgpstream_debug("\tBSF_MGR:: add_filter malloc failed");
+      bgpstream_log_warn("\tBSF_MGR: can't allocate memory");
+      return;
     }
+  }
   bgpstream_str_set_insert(*v, filter_value);
 
   bgpstream_debug("\tBSF_MGR:: add_filter stop");
   return;
 }
 
-
-void bgpstream_filter_mgr_rib_period_filter_add(bgpstream_filter_mgr_t *bs_filter_mgr,
-                                               uint32_t period)
+void bgpstream_filter_mgr_rib_period_filter_add(
+  bgpstream_filter_mgr_t *bs_filter_mgr, uint32_t period)
 {
   bgpstream_debug("\tBSF_MGR:: add_filter start");
   assert(bs_filter_mgr != NULL);
-  if(period != 0 && bs_filter_mgr->last_processed_ts == NULL)
-    {
-      if((bs_filter_mgr->last_processed_ts = kh_init(collector_ts)) == NULL)
-        {
-          bgpstream_log_warn("\tBSF_MGR: can't allocate memory for collectortype map");
-        }
+  if (period != 0 && bs_filter_mgr->last_processed_ts == NULL) {
+    if ((bs_filter_mgr->last_processed_ts = kh_init(collector_ts)) == NULL) {
+      bgpstream_log_warn(
+        "\tBSF_MGR: can't allocate memory for collectortype map");
     }
+  }
   bs_filter_mgr->rib_period = period;
   bgpstream_debug("\tBSF_MGR:: add_filter end");
-
 }
 
-
-void bgpstream_filter_mgr_interval_filter_add(bgpstream_filter_mgr_t *bs_filter_mgr,
-					      uint32_t begin_time,
-                                              uint32_t end_time){
+void bgpstream_filter_mgr_interval_filter_add(
+  bgpstream_filter_mgr_t *bs_filter_mgr, uint32_t begin_time, uint32_t end_time)
+{
   bgpstream_debug("\tBSF_MGR:: add_filter start");
-  if(bs_filter_mgr == NULL) {
+  if (bs_filter_mgr == NULL) {
     return; // nothing to customize
   }
   // create a new filter structure
-  bgpstream_interval_filter_t *f = (bgpstream_interval_filter_t*) malloc(sizeof(bgpstream_interval_filter_t));
-  if(f == NULL) {
+  bgpstream_interval_filter_t *f =
+    (bgpstream_interval_filter_t *)malloc(sizeof(bgpstream_interval_filter_t));
+  if (f == NULL) {
     bgpstream_debug("\tBSF_MGR:: add_filter malloc failed");
     bgpstream_log_warn("\tBSF_MGR: can't allocate memory");
     return;
@@ -199,17 +192,18 @@ void bgpstream_filter_mgr_interval_filter_add(bgpstream_filter_mgr_t *bs_filter_
   bgpstream_debug("\tBSF_MGR:: add_filter stop");
 }
 
-int bgpstream_filter_mgr_validate(bgpstream_filter_mgr_t *filter_mgr) {
-  bgpstream_interval_filter_t * tif;
+int bgpstream_filter_mgr_validate(bgpstream_filter_mgr_t *filter_mgr)
+{
+  bgpstream_interval_filter_t *tif;
   /* currently we only validate the intervals */
-  if(filter_mgr->time_intervals != NULL) {
+  if (filter_mgr->time_intervals != NULL) {
     tif = filter_mgr->time_intervals;
 
-    while(tif != NULL) {
-      if(tif->end_time != BGPSTREAM_FOREVER &&
-         tif->begin_time > tif->end_time) {
+    while (tif != NULL) {
+      if (tif->end_time != BGPSTREAM_FOREVER &&
+          tif->begin_time > tif->end_time) {
         /* invalid interval */
-        fprintf(stderr, "ERROR: Interval %"PRIu32",%"PRIu32" is invalid\n",
+        fprintf(stderr, "ERROR: Interval %" PRIu32 ",%" PRIu32 " is invalid\n",
                 tif->begin_time, tif->end_time);
         return -1;
       }
@@ -222,62 +216,58 @@ int bgpstream_filter_mgr_validate(bgpstream_filter_mgr_t *filter_mgr) {
 }
 
 /* destroy the memory allocated for bgpstream filter */
-void bgpstream_filter_mgr_destroy(bgpstream_filter_mgr_t *bs_filter_mgr) {
+void bgpstream_filter_mgr_destroy(bgpstream_filter_mgr_t *bs_filter_mgr)
+{
   bgpstream_debug("\tBSF_MGR:: destroy start");
-  if(bs_filter_mgr == NULL) {
+  if (bs_filter_mgr == NULL) {
     return; // nothing to destroy
   }
   // destroying filters
-  bgpstream_interval_filter_t * tif;
+  bgpstream_interval_filter_t *tif;
   khiter_t k;
   // projects
-  if(bs_filter_mgr->projects != NULL) {
+  if (bs_filter_mgr->projects != NULL) {
     bgpstream_str_set_destroy(bs_filter_mgr->projects);
   }
   // collectors
-  if(bs_filter_mgr->collectors != NULL) {
+  if (bs_filter_mgr->collectors != NULL) {
     bgpstream_str_set_destroy(bs_filter_mgr->collectors);
   }
   // bgp_types
-  if(bs_filter_mgr->bgp_types != NULL) {
+  if (bs_filter_mgr->bgp_types != NULL) {
     bgpstream_str_set_destroy(bs_filter_mgr->bgp_types);
   }
   // peer asns
-  if(bs_filter_mgr->peer_asns != NULL) {
+  if (bs_filter_mgr->peer_asns != NULL) {
     bgpstream_id_set_destroy(bs_filter_mgr->peer_asns);
   }
   // prefixes
-  if(bs_filter_mgr->prefixes != NULL) {
+  if (bs_filter_mgr->prefixes != NULL) {
     bgpstream_patricia_tree_destroy(bs_filter_mgr->prefixes);
   }
   // communities
-  if(bs_filter_mgr->communities != NULL)
-    {
-      kh_destroy(bgpstream_community_filter, bs_filter_mgr->communities);
-    }
+  if (bs_filter_mgr->communities != NULL) {
+    kh_destroy(bgpstream_community_filter, bs_filter_mgr->communities);
+  }
   // time_intervals
   tif = NULL;
-  while(bs_filter_mgr->time_intervals != NULL) {
-    tif =  bs_filter_mgr->time_intervals;
-    bs_filter_mgr->time_intervals =  bs_filter_mgr->time_intervals->next;
+  while (bs_filter_mgr->time_intervals != NULL) {
+    tif = bs_filter_mgr->time_intervals;
+    bs_filter_mgr->time_intervals = bs_filter_mgr->time_intervals->next;
     free(tif);
   }
   // rib/update frequency
-  if(bs_filter_mgr->last_processed_ts != NULL)
-    {
-      for(k=kh_begin(bs_filter_mgr->last_processed_ts); k!=kh_end(bs_filter_mgr->last_processed_ts); ++k)
-        {
-          if(kh_exist(bs_filter_mgr->last_processed_ts,k))
-            {
-              free(kh_key(bs_filter_mgr->last_processed_ts,k));
-            }
-        }
-      kh_destroy(collector_ts, bs_filter_mgr->last_processed_ts);
+  if (bs_filter_mgr->last_processed_ts != NULL) {
+    for (k = kh_begin(bs_filter_mgr->last_processed_ts);
+         k != kh_end(bs_filter_mgr->last_processed_ts); ++k) {
+      if (kh_exist(bs_filter_mgr->last_processed_ts, k)) {
+        free(kh_key(bs_filter_mgr->last_processed_ts, k));
+      }
     }
+    kh_destroy(collector_ts, bs_filter_mgr->last_processed_ts);
+  }
   // free the mgr structure
   free(bs_filter_mgr);
   bs_filter_mgr = NULL;
   bgpstream_debug("\tBSF_MGR:: destroy end");
 }
-
-

--- a/lib/bgpstream_filter.h
+++ b/lib/bgpstream_filter.h
@@ -28,24 +28,23 @@
 #include "bgpstream_constants.h"
 #include "khash.h"
 
-
 /* hash table community filter:
  * community -> filter mask (asn only, value only, both) */
 KHASH_INIT(bgpstream_community_filter, bgpstream_community_t, uint8_t, 1,
-	   bgpstream_community_hash_value, bgpstream_community_equal_value);
+           bgpstream_community_hash_value, bgpstream_community_equal_value);
 typedef khash_t(bgpstream_community_filter) bgpstream_community_filter_t;
 
 typedef struct struct_bgpstream_interval_filter_t {
   uint32_t begin_time;
   uint32_t end_time;
-  struct struct_bgpstream_interval_filter_t * next;
+  struct struct_bgpstream_interval_filter_t *next;
 } bgpstream_interval_filter_t;
 
-KHASH_INIT(collector_ts, char*, uint32_t, 1,
-	   kh_str_hash_func, kh_str_hash_equal);
+KHASH_INIT(collector_ts, char *, uint32_t, 1, kh_str_hash_func,
+           kh_str_hash_equal);
 
 typedef khash_t(collector_ts) collector_ts_t;
-                                   
+
 typedef struct struct_bgpstream_filter_mgr_t {
   bgpstream_str_set_t *projects;
   bgpstream_str_set_t *collectors;
@@ -53,33 +52,30 @@ typedef struct struct_bgpstream_filter_mgr_t {
   bgpstream_id_set_t *peer_asns;
   bgpstream_patricia_tree_t *prefixes;
   bgpstream_community_filter_t *communities;
-  bgpstream_interval_filter_t * time_intervals;
+  bgpstream_interval_filter_t *time_intervals;
   collector_ts_t *last_processed_ts;
   uint32_t rib_period;
 } bgpstream_filter_mgr_t;
-
 
 /* allocate memory for a new bgpstream filter */
 bgpstream_filter_mgr_t *bgpstream_filter_mgr_create();
 
 /* configure filters in order to select a subset of the bgp data available */
 void bgpstream_filter_mgr_filter_add(bgpstream_filter_mgr_t *bs_filter_mgr,
-				     bgpstream_filter_type_t filter_type,
-				     const char* filter_value);
+                                     bgpstream_filter_type_t filter_type,
+                                     const char *filter_value);
 
-void bgpstream_filter_mgr_rib_period_filter_add(bgpstream_filter_mgr_t *bs_filter_mgr,
-                                                uint32_t period);
+void bgpstream_filter_mgr_rib_period_filter_add(
+  bgpstream_filter_mgr_t *bs_filter_mgr, uint32_t period);
 
-void bgpstream_filter_mgr_interval_filter_add(bgpstream_filter_mgr_t *bs_filter_mgr,
-					      uint32_t begin_time,
-					      uint32_t end_time);
+void bgpstream_filter_mgr_interval_filter_add(
+  bgpstream_filter_mgr_t *bs_filter_mgr, uint32_t begin_time,
+  uint32_t end_time);
 
 /* validate the current filters */
 int bgpstream_filter_mgr_validate(bgpstream_filter_mgr_t *mgr);
 
-
 /* destroy the memory allocated for bgpstream filter */
 void bgpstream_filter_mgr_destroy(bgpstream_filter_mgr_t *bs_filter_mgr);
-
 
 #endif /* _BGPSTREAM_FILTER_H */

--- a/lib/bgpstream_input.c
+++ b/lib/bgpstream_input.c
@@ -23,36 +23,37 @@
 
 #include "bgpstream_input.h"
 #include "bgpstream_debug.h"
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
 #include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-
- //function used for debug
-static void print_input_queue(const bgpstream_input_t * const input_queue) {
+// function used for debug
+static void print_input_queue(const bgpstream_input_t *const input_queue)
+{
 #ifdef NDEBUG
-  const bgpstream_input_t * iterator = input_queue;
+  const bgpstream_input_t *iterator = input_queue;
   bgpstream_debug("INPUT QUEUE: start");
   int i = 1;
-  while(iterator != NULL) {    
-    bgpstream_debug("\t%d %s %s %d",i, iterator->filecollector, 
-	  iterator->filetype, iterator->epoch_filetime);
+  while (iterator != NULL) {
+    bgpstream_debug("\t%d %s %s %d", i, iterator->filecollector,
+                    iterator->filetype, iterator->epoch_filetime);
     iterator = iterator->next;
     i++;
   }
   iterator = NULL;
-  bgpstream_debug("\nINPUT QUEUE: end");  
+  bgpstream_debug("\nINPUT QUEUE: end");
 #endif
 }
 
-
-/* Initialize the bgpstream input manager  
+/* Initialize the bgpstream input manager
  */
-bgpstream_input_mgr_t *bgpstream_input_mgr_create() {
+bgpstream_input_mgr_t *bgpstream_input_mgr_create()
+{
   bgpstream_debug("\tBSI_MGR: create input mgr start");
-  bgpstream_input_mgr_t *bs_input_mgr = (bgpstream_input_mgr_t*) malloc(sizeof(bgpstream_input_mgr_t));
-  if(bs_input_mgr == NULL) {
+  bgpstream_input_mgr_t *bs_input_mgr =
+    (bgpstream_input_mgr_t *)malloc(sizeof(bgpstream_input_mgr_t));
+  if (bs_input_mgr == NULL) {
     return NULL; // can't allocate memory
   }
   bs_input_mgr->head = NULL;
@@ -65,12 +66,14 @@ bgpstream_input_mgr_t *bgpstream_input_mgr_create() {
   return bs_input_mgr;
 }
 
-
-/* Check if the current status is EMPTY 
+/* Check if the current status is EMPTY
  */
-bool bgpstream_input_mgr_is_empty(const bgpstream_input_mgr_t * const bs_input_mgr) {
+bool bgpstream_input_mgr_is_empty(
+  const bgpstream_input_mgr_t *const bs_input_mgr)
+{
   bgpstream_debug("\tBSI_MGR: is empty start");
-  if(bs_input_mgr != NULL && bs_input_mgr->status != BGPSTREAM_INPUT_MGR_STATUS_EMPTY_INPUT_QUEUE) {
+  if (bs_input_mgr != NULL &&
+      bs_input_mgr->status != BGPSTREAM_INPUT_MGR_STATUS_EMPTY_INPUT_QUEUE) {
     bgpstream_debug("\tBSI_MGR: is empty end: not empty!");
     return false;
   }
@@ -78,29 +81,31 @@ bool bgpstream_input_mgr_is_empty(const bgpstream_input_mgr_t * const bs_input_m
   return true;
 }
 
-
 /* Add a new input object to the sorted queue
- * managed by the bgpstream input manager 
+ * managed by the bgpstream input manager
  * (bgpstream objects are sorted by filetime)
  */
-int bgpstream_input_mgr_push_sorted_input(bgpstream_input_mgr_t * const bs_input_mgr, 
-					  char * filename, char * fileproject,
-					  char * filecollector, char * const filetype,
-					  const int epoch_filetime, const int time_span) {
+int bgpstream_input_mgr_push_sorted_input(
+  bgpstream_input_mgr_t *const bs_input_mgr, char *filename, char *fileproject,
+  char *filecollector, char *const filetype, const int epoch_filetime,
+  const int time_span)
+{
   bgpstream_debug("\t\tBSI: push input start");
-  if(bs_input_mgr == NULL) {
-    return 0; // if the bs_input_mgr is not initialized, then we cannot insert any new input
+  if (bs_input_mgr == NULL) {
+    return 0; // if the bs_input_mgr is not initialized, then we cannot insert
+              // any new input
   }
   // create a new bgpstream_input object
-  bgpstream_input_t *bs_input = (bgpstream_input_t*) malloc(sizeof(bgpstream_input_t));
-  if(bs_input == NULL) {
-    return 0; // can't allocate memory    
+  bgpstream_input_t *bs_input =
+    (bgpstream_input_t *)malloc(sizeof(bgpstream_input_t));
+  if (bs_input == NULL) {
+    return 0; // can't allocate memory
   }
   // initialize bgpstream_input fields
   bs_input->next = NULL;
   // initialization done
 
- /* we already own the buffers */
+  /* we already own the buffers */
   bs_input->filename = filename;
   bs_input->fileproject = fileproject;
   bs_input->filecollector = filecollector;
@@ -110,95 +115,87 @@ int bgpstream_input_mgr_push_sorted_input(bgpstream_input_mgr_t * const bs_input
   bs_input->time_span = time_span;
 
   // update the bs_input_mgr
-  if(bs_input_mgr->status == BGPSTREAM_INPUT_MGR_STATUS_EMPTY_INPUT_QUEUE) {
+  if (bs_input_mgr->status == BGPSTREAM_INPUT_MGR_STATUS_EMPTY_INPUT_QUEUE) {
     // if the queue is empty a new input is added
     // as first element
     bs_input_mgr->head = bs_input;
     bs_input_mgr->tail = bs_input;
     bs_input_mgr->status = BGPSTREAM_INPUT_MGR_STATUS_NON_EMPTY_INPUT_QUEUE;
-  }
-  else {
+  } else {
     // otherwise we scan the queue until we
     // reach the end or find an element whose
     // filetime is newer
     bgpstream_input_t *current = bs_input_mgr->head;
     bgpstream_input_t *previous = bs_input_mgr->head;
-    while(current != NULL && current->epoch_filetime <= epoch_filetime) {
-      // if the file is already in queue we do not add a 
+    while (current != NULL && current->epoch_filetime <= epoch_filetime) {
+      // if the file is already in queue we do not add a
       // duplicate
-      if(current->epoch_filetime == epoch_filetime &&
-	 strcmp(current->filecollector, filecollector) == 0 &&
-	 strcmp(current->fileproject, fileproject) == 0 &&
-	 strcmp(current->filetype, filetype) == 0) {
-	return 0;
+      if (current->epoch_filetime == epoch_filetime &&
+          strcmp(current->filecollector, filecollector) == 0 &&
+          strcmp(current->fileproject, fileproject) == 0 &&
+          strcmp(current->filetype, filetype) == 0) {
+        return 0;
       }
       // ribs have higher priority (ribs and updates are grouped
       // together, ribs come before updates - if they have the same
       // filetime)
-      if(current->epoch_filetime == epoch_filetime &&
-	 filetype[0] == 'r' && /* "ribs" */
-	 current->filetype[0] == 'u') { /* "updates" */
-	break;
-      }
-      else{
-	previous = current;
-	current = current->next;
+      if (current->epoch_filetime == epoch_filetime &&
+          filetype[0] == 'r' &&          /* "ribs" */
+          current->filetype[0] == 'u') { /* "updates" */
+        break;
+      } else {
+        previous = current;
+        current = current->next;
       }
     }
     // new input object is inserted at
     // previous -> new object -> current
-    if(current == NULL) {
+    if (current == NULL) {
       // case 1: end of queue reached
       bs_input_mgr->tail->next = bs_input;
       bs_input_mgr->tail = bs_input;
-    }
-    else {
-      if(current == previous) {
-	// case 2: head of queue
-	bs_input->next = bs_input_mgr->head;
-	bs_input_mgr->head = bs_input;
-      }
-      else {
-	// case 3: internal position
-	bs_input->next = current;
-	previous->next = bs_input;
+    } else {
+      if (current == previous) {
+        // case 2: head of queue
+        bs_input->next = bs_input_mgr->head;
+        bs_input_mgr->head = bs_input;
+      } else {
+        // case 3: internal position
+        bs_input->next = current;
+        previous->next = bs_input;
       }
     }
   }
-  bgpstream_debug("\tBSI_MGR: sorted push: %s",filename);
+  bgpstream_debug("\tBSI_MGR: sorted push: %s", filename);
   bgpstream_debug("\tBSI_MGR: sorted push input mgr end");
   return 1;
 }
 
-
-
-static void bgpstream_set_intervals(bgpstream_input_t *input, 
-				    int *current_interval_start,
-				    int *current_interval_end ){
+static void bgpstream_set_intervals(bgpstream_input_t *input,
+                                    int *current_interval_start,
+                                    int *current_interval_end)
+{
   assert(input);
   *current_interval_start = 0;
-  *current_interval_end = 0;  
+  *current_interval_end = 0;
 
-  if(strcmp(input->filetype,"ribs") == 0)
-    {
-      *current_interval_start = input->epoch_filetime - input->time_span;
+  if (strcmp(input->filetype, "ribs") == 0) {
+    *current_interval_start = input->epoch_filetime - input->time_span;
+    *current_interval_end = input->epoch_filetime + input->time_span;
+  } else {
+    if (strcmp(input->filetype, "updates") == 0) {
+      *current_interval_start = input->epoch_filetime;
       *current_interval_end = input->epoch_filetime + input->time_span;
     }
-  else
-    {
-      if(strcmp(input->filetype,"updates") == 0)
-        {
-          *current_interval_start = input->epoch_filetime;
-          *current_interval_end = input->epoch_filetime + input->time_span;
-        }
-    }
+  }
 }
 
-
-/* Set the last input to process  
+/* Set the last input to process
  * the function is static: it is not visible outside this file
  */
-static void bgpstream_input_mgr_set_last_to_process(bgpstream_input_mgr_t * const bs_input_mgr){
+static void bgpstream_input_mgr_set_last_to_process(
+  bgpstream_input_mgr_t *const bs_input_mgr)
+{
   bgpstream_debug("\tBSI_MGR: last to process set start");
   bs_input_mgr->last_to_process = NULL;
   bgpstream_input_t *iterator = bs_input_mgr->head;
@@ -212,41 +209,46 @@ static void bgpstream_input_mgr_set_last_to_process(bgpstream_input_mgr_t * cons
    *   to the update interval size (e.g. 5 mins)
    * - each rib affects an interval of time that corresponds to:
    *   [ rib_time - 1 update interval, rib_time + 1 update interval]
-   * 
+   *
    * in order to select the data to process we start with the first
    * bgp data in the queue and we add the next one if its interval
    * overlaps with the current one. Also if it does overlap, then
    * the reference interval is expanded accordingly.
    */
 
-  if(iterator == NULL) {
-    bgpstream_debug("\tBSI_MGR: empty queue end");  
+  if (iterator == NULL) {
+    bgpstream_debug("\tBSI_MGR: empty queue end");
     return;
   }
-  
+
   /* step 0: init the "global" (to_process) interval end)
    * using the first input object */
-  bgpstream_set_intervals(iterator, &current_interval_start, &to_process_interval_end);
+  bgpstream_set_intervals(iterator, &current_interval_start,
+                          &to_process_interval_end);
   int readers_counter = 0;
-  const int max_readers = 200; 
-  while(iterator != NULL && readers_counter < max_readers) { 
+  const int max_readers = 200;
+  while (iterator != NULL && readers_counter < max_readers) {
     readers_counter++;
     // compute current input interval
-    bgpstream_set_intervals(iterator, &current_interval_start, &current_interval_end);
-    /* fprintf(stderr, "intervals: %d -> %d\n", current_interval_start, current_interval_end); */
+    bgpstream_set_intervals(iterator, &current_interval_start,
+                            &current_interval_end);
+    /* fprintf(stderr, "intervals: %d -> %d\n", current_interval_start,
+     * current_interval_end); */
     /* fprintf(stderr, "max end: %d \n", to_process_interval_end); */
     // if it does not overlap with the global one, then we reached the end
-    if(current_interval_start >= to_process_interval_end) {
+    if (current_interval_start >= to_process_interval_end) {
       // fprintf(stderr,"\n\n");
       break;
     }
     // otherwise, we extend the global interval end
-    if(to_process_interval_end < current_interval_end) {
-      to_process_interval_end = current_interval_end;    
-    } 
+    if (to_process_interval_end < current_interval_end) {
+      to_process_interval_end = current_interval_end;
+    }
 
-    /* fprintf(stderr,"%s - %s\n", iterator->fileproject, iterator->filetype); */
-    /* fprintf(stderr,"\t%d - %d | %d\n", current_interval_start, current_interval_end, to_process_interval_end);     */
+    /* fprintf(stderr,"%s - %s\n", iterator->fileproject, iterator->filetype);
+     */
+    /* fprintf(stderr,"\t%d - %d | %d\n", current_interval_start,
+     * current_interval_end, to_process_interval_end);     */
     // and we update the last to process
     bs_input_mgr->last_to_process = iterator;
     // next
@@ -256,33 +258,34 @@ static void bgpstream_input_mgr_set_last_to_process(bgpstream_input_mgr_t * cons
   bgpstream_debug("\tBSI_MGR: last to process set end");
 }
 
-
-
-/* Remove a sublist-queue of input objects to process 
- * from the FIFO queue managed by the bgpstream input manager 
+/* Remove a sublist-queue of input objects to process
+ * from the FIFO queue managed by the bgpstream input manager
  */
-bgpstream_input_t *bgpstream_input_mgr_get_queue_to_process(bgpstream_input_mgr_t * const bs_input_mgr) {
+bgpstream_input_t *bgpstream_input_mgr_get_queue_to_process(
+  bgpstream_input_mgr_t *const bs_input_mgr)
+{
   bgpstream_debug("\tBSI_MGR: get subqueue to process start");
-  if(bs_input_mgr == NULL) {
-    return NULL; // if the bs_input_mgr is not initialized, then we cannot remove any input
+  if (bs_input_mgr == NULL) {
+    return NULL; // if the bs_input_mgr is not initialized, then we cannot
+                 // remove any input
   }
-  if(bs_input_mgr->status == BGPSTREAM_INPUT_MGR_STATUS_EMPTY_INPUT_QUEUE){
+  if (bs_input_mgr->status == BGPSTREAM_INPUT_MGR_STATUS_EMPTY_INPUT_QUEUE) {
     return NULL; // can't get a sublist from an empty queue
   }
-  /* this is the only function that call the function 
+  /* this is the only function that call the function
    * bgpstream_input_set_last_to_process */
   bgpstream_input_mgr_set_last_to_process(bs_input_mgr);
-  if(bs_input_mgr->last_to_process == NULL ){
+  if (bs_input_mgr->last_to_process == NULL) {
     return NULL;
   }
-  bgpstream_input_t* to_process = bs_input_mgr->head;
+  bgpstream_input_t *to_process = bs_input_mgr->head;
   // change FIFO queue internal connections
   bs_input_mgr->head = bs_input_mgr->last_to_process->next;
   /* we don't want external functions to access the queue
    * also we need to establish the end of the sub-queue exported */
-  bs_input_mgr->last_to_process->next = NULL; 
+  bs_input_mgr->last_to_process->next = NULL;
   bs_input_mgr->last_to_process = NULL; // reset last_to_process ptr
-  if(bs_input_mgr->head == NULL) { // check if we removed the entire queue
+  if (bs_input_mgr->head == NULL) {     // check if we removed the entire queue
     bs_input_mgr->tail = NULL;
     bs_input_mgr->status = BGPSTREAM_INPUT_MGR_STATUS_EMPTY_INPUT_QUEUE;
   }
@@ -291,15 +294,15 @@ bgpstream_input_t *bgpstream_input_mgr_get_queue_to_process(bgpstream_input_mgr_
   return to_process;
 }
 
-
 /* Recursively destroy the bgpstream input objects in the
  * queue
  */
-void bgpstream_input_mgr_destroy_queue(bgpstream_input_t *queue) {
+void bgpstream_input_mgr_destroy_queue(bgpstream_input_t *queue)
+{
   bgpstream_debug("\tBSI_MGR: subqueue destroy start");
   bgpstream_input_t *iterator = queue;
   bgpstream_input_t *current = NULL;
-  while(iterator!=NULL) {
+  while (iterator != NULL) {
     current = iterator;
     iterator = iterator->next;
     // deallocating memory for current bgpstream_input object
@@ -312,14 +315,14 @@ void bgpstream_input_mgr_destroy_queue(bgpstream_input_t *queue) {
   bgpstream_debug("\tBSI_MGR: subqueue destroy end");
 }
 
-
-/* Destroy the bgpstream_input manager 
+/* Destroy the bgpstream_input manager
 */
-void bgpstream_input_mgr_destroy(bgpstream_input_mgr_t *bs_input_mgr){
+void bgpstream_input_mgr_destroy(bgpstream_input_mgr_t *bs_input_mgr)
+{
   bgpstream_debug("\tBSI_MGR: input mgr destroy start");
-  if(bs_input_mgr == NULL){
+  if (bs_input_mgr == NULL) {
     return; // already empty
-  }  
+  }
   bgpstream_input_mgr_destroy_queue(bs_input_mgr->head); // destroy queue
   bs_input_mgr->head = NULL;
   bs_input_mgr->tail = NULL;
@@ -328,4 +331,3 @@ void bgpstream_input_mgr_destroy(bgpstream_input_mgr_t *bs_input_mgr){
   free(bs_input_mgr);
   bgpstream_debug("\tBSI_MGR: input mgr destroy end");
 }
-

--- a/lib/bgpstream_input.h
+++ b/lib/bgpstream_input.h
@@ -27,18 +27,16 @@
 #include "bgpstream_constants.h"
 #include <stdbool.h>
 
-
-
 typedef struct struct_bgpstream_input_t {
   struct struct_bgpstream_input_t *next;
-  char *filename; // name of bgpdump 
-  char *fileproject; // bgpdump project
+  char *filename;      // name of bgpdump
+  char *fileproject;   // bgpdump project
   char *filecollector; // bgpdump collector
-  char *filetype; // type of bgpdump (rib or update)
-  int epoch_filetime; // timestamp associated to the time the bgp data was generated
+  char *filetype;      // type of bgpdump (rib or update)
+  int epoch_filetime;  // timestamp associated to the time the bgp data was
+                       // generated
   int time_span;
 } bgpstream_input_t;
-
 
 typedef enum {
   BGPSTREAM_INPUT_MGR_STATUS_EMPTY_INPUT_QUEUE,
@@ -54,17 +52,17 @@ typedef struct struct_bgpstream_input_mgr_t {
   int epoch_last_ts_input;
 } bgpstream_input_mgr_t;
 
-
 /* prototypes */
 bgpstream_input_mgr_t *bgpstream_input_mgr_create();
-bool bgpstream_input_mgr_is_empty(const bgpstream_input_mgr_t * const bs_input_mgr);
-int bgpstream_input_mgr_push_sorted_input(bgpstream_input_mgr_t * const bs_input_mgr, 
-					  char * filename, char * fileproject,
-					  char * filecollector, char * const filetype,
-					  const int epoch_filetime, const int time_span);
-bgpstream_input_t *bgpstream_input_mgr_get_queue_to_process(bgpstream_input_mgr_t * const bs_input_mgr);
+bool bgpstream_input_mgr_is_empty(
+  const bgpstream_input_mgr_t *const bs_input_mgr);
+int bgpstream_input_mgr_push_sorted_input(
+  bgpstream_input_mgr_t *const bs_input_mgr, char *filename, char *fileproject,
+  char *filecollector, char *const filetype, const int epoch_filetime,
+  const int time_span);
+bgpstream_input_t *bgpstream_input_mgr_get_queue_to_process(
+  bgpstream_input_mgr_t *const bs_input_mgr);
 void bgpstream_input_mgr_destroy_queue(bgpstream_input_t *queue);
 void bgpstream_input_mgr_destroy(bgpstream_input_mgr_t *bs_input_mgr);
-
 
 #endif /* _BGPSTREAM_INPUT_H */

--- a/lib/bgpstream_int.h
+++ b/lib/bgpstream_int.h
@@ -27,10 +27,9 @@
 #include "bgpstream.h"
 
 #include "bgpstream_datasource.h"
+#include "bgpstream_filter.h"
 #include "bgpstream_input.h"
 #include "bgpstream_reader.h"
-#include "bgpstream_filter.h"
-
 
 typedef enum {
   BGPSTREAM_STATUS_ALLOCATED,
@@ -45,7 +44,5 @@ struct struct_bgpstream_t {
   bgpstream_datasource_mgr_t *datasource_mgr;
   bgpstream_status status;
 };
-
-
 
 #endif /* _BGPSTREAM_INT_H */

--- a/lib/bgpstream_reader.c
+++ b/lib/bgpstream_reader.c
@@ -23,32 +23,33 @@
 
 #include <assert.h>
 #include <pthread.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 
-#include "bgpstream_reader.h"
-#include "bgpstream_input.h"
 #include "bgpstream_debug.h"
+#include "bgpstream_input.h"
+#include "bgpstream_reader.h"
 
 #include "utils.h"
 
 #define BUFFER_LEN 1024
 
 #define DUMP_OPEN_MAX_RETRIES 5
-#define DUMP_OPEN_MIN_RETRY_WAIT  10
+#define DUMP_OPEN_MIN_RETRY_WAIT 10
 
 struct struct_bgpstream_reader_t {
   struct struct_bgpstream_reader_t *next;
-  char dump_name[BGPSTREAM_DUMP_MAX_LEN];  // name of bgp dump 
-  char dump_project[BGPSTREAM_PAR_MAX_LEN];  // name of bgp project 
-  char dump_collector[BGPSTREAM_PAR_MAX_LEN];  // name of bgp collector 
-  char dump_type[BGPSTREAM_PAR_MAX_LEN];  // type of bgp dump (rib or update)
-  long dump_time;         // timestamp associated with the time the bgp data was aggregated
-  long record_time;       // timestamp associated with the current bd_entry
+  char dump_name[BGPSTREAM_DUMP_MAX_LEN];     // name of bgp dump
+  char dump_project[BGPSTREAM_PAR_MAX_LEN];   // name of bgp project
+  char dump_collector[BGPSTREAM_PAR_MAX_LEN]; // name of bgp collector
+  char dump_type[BGPSTREAM_PAR_MAX_LEN]; // type of bgp dump (rib or update)
+  long
+    dump_time; // timestamp associated with the time the bgp data was aggregated
+  long record_time; // timestamp associated with the current bd_entry
   BGPDUMP_ENTRY *bd_entry;
   int successful_read; // n. successful reads, i.e. entry != NULL
-  int valid_read; // n. reads successful and compatible with filters
+  int valid_read;      // n. reads successful and compatible with filters
   bgpstream_reader_status_t status;
 
   BGPDUMP *bd_mgr;
@@ -70,12 +71,12 @@ static void *thread_producer(void *user)
 
   /* all we do is open the dump */
   /* but try a few times in case there is a transient failure */
-  while(retries < DUMP_OPEN_MAX_RETRIES && bsr->bd_mgr == NULL) {
-    if((bsr->bd_mgr = bgpdump_open_dump(bsr->dump_name)) == NULL) {
+  while (retries < DUMP_OPEN_MAX_RETRIES && bsr->bd_mgr == NULL) {
+    if ((bsr->bd_mgr = bgpdump_open_dump(bsr->dump_name)) == NULL) {
       fprintf(stderr, "WARN: Could not open dumpfile (%s). Attempt %d of %d\n",
-              bsr->dump_name, retries+1, DUMP_OPEN_MAX_RETRIES);
+              bsr->dump_name, retries + 1, DUMP_OPEN_MAX_RETRIES);
       retries++;
-      if(retries < DUMP_OPEN_MAX_RETRIES) {
+      if (retries < DUMP_OPEN_MAX_RETRIES) {
         sleep(delay);
         delay *= 2;
       }
@@ -83,10 +84,11 @@ static void *thread_producer(void *user)
   }
 
   pthread_mutex_lock(&bsr->mutex);
-  if(bsr->bd_mgr == NULL) {
-    fprintf(stderr,
-            "ERROR: Could not open dumpfile (%s) after %d attempts. Giving up.\n",
-            bsr->dump_name, DUMP_OPEN_MAX_RETRIES);
+  if (bsr->bd_mgr == NULL) {
+    fprintf(
+      stderr,
+      "ERROR: Could not open dumpfile (%s) after %d attempts. Giving up.\n",
+      bsr->dump_name, DUMP_OPEN_MAX_RETRIES);
     bsr->status = BGPSTREAM_READER_STATUS_CANT_OPEN_DUMP;
   }
   bsr->dump_ready = 1;
@@ -98,14 +100,14 @@ static void *thread_producer(void *user)
 
 static BGPDUMP_ENTRY *get_next_entry(bgpstream_reader_t *bsr)
 {
-  if(bsr->skip_dump_check == 0) {
+  if (bsr->skip_dump_check == 0) {
     pthread_mutex_lock(&bsr->mutex);
     while (bsr->dump_ready == 0) {
       pthread_cond_wait(&bsr->dump_ready_cond, &bsr->mutex);
     }
     pthread_mutex_unlock(&bsr->mutex);
 
-    if(bsr->status == BGPSTREAM_READER_STATUS_CANT_OPEN_DUMP) {
+    if (bsr->status == BGPSTREAM_READER_STATUS_CANT_OPEN_DUMP) {
       return NULL;
     }
 
@@ -118,45 +120,50 @@ static BGPDUMP_ENTRY *get_next_entry(bgpstream_reader_t *bsr)
 
 /* -------------- Reader functions -------------- */
 
-static bool bgpstream_reader_filter_bd_entry(const BGPDUMP_ENTRY * const bd_entry, 
-					     const bgpstream_filter_mgr_t * const filter_mgr) {
-  bgpstream_debug("\t\tBSR: filter entry: start");  
-  bgpstream_interval_filter_t * tif;
-  if(bd_entry != NULL && filter_mgr != NULL) {
-    if(filter_mgr->time_intervals == NULL ) {
-        bgpstream_debug("\t\tBSR: filter entry: end");  
-	return true; // no time filtering, 
+static bool
+bgpstream_reader_filter_bd_entry(const BGPDUMP_ENTRY *const bd_entry,
+                                 const bgpstream_filter_mgr_t *const filter_mgr)
+{
+  bgpstream_debug("\t\tBSR: filter entry: start");
+  bgpstream_interval_filter_t *tif;
+  if (bd_entry != NULL && filter_mgr != NULL) {
+    if (filter_mgr->time_intervals == NULL) {
+      bgpstream_debug("\t\tBSR: filter entry: end");
+      return true; // no time filtering,
     }
     int current_entry_time = bd_entry->time;
     tif = filter_mgr->time_intervals;
-    while(tif != NULL) {      
-      if(current_entry_time >= tif->begin_time &&
-         (tif->end_time == BGPSTREAM_FOREVER ||
-          current_entry_time <= tif->end_time)) {
-	bgpstream_debug("\t\tBSR: filter entry: OK");  
-	return true;
+    while (tif != NULL) {
+      if (current_entry_time >= tif->begin_time &&
+          (tif->end_time == BGPSTREAM_FOREVER ||
+           current_entry_time <= tif->end_time)) {
+        bgpstream_debug("\t\tBSR: filter entry: OK");
+        return true;
       }
       tif = tif->next;
     }
-  }  
-  bgpstream_debug("\t\tBSR: filter entry: DISCARDED");    
+  }
+  bgpstream_debug("\t\tBSR: filter entry: DISCARDED");
   return false;
 }
 
-
-static void bgpstream_reader_read_new_data(bgpstream_reader_t * const bs_reader,
-					   const bgpstream_filter_mgr_t * const filter_mgr) {
+static void
+bgpstream_reader_read_new_data(bgpstream_reader_t *const bs_reader,
+                               const bgpstream_filter_mgr_t *const filter_mgr)
+{
   bool significant_entry = false;
-  bgpstream_debug("\t\tBSR: read new data: start");  
-  if(bs_reader == NULL) {
-    bgpstream_debug("\t\tBSR: read new data: invalid reader provided");    
+  bgpstream_debug("\t\tBSR: read new data: start");
+  if (bs_reader == NULL) {
+    bgpstream_debug("\t\tBSR: read new data: invalid reader provided");
     return;
-  }  
-  if(bs_reader->status != BGPSTREAM_READER_STATUS_VALID_ENTRY) {
-    bgpstream_debug("\t\tBSR: read new data: reader cannot read new data (previous read was not successful)");    
+  }
+  if (bs_reader->status != BGPSTREAM_READER_STATUS_VALID_ENTRY) {
+    bgpstream_debug("\t\tBSR: read new data: reader cannot read new data "
+                    "(previous read was not successful)");
     return;
-  }  
-  // if a valid record was read before (or it is the first time we read something)
+  }
+  // if a valid record was read before (or it is the first time we read
+  // something)
   // assert(bs_reader->status == BGPSTREAM_READER_STATUS_VALID_ENTRY)
   bgpstream_debug("\t\tBSR: read new data: bd_entry has to be set to NULL");
   // entry should not be destroyed, otherwise we could destroy
@@ -165,96 +172,94 @@ static void bgpstream_reader_read_new_data(bgpstream_reader_t * const bs_reader,
   bs_reader->bd_entry = NULL;
   // check if the end of the file was already reached before
   // reading a new value
-  //if(bs_reader->bd_mgr->eof != 0) {
-  //  bgpstream_debug("\t\tBSR: read new data: end of file reached");      
+  // if(bs_reader->bd_mgr->eof != 0) {
+  //  bgpstream_debug("\t\tBSR: read new data: end of file reached");
   //  bs_reader->status = BGPSTREAM_READER_STATUS_END_OF_DUMP;
   //  return;
   //}
-  bgpstream_debug("\t\tBSR: read new data (previous): %ld\t%ld\t%s\t%s\t%d",  
-	bs_reader->record_time,
-	bs_reader->dump_time,
-	bs_reader->dump_type, 
-	bs_reader->dump_collector,
-	bs_reader->status);
-  bgpstream_debug("\t\tBSR: read new data: reading new entry (or entries) in bgpdump");   
+  bgpstream_debug("\t\tBSR: read new data (previous): %ld\t%ld\t%s\t%s\t%d",
+                  bs_reader->record_time, bs_reader->dump_time,
+                  bs_reader->dump_type, bs_reader->dump_collector,
+                  bs_reader->status);
+  bgpstream_debug(
+    "\t\tBSR: read new data: reading new entry (or entries) in bgpdump");
   bgpstream_debug("\t\tBSR: read new data: from %s", bs_reader->dump_name);
-  while(!significant_entry) {
+  while (!significant_entry) {
     bgpstream_debug("\t\t\tBSR: read new data: reading");
     // try and get the next entry
     // will block until dump is open (or fails)
     bs_reader->bd_entry = get_next_entry(bs_reader);
     // check if there was an error opening the dump
-    if(bs_reader->status == BGPSTREAM_READER_STATUS_CANT_OPEN_DUMP) {
+    if (bs_reader->status == BGPSTREAM_READER_STATUS_CANT_OPEN_DUMP) {
       return;
     }
     // check if an entry has been read
-    if(bs_reader->bd_entry != NULL) {
+    if (bs_reader->bd_entry != NULL) {
       bs_reader->successful_read++;
       // check if entry is compatible with filters
-      if(bgpstream_reader_filter_bd_entry(bs_reader->bd_entry, filter_mgr)) {
-	// update reader fields
-	bs_reader->valid_read++;
-	bs_reader->status = BGPSTREAM_READER_STATUS_VALID_ENTRY;
-	bs_reader->record_time = (long) bs_reader->bd_entry->time;
-	significant_entry = true;
+      if (bgpstream_reader_filter_bd_entry(bs_reader->bd_entry, filter_mgr)) {
+        // update reader fields
+        bs_reader->valid_read++;
+        bs_reader->status = BGPSTREAM_READER_STATUS_VALID_ENTRY;
+        bs_reader->record_time = (long)bs_reader->bd_entry->time;
+        significant_entry = true;
       }
-      // if not compatible, destroy bgpdump entry 
+      // if not compatible, destroy bgpdump entry
       else {
-	bgpdump_free_mem(bs_reader->bd_entry);          
-	bs_reader->bd_entry = NULL;
-	// significant_entry = false;	
+        bgpdump_free_mem(bs_reader->bd_entry);
+        bs_reader->bd_entry = NULL;
+        // significant_entry = false;
       }
     }
     // if an entry has not been read (i.e. b_e = NULL)
     else {
       // if the corrupted entry flag is
       // active, then dump is corrupted
-      if(bs_reader->bd_mgr->corrupted_read) {
-	bs_reader->status = BGPSTREAM_READER_STATUS_CORRUPTED_DUMP;
-	significant_entry = true;	
+      if (bs_reader->bd_mgr->corrupted_read) {
+        bs_reader->status = BGPSTREAM_READER_STATUS_CORRUPTED_DUMP;
+        significant_entry = true;
       }
       // empty read, not corrupted
       else {
-	// end of file
-	if(bs_reader->bd_mgr->eof != 0) {
-	  significant_entry = true;
-	  if(bs_reader->successful_read == 0) {
-	    // file was empty
-	    bs_reader->status = BGPSTREAM_READER_STATUS_EMPTY_DUMP;
-	  }
-	  else {
-	    if(bs_reader->valid_read == 0) {
-	      // valid contained entries, but
-	      // none of them was compatible with
-	      // filters
-	      bs_reader->status = BGPSTREAM_READER_STATUS_FILTERED_DUMP;
-	    }
-	    else {
-	      // something valid has been read before
-	      // reached the end of file
-	      bs_reader->status = BGPSTREAM_READER_STATUS_END_OF_DUMP;	
-	    }
-	  }
-	}	  
-	// empty space at the *beginning* of file
-	else {
-	  // do nothing - continue to read
-	  // significant_entry = false;	
-	}
+        // end of file
+        if (bs_reader->bd_mgr->eof != 0) {
+          significant_entry = true;
+          if (bs_reader->successful_read == 0) {
+            // file was empty
+            bs_reader->status = BGPSTREAM_READER_STATUS_EMPTY_DUMP;
+          } else {
+            if (bs_reader->valid_read == 0) {
+              // valid contained entries, but
+              // none of them was compatible with
+              // filters
+              bs_reader->status = BGPSTREAM_READER_STATUS_FILTERED_DUMP;
+            } else {
+              // something valid has been read before
+              // reached the end of file
+              bs_reader->status = BGPSTREAM_READER_STATUS_END_OF_DUMP;
+            }
+          }
+        }
+        // empty space at the *beginning* of file
+        else {
+          // do nothing - continue to read
+          // significant_entry = false;
+        }
       }
     }
   }
   // a significant entry has been found
   // and the reader has been updated accordingly
-  bgpstream_debug("\t\tBSR: read new data: end");  
+  bgpstream_debug("\t\tBSR: read new data: end");
   return;
 }
 
-static void bgpstream_reader_destroy(bgpstream_reader_t * const bs_reader) {
+static void bgpstream_reader_destroy(bgpstream_reader_t *const bs_reader)
+{
 
   bgpstream_debug("\t\tBSR: destroy reader start");
-  if(bs_reader == NULL) {
-    bgpstream_debug("\t\tBSR: destroy reader: null reader provided");    
+  if (bs_reader == NULL) {
+    bgpstream_debug("\t\tBSR: destroy reader: null reader provided");
     return;
   }
 
@@ -269,25 +274,28 @@ static void bgpstream_reader_destroy(bgpstream_reader_t * const bs_reader) {
   bs_reader->bd_entry = NULL;
   // close bgpdump
   bgpdump_close_dump(bs_reader->bd_mgr);
-  bs_reader->bd_mgr = NULL;  
+  bs_reader->bd_mgr = NULL;
   // deallocate all memory for reader
   free(bs_reader);
   bgpstream_debug("\t\tBSR: destroy reader end");
 }
 
-static bgpstream_reader_t * bgpstream_reader_create(const bgpstream_input_t * const bs_input,
-						    const bgpstream_filter_mgr_t * const filter_mgr) {
+static bgpstream_reader_t *
+bgpstream_reader_create(const bgpstream_input_t *const bs_input,
+                        const bgpstream_filter_mgr_t *const filter_mgr)
+{
   bgpstream_debug("\t\tBSR: create reader start");
-  if(bs_input == NULL) {
+  if (bs_input == NULL) {
     bgpstream_debug("\t\tBSR: create reader: empty bs_input provided");
     bgpstream_debug("\t\tBSR: create reader end");
     return NULL; // no input to read
   }
   // allocate memory for reader
-  bgpstream_reader_t *bs_reader = (bgpstream_reader_t*) malloc(sizeof(bgpstream_reader_t));
-  if(bs_reader == NULL) {
+  bgpstream_reader_t *bs_reader =
+    (bgpstream_reader_t *)malloc(sizeof(bgpstream_reader_t));
+  if (bs_reader == NULL) {
     bgpstream_debug("\t\tBSR: create reader: can't allocate memory for reader");
-    bgpstream_debug("\t\tBSR: create reader end"); 
+    bgpstream_debug("\t\tBSR: create reader end");
     return NULL; // can't allocate memory for reader
   }
   bgpstream_debug("\t\tBSR: create reader: initialize fields");
@@ -295,10 +303,10 @@ static bgpstream_reader_t * bgpstream_reader_create(const bgpstream_input_t * co
   bs_reader->next = NULL;
   bs_reader->bd_mgr = NULL;
   bs_reader->bd_entry = NULL;
-  //memset(bs_reader->dump_name, 0, BGPSTREAM_DUMP_MAX_LEN);
-  //memset(bs_reader->dump_project, 0, BGPSTREAM_PAR_MAX_LEN);
-  //memset(bs_reader->dump_collector, 0, BGPSTREAM_PAR_MAX_LEN);
-  //memset(bs_reader->dump_type, 0, BGPSTREAM_PAR_MAX_LEN);
+  // memset(bs_reader->dump_name, 0, BGPSTREAM_DUMP_MAX_LEN);
+  // memset(bs_reader->dump_project, 0, BGPSTREAM_PAR_MAX_LEN);
+  // memset(bs_reader->dump_collector, 0, BGPSTREAM_PAR_MAX_LEN);
+  // memset(bs_reader->dump_type, 0, BGPSTREAM_PAR_MAX_LEN);
   // init done
   strcpy(bs_reader->dump_name, bs_input->filename);
   strcpy(bs_reader->dump_project, bs_input->fileproject);
@@ -306,12 +314,13 @@ static bgpstream_reader_t * bgpstream_reader_create(const bgpstream_input_t * co
   strcpy(bs_reader->dump_type, bs_input->filetype);
   bs_reader->dump_time = bs_input->epoch_filetime;
   bs_reader->record_time = bs_input->epoch_filetime;
-  bs_reader->status = BGPSTREAM_READER_STATUS_VALID_ENTRY; // let's be optimistic :)
+  bs_reader->status =
+    BGPSTREAM_READER_STATUS_VALID_ENTRY; // let's be optimistic :)
   bs_reader->valid_read = 0;
   bs_reader->successful_read = 0;
 
   pthread_mutex_init(&bs_reader->mutex, NULL);
-  pthread_cond_init(&bs_reader->dump_ready_cond,NULL);
+  pthread_cond_init(&bs_reader->dump_ready_cond, NULL);
   bs_reader->dump_ready = 0;
   bs_reader->skip_dump_check = 0;
 
@@ -326,55 +335,54 @@ static bgpstream_reader_t * bgpstream_reader_create(const bgpstream_input_t * co
   return bs_reader;
 }
 
-
-
-static void bgpstream_reader_export_record(bgpstream_reader_t * const bs_reader, 
-					   bgpstream_record_t * const bs_record,
-                                           const bgpstream_filter_mgr_t *const filter_mgr) {
-  bgpstream_debug("\t\tBSR: export record: start");    
-  if(bs_reader == NULL) {
-    bgpstream_debug("\t\tBSR: export record: invalid reader provided");    
+static void
+bgpstream_reader_export_record(bgpstream_reader_t *const bs_reader,
+                               bgpstream_record_t *const bs_record,
+                               const bgpstream_filter_mgr_t *const filter_mgr)
+{
+  bgpstream_debug("\t\tBSR: export record: start");
+  if (bs_reader == NULL) {
+    bgpstream_debug("\t\tBSR: export record: invalid reader provided");
     return;
-  }  
-  if(bs_record == NULL) {
-    bgpstream_debug("\t\tBSR: export record: invalid record provided");    
+  }
+  if (bs_record == NULL) {
+    bgpstream_debug("\t\tBSR: export record: invalid record provided");
     return;
-  }  
-  // if bs_reader status is BGPSTREAM_READER_STATUS_END_OF_DUMP we shouldn't have called this
+  }
+  // if bs_reader status is BGPSTREAM_READER_STATUS_END_OF_DUMP we shouldn't
+  // have called this
   // function
-  if(bs_reader->status == BGPSTREAM_READER_STATUS_END_OF_DUMP) {
-    bgpstream_debug("\t\tBSR: export record: end of dump was reached");    
+  if (bs_reader->status == BGPSTREAM_READER_STATUS_END_OF_DUMP) {
+    bgpstream_debug("\t\tBSR: export record: end of dump was reached");
     return;
-  }  
+  }
   // read bgpstream_reader field and copy them to a bs_record
-  bgpstream_debug("\t\tBSR: export record: copying bd_entry");    
+  bgpstream_debug("\t\tBSR: export record: copying bd_entry");
   bs_record->bd_entry = bs_reader->bd_entry;
   // disconnect reader from exported entry
   bs_reader->bd_entry = NULL;
   // memset(bs_record->attributes.dump_project, 0, BGPSTREAM_PAR_MAX_LEN);
   // memset(bs_record->attributes.dump_collector, 0, BGPSTREAM_PAR_MAX_LEN);
-  bgpstream_debug("\t\tBSR: export record: copying attributes");    
+  bgpstream_debug("\t\tBSR: export record: copying attributes");
   strcpy(bs_record->attributes.dump_project, bs_reader->dump_project);
   strcpy(bs_record->attributes.dump_collector, bs_reader->dump_collector);
   //   strcpy(bs_record->attributes.dump_type, bs_reader->dump_type);
-  if(strcmp(bs_reader->dump_type, "ribs") == 0) {
+  if (strcmp(bs_reader->dump_type, "ribs") == 0) {
     bs_record->attributes.dump_type = BGPSTREAM_RIB;
-  }
-  else {
+  } else {
     bs_record->attributes.dump_type = BGPSTREAM_UPDATE;
   }
   bs_record->attributes.dump_time = bs_reader->dump_time;
   bs_record->attributes.record_time = bs_reader->record_time;
-  // if this is the first significant record and no previous 
+  // if this is the first significant record and no previous
   // valid record has been discarded because of time
-  if(bs_reader->valid_read == 1 && bs_reader->successful_read == 1) {
+  if (bs_reader->valid_read == 1 && bs_reader->successful_read == 1) {
     bs_record->dump_pos = BGPSTREAM_DUMP_START;
-  }
-  else {
+  } else {
     bs_record->dump_pos = BGPSTREAM_DUMP_MIDDLE;
   }
-  bgpstream_debug("\t\tBSR: export record: copying status");    
-  switch(bs_reader->status){
+  bgpstream_debug("\t\tBSR: export record: copying status");
+  switch (bs_reader->status) {
   case BGPSTREAM_READER_STATUS_VALID_ENTRY:
     bs_record->status = BGPSTREAM_RECORD_STATUS_VALID_RECORD;
     break;
@@ -393,64 +401,62 @@ static void bgpstream_reader_export_record(bgpstream_reader_t * const bs_reader,
   default:
     bs_record->status = BGPSTREAM_RECORD_STATUS_EMPTY_SOURCE;
   }
-  bgpstream_debug("Exported: %ld\t%ld\t%d\t%s\t%d", 		   
-		   bs_record->attributes.record_time,
-		   bs_record->attributes.dump_time,
-		   bs_record->attributes.dump_type, 
-		   bs_record->attributes.dump_collector,
-		   bs_record->status);
+  bgpstream_debug(
+    "Exported: %ld\t%ld\t%d\t%s\t%d", bs_record->attributes.record_time,
+    bs_record->attributes.dump_time, bs_record->attributes.dump_type,
+    bs_record->attributes.dump_collector, bs_record->status);
 
   /** safe option for rib period filter*/
   char buffer[BUFFER_LEN];
   khiter_t k;
   int khret;
-  if(filter_mgr->rib_period != 0 &&
-     (bs_record->status == BGPSTREAM_RECORD_STATUS_CORRUPTED_SOURCE ||
-      bs_record->status == BGPSTREAM_RECORD_STATUS_CORRUPTED_RECORD))
-    {
-      snprintf(buffer, BUFFER_LEN, "%s.%s",
-               bs_record->attributes.dump_project, bs_record->attributes.dump_collector);
-      if((k = kh_get(collector_ts, filter_mgr->last_processed_ts,
-                     buffer)) == kh_end(filter_mgr->last_processed_ts))
-        {
-          k = kh_put(collector_ts, filter_mgr->last_processed_ts,
-                     strdup(buffer), &khret);
-        }
-      kh_value(filter_mgr->last_processed_ts, k) = 0;
+  if (filter_mgr->rib_period != 0 &&
+      (bs_record->status == BGPSTREAM_RECORD_STATUS_CORRUPTED_SOURCE ||
+       bs_record->status == BGPSTREAM_RECORD_STATUS_CORRUPTED_RECORD)) {
+    snprintf(buffer, BUFFER_LEN, "%s.%s", bs_record->attributes.dump_project,
+             bs_record->attributes.dump_collector);
+    if ((k = kh_get(collector_ts, filter_mgr->last_processed_ts, buffer)) ==
+        kh_end(filter_mgr->last_processed_ts)) {
+      k = kh_put(collector_ts, filter_mgr->last_processed_ts, strdup(buffer),
+                 &khret);
     }
+    kh_value(filter_mgr->last_processed_ts, k) = 0;
+  }
 
-  bgpstream_debug("\t\tBSR: export record: end");    
+  bgpstream_debug("\t\tBSR: export record: end");
 }
 
-
- //function used for debug
-static void print_reader_queue(const bgpstream_reader_t * const reader_queue) {
+// function used for debug
+static void print_reader_queue(const bgpstream_reader_t *const reader_queue)
+{
 #ifdef NDEBUG
-  const bgpstream_reader_t * iterator = reader_queue;
+  const bgpstream_reader_t *iterator = reader_queue;
   bgpstream_debug("READER QUEUE: start");
   int i = 1;
-  while(iterator != NULL) {    
-    bgpstream_debug("\t%d %s %s %ld %ld %d",i, iterator->dump_collector, iterator->dump_type, iterator->dump_time, iterator->record_time, iterator->status);
+  while (iterator != NULL) {
+    bgpstream_debug("\t%d %s %s %ld %ld %d", i, iterator->dump_collector,
+                    iterator->dump_type, iterator->dump_time,
+                    iterator->record_time, iterator->status);
     iterator = iterator->next;
     i++;
   }
   iterator = NULL;
-  bgpstream_debug("\nREADER QUEUE: end");  
+  bgpstream_debug("\nREADER QUEUE: end");
 #endif
 }
 
-
-
-
 /* -------------- Reader mgr functions -------------- */
 
-
-bgpstream_reader_mgr_t * bgpstream_reader_mgr_create(const bgpstream_filter_mgr_t * const filter_mgr) {
+bgpstream_reader_mgr_t *
+bgpstream_reader_mgr_create(const bgpstream_filter_mgr_t *const filter_mgr)
+{
   bgpstream_debug("\tBSR_MGR: create reader mgr: start");
   // allocate memory and initialize fields
-  bgpstream_reader_mgr_t *bs_reader_mgr = (bgpstream_reader_mgr_t*) malloc(sizeof(bgpstream_reader_mgr_t));
-  if(bs_reader_mgr == NULL) {
-    bgpstream_debug("\tBSR_MGR: create reader mgr: can't allocate memory for reader mgr");
+  bgpstream_reader_mgr_t *bs_reader_mgr =
+    (bgpstream_reader_mgr_t *)malloc(sizeof(bgpstream_reader_mgr_t));
+  if (bs_reader_mgr == NULL) {
+    bgpstream_debug(
+      "\tBSR_MGR: create reader mgr: can't allocate memory for reader mgr");
     bgpstream_debug("\tBSR_MGR: create reader mgr end");
     return NULL; // can't allocate memory for reader
   }
@@ -463,124 +469,124 @@ bgpstream_reader_mgr_t * bgpstream_reader_mgr_create(const bgpstream_filter_mgr_
   return bs_reader_mgr;
 }
 
-
-bool bgpstream_reader_mgr_is_empty(const bgpstream_reader_mgr_t * const bs_reader_mgr) {
+bool bgpstream_reader_mgr_is_empty(
+  const bgpstream_reader_mgr_t *const bs_reader_mgr)
+{
   bgpstream_debug("\tBSR_MGR: is_empty start");
-  if(bs_reader_mgr == NULL) {
-  bgpstream_debug("\tBSR_MGR: is_empty end: empty!");
-    return true;
-  }
-  if(bs_reader_mgr->status == BGPSTREAM_READER_MGR_STATUS_EMPTY_READER_MGR) {
+  if (bs_reader_mgr == NULL) {
     bgpstream_debug("\tBSR_MGR: is_empty end: empty!");
     return true;
   }
-  else {
+  if (bs_reader_mgr->status == BGPSTREAM_READER_MGR_STATUS_EMPTY_READER_MGR) {
+    bgpstream_debug("\tBSR_MGR: is_empty end: empty!");
+    return true;
+  } else {
     bgpstream_debug("\tBSR_MGR: is_empty end: non-empty!");
     return false;
   }
 }
 
-
-static void bgpstream_reader_mgr_sorted_insert(bgpstream_reader_mgr_t * const bs_reader_mgr, 
-					       bgpstream_reader_t * const bs_reader) {
+static void
+bgpstream_reader_mgr_sorted_insert(bgpstream_reader_mgr_t *const bs_reader_mgr,
+                                   bgpstream_reader_t *const bs_reader)
+{
   bgpstream_debug("\tBSR_MGR: sorted insert:start");
-  if(bs_reader_mgr == NULL) {
-    bgpstream_debug("\tBSR_MGR: sorted insert: null reader mgr provided");    
+  if (bs_reader_mgr == NULL) {
+    bgpstream_debug("\tBSR_MGR: sorted insert: null reader mgr provided");
     return;
   }
-  if(bs_reader == NULL) {
-    bgpstream_debug("\tBSR_MGR: sorted insert: null reader provided");    
+  if (bs_reader == NULL) {
+    bgpstream_debug("\tBSR_MGR: sorted insert: null reader provided");
     return;
-  }  
+  }
 
-  bgpstream_reader_t * iterator = bs_reader_mgr->reader_queue;
-  bgpstream_reader_t * previous_iterator = bs_reader_mgr->reader_queue;
+  bgpstream_reader_t *iterator = bs_reader_mgr->reader_queue;
+  bgpstream_reader_t *previous_iterator = bs_reader_mgr->reader_queue;
   bool inserted = false;
   // insert new reader in priority queue
-  while(!inserted) {    
+  while (!inserted) {
     // case 1: insertion in empty queue (reader_queue == NULL)
-    if(bs_reader_mgr->status == BGPSTREAM_READER_MGR_STATUS_EMPTY_READER_MGR) {
+    if (bs_reader_mgr->status == BGPSTREAM_READER_MGR_STATUS_EMPTY_READER_MGR) {
       bs_reader_mgr->reader_queue = bs_reader;
       bs_reader->next = NULL;
-      bs_reader_mgr->status = BGPSTREAM_READER_MGR_STATUS_NON_EMPTY_READER_MGR;  
+      bs_reader_mgr->status = BGPSTREAM_READER_MGR_STATUS_NON_EMPTY_READER_MGR;
       inserted = true;
       continue;
     }
     // case 2: insertion in non-empty queue
     else {
       // reached the end of the queue
-      if(iterator == NULL) {
-	previous_iterator->next = bs_reader;
-	bs_reader->next = NULL;
-	inserted = true;
-	continue;
+      if (iterator == NULL) {
+        previous_iterator->next = bs_reader;
+        bs_reader->next = NULL;
+        inserted = true;
+        continue;
       }
       // still in the middle of the queue
       else {
-	// if time is the same
-	if(bs_reader->record_time == iterator->record_time) {
-	  // if type is the same -> continue
-	  if(strcmp(iterator->dump_type, bs_reader->dump_type) == 0){
-	    previous_iterator = iterator;
-	    iterator = previous_iterator->next;
-	    continue;
-	  }
-	  // if the queue contains ribs, and the current reader
-	  // is an update -> continue
-	  if(strcmp(iterator->dump_type, "ribs") == 0 &&
-	     strcmp(bs_reader->dump_type, "updates") == 0){
-	    previous_iterator = iterator;
-	    iterator = previous_iterator->next;
-	    continue;
-	  }
-	  // if the queue contains updates, and the current reader 
-	  // is a rib -> insert
-	  if(strcmp(iterator->dump_type, "updates") == 0 &&
-	     strcmp(bs_reader->dump_type, "ribs") == 0){
-	    // insertion at the beginning of the queue
-	    if(previous_iterator == bs_reader_mgr->reader_queue &&
-	       iterator == bs_reader_mgr->reader_queue) {
-	      bs_reader->next = bs_reader_mgr->reader_queue;
-	      bs_reader_mgr->reader_queue = bs_reader;
-	    }
-	    // insertion in the middle of the queue
-	    else {
-	      previous_iterator->next = bs_reader;
-	      bs_reader->next = iterator;
-	    }
-	    inserted = true;
-	    continue;
-	  }
-	}
-	// if time is different
-	else {
-	  // if reader time is lower than iterator time
-	  // then insert
-	  if(bs_reader->record_time < iterator->record_time) {
-	    // insertion at the beginning of the queue
-	    if(previous_iterator == bs_reader_mgr->reader_queue &&
-	       iterator == bs_reader_mgr->reader_queue) {
-	      bs_reader->next = bs_reader_mgr->reader_queue;
-	      bs_reader_mgr->reader_queue = bs_reader;
-	    }
-	    // insertion in the middle of the queue
-	    else {
-	      previous_iterator->next = bs_reader;
-	      bs_reader->next = iterator;
-	    }
-	    inserted = true;	    
-	    continue;
-	  }
-	}
-	// otherwise update the iterators
-	previous_iterator = iterator;
-	iterator = previous_iterator->next;
-      }      
-    }  
+        // if time is the same
+        if (bs_reader->record_time == iterator->record_time) {
+          // if type is the same -> continue
+          if (strcmp(iterator->dump_type, bs_reader->dump_type) == 0) {
+            previous_iterator = iterator;
+            iterator = previous_iterator->next;
+            continue;
+          }
+          // if the queue contains ribs, and the current reader
+          // is an update -> continue
+          if (strcmp(iterator->dump_type, "ribs") == 0 &&
+              strcmp(bs_reader->dump_type, "updates") == 0) {
+            previous_iterator = iterator;
+            iterator = previous_iterator->next;
+            continue;
+          }
+          // if the queue contains updates, and the current reader
+          // is a rib -> insert
+          if (strcmp(iterator->dump_type, "updates") == 0 &&
+              strcmp(bs_reader->dump_type, "ribs") == 0) {
+            // insertion at the beginning of the queue
+            if (previous_iterator == bs_reader_mgr->reader_queue &&
+                iterator == bs_reader_mgr->reader_queue) {
+              bs_reader->next = bs_reader_mgr->reader_queue;
+              bs_reader_mgr->reader_queue = bs_reader;
+            }
+            // insertion in the middle of the queue
+            else {
+              previous_iterator->next = bs_reader;
+              bs_reader->next = iterator;
+            }
+            inserted = true;
+            continue;
+          }
+        }
+        // if time is different
+        else {
+          // if reader time is lower than iterator time
+          // then insert
+          if (bs_reader->record_time < iterator->record_time) {
+            // insertion at the beginning of the queue
+            if (previous_iterator == bs_reader_mgr->reader_queue &&
+                iterator == bs_reader_mgr->reader_queue) {
+              bs_reader->next = bs_reader_mgr->reader_queue;
+              bs_reader_mgr->reader_queue = bs_reader;
+            }
+            // insertion in the middle of the queue
+            else {
+              previous_iterator->next = bs_reader;
+              bs_reader->next = iterator;
+            }
+            inserted = true;
+            continue;
+          }
+        }
+        // otherwise update the iterators
+        previous_iterator = iterator;
+        iterator = previous_iterator->next;
+      }
+    }
   }
   bgpstream_debug("\tBSR_MGR: sorted insert: end");
 }
-
 
 static int
 bgpstream_reader_period_check(const bgpstream_input_t *in,
@@ -591,112 +597,105 @@ bgpstream_reader_period_check(const bgpstream_input_t *in,
   khiter_t k;
   int khret;
 
-  if((filter_mgr->rib_period != 0  &&
-      strcmp(in->filetype, "ribs") == 0))      
-    {
-      snprintf(buffer, BUFFER_LEN, "%s.%s",
-               in->fileproject, in->filecollector);             
-      /* first instance */
-      if((k = kh_get(collector_ts, filter_mgr->last_processed_ts,
-                     buffer)) == kh_end(filter_mgr->last_processed_ts))
-        {
-          k = kh_put(collector_ts, filter_mgr->last_processed_ts,
-                     strdup(buffer), &khret);
-          kh_value(filter_mgr->last_processed_ts, k) = in->epoch_filetime;
-          return 1;
-        }
-
-      /* we have to check the frequency only if we get a new filetime */
-      if(in->epoch_filetime != kh_value(filter_mgr->last_processed_ts, k))
-        {
-          if(in->epoch_filetime <
-             kh_value(filter_mgr->last_processed_ts, k) + filter_mgr->rib_period)
-            {
-              return 0;
-            }
-          kh_value(filter_mgr->last_processed_ts, k) = in->epoch_filetime;
-        }
+  if ((filter_mgr->rib_period != 0 && strcmp(in->filetype, "ribs") == 0)) {
+    snprintf(buffer, BUFFER_LEN, "%s.%s", in->fileproject, in->filecollector);
+    /* first instance */
+    if ((k = kh_get(collector_ts, filter_mgr->last_processed_ts, buffer)) ==
+        kh_end(filter_mgr->last_processed_ts)) {
+      k = kh_put(collector_ts, filter_mgr->last_processed_ts, strdup(buffer),
+                 &khret);
+      kh_value(filter_mgr->last_processed_ts, k) = in->epoch_filetime;
+      return 1;
     }
+
+    /* we have to check the frequency only if we get a new filetime */
+    if (in->epoch_filetime != kh_value(filter_mgr->last_processed_ts, k)) {
+      if (in->epoch_filetime <
+          kh_value(filter_mgr->last_processed_ts, k) + filter_mgr->rib_period) {
+        return 0;
+      }
+      kh_value(filter_mgr->last_processed_ts, k) = in->epoch_filetime;
+    }
+  }
 
   return 1;
 }
 
-
-void bgpstream_reader_mgr_add(bgpstream_reader_mgr_t * const bs_reader_mgr, 
-			      const bgpstream_input_t * const toprocess_queue,
-			      const bgpstream_filter_mgr_t * const filter_mgr) {
+void bgpstream_reader_mgr_add(bgpstream_reader_mgr_t *const bs_reader_mgr,
+                              const bgpstream_input_t *const toprocess_queue,
+                              const bgpstream_filter_mgr_t *const filter_mgr)
+{
   bgpstream_debug("\tBSR_MGR: add input: start");
-  const bgpstream_input_t * iterator = toprocess_queue;
-  bgpstream_reader_t * bs_reader = NULL;
+  const bgpstream_input_t *iterator = toprocess_queue;
+  bgpstream_reader_t *bs_reader = NULL;
 
   /* tmp structure to hold reader pointers */
   bgpstream_reader_t **tmp_reader_queue = NULL;
   int i = 0;
   int max_readers = 0;
   int max = 0;
-  while(iterator != NULL) {
+  while (iterator != NULL) {
     max_readers++;
     iterator = iterator->next;
   }
-  tmp_reader_queue = (bgpstream_reader_t **) malloc(sizeof(bgpstream_reader_t *) * max_readers);
+  tmp_reader_queue =
+    (bgpstream_reader_t **)malloc(sizeof(bgpstream_reader_t *) * max_readers);
 
   /* foreach  bgpstream input add it to the queue and create a reader */
   iterator = toprocess_queue;
-  while(iterator != NULL) {
-    if(bgpstream_reader_period_check(iterator, filter_mgr))
-      {        
-        bgpstream_debug("\tBSR_MGR: add input: i");
-        // a) create a new reader (create includes the first read)
-        bs_reader = bgpstream_reader_create(iterator, filter_mgr);
-        // if it creates correctly then add it to the temporary queue
-        if(bs_reader != NULL) {
-          tmp_reader_queue[i] = bs_reader;
-          i++;
-        }
-        else{
-          bgpstream_log_err("ERROR: could not create reader\n");
-          return;
-        }
+  while (iterator != NULL) {
+    if (bgpstream_reader_period_check(iterator, filter_mgr)) {
+      bgpstream_debug("\tBSR_MGR: add input: i");
+      // a) create a new reader (create includes the first read)
+      bs_reader = bgpstream_reader_create(iterator, filter_mgr);
+      // if it creates correctly then add it to the temporary queue
+      if (bs_reader != NULL) {
+        tmp_reader_queue[i] = bs_reader;
+        i++;
+      } else {
+        bgpstream_log_err("ERROR: could not create reader\n");
+        return;
       }
+    }
     // go to the next input
     iterator = iterator->next;
   }
-  /* then for each reader read the first record and add it to the reader queue */
+  /* then for each reader read the first record and add it to the reader queue
+   */
   max = i;
-  for(i =0; i < max; i++)
-    {
-      bs_reader = tmp_reader_queue[i];
-      bgpstream_reader_read_new_data(bs_reader, filter_mgr);
-      bgpstream_reader_mgr_sorted_insert(bs_reader_mgr, bs_reader);
-    }
+  for (i = 0; i < max; i++) {
+    bs_reader = tmp_reader_queue[i];
+    bgpstream_reader_read_new_data(bs_reader, filter_mgr);
+    bgpstream_reader_mgr_sorted_insert(bs_reader_mgr, bs_reader);
+  }
   free(tmp_reader_queue);
   tmp_reader_queue = NULL;
   print_reader_queue(bs_reader_mgr->reader_queue);
   bgpstream_debug("\tBSR_MGR: add input: end");
 }
 
-
-
-int bgpstream_reader_mgr_get_next_record(bgpstream_reader_mgr_t * const bs_reader_mgr, 
-					 bgpstream_record_t *const bs_record,
-					 const bgpstream_filter_mgr_t * const filter_mgr) {
+int bgpstream_reader_mgr_get_next_record(
+  bgpstream_reader_mgr_t *const bs_reader_mgr,
+  bgpstream_record_t *const bs_record,
+  const bgpstream_filter_mgr_t *const filter_mgr)
+{
   bgpstream_debug("\tBSR_MGR: get_next_record: start");
-  if(bs_reader_mgr == NULL) {
-    bgpstream_debug("\tBSR_MGR: get_next_record: null reader mgr provided");    
+  if (bs_reader_mgr == NULL) {
+    bgpstream_debug("\tBSR_MGR: get_next_record: null reader mgr provided");
     return -1;
   }
-  if(bs_record == NULL) {
-    bgpstream_debug("BSR_MGR: get_next_record: null record provided");    
+  if (bs_record == NULL) {
+    bgpstream_debug("BSR_MGR: get_next_record: null record provided");
     return -1;
   }
-  if(bs_reader_mgr->status == BGPSTREAM_READER_MGR_STATUS_EMPTY_READER_MGR) {
-    bgpstream_debug("\tBSR_MGR: get_next_record: empty reader mgr");    
+  if (bs_reader_mgr->status == BGPSTREAM_READER_MGR_STATUS_EMPTY_READER_MGR) {
+    bgpstream_debug("\tBSR_MGR: get_next_record: empty reader mgr");
     return 0;
   }
-  // get head from reader queue 
+  // get head from reader queue
   bgpstream_reader_t *bs_reader = bs_reader_mgr->reader_queue;
   bs_reader_mgr->reader_queue = bs_reader_mgr->reader_queue->next;
-  if(bs_reader_mgr->reader_queue == NULL) { // check if last reader
+  if (bs_reader_mgr->reader_queue == NULL) { // check if last reader
     bs_reader_mgr->status = BGPSTREAM_READER_MGR_STATUS_EMPTY_READER_MGR;
   }
   // disconnect reader from the queue
@@ -709,13 +708,13 @@ int bgpstream_reader_mgr_get_next_record(bgpstream_reader_mgr_t * const bs_reade
   int read_diff = bs_reader->successful_read - bs_reader->valid_read;
   // if previous read was successful, we read next
   // entry from same reader
-  if(bs_reader->status == BGPSTREAM_READER_STATUS_VALID_ENTRY) {
+  if (bs_reader->status == BGPSTREAM_READER_STATUS_VALID_ENTRY) {
     bgpstream_reader_read_new_data(bs_reader, filter_mgr);
     // if end of dump is reached after a successful read (already exported)
     // we destroy the reader
-    if(bs_reader->status == BGPSTREAM_READER_STATUS_END_OF_DUMP) {
-      if((bs_reader->successful_read - bs_reader->valid_read) == read_diff) {
-	bs_record->dump_pos = BGPSTREAM_DUMP_END;
+    if (bs_reader->status == BGPSTREAM_READER_STATUS_END_OF_DUMP) {
+      if ((bs_reader->successful_read - bs_reader->valid_read) == read_diff) {
+        bs_record->dump_pos = BGPSTREAM_DUMP_END;
       }
       // otherwise we maintain the dump_pos already assigned
       bgpstream_reader_destroy(bs_reader);
@@ -731,21 +730,21 @@ int bgpstream_reader_mgr_get_next_record(bgpstream_reader_mgr_t * const bs_reade
     bgpstream_reader_destroy(bs_reader);
   }
   bgpstream_debug("\tBSR_MGR: get_next_record: end");
-  return 1; 
+  return 1;
 }
 
-
-void bgpstream_reader_mgr_destroy(bgpstream_reader_mgr_t * const bs_reader_mgr) {
+void bgpstream_reader_mgr_destroy(bgpstream_reader_mgr_t *const bs_reader_mgr)
+{
   bgpstream_debug("\tBSR_MGR: destroy reader mgr: start");
-  if(bs_reader_mgr == NULL) {
-    bgpstream_debug("\tBSR_MGR: destroy reader mgr:  null reader mgr provided");    
+  if (bs_reader_mgr == NULL) {
+    bgpstream_debug("\tBSR_MGR: destroy reader mgr:  null reader mgr provided");
     return;
   }
   bs_reader_mgr->filter_mgr = NULL;
-  bgpstream_debug("\tBSR_MGR: destroy reader mgr:  destroying reader queue");    
+  bgpstream_debug("\tBSR_MGR: destroy reader mgr:  destroying reader queue");
   // foreach reader in queue: destroy reader
   bgpstream_reader_t *iterator;
-  while(bs_reader_mgr->reader_queue !=NULL){
+  while (bs_reader_mgr->reader_queue != NULL) {
     // at every step we destroy the reader referenced
     // by the reader_queue
     iterator = bs_reader_mgr->reader_queue;
@@ -756,4 +755,3 @@ void bgpstream_reader_mgr_destroy(bgpstream_reader_mgr_t * const bs_reader_mgr) 
   free(bs_reader_mgr);
   bgpstream_debug("\tBSR_MGR: destroy reader mgr: end");
 }
-

--- a/lib/bgpstream_reader.h
+++ b/lib/bgpstream_reader.h
@@ -28,19 +28,18 @@
 #include <stdbool.h>
 
 #include "bgpstream_constants.h"
-#include "bgpstream_record.h"
+#include "bgpstream_filter.h"
 #include "bgpstream_input.h"
-#include "bgpstream_filter.h" 
+#include "bgpstream_record.h"
 
 #include <bgpdump_lib.h>
 
-
 typedef enum {
-  BGPSTREAM_READER_STATUS_VALID_ENTRY, 
-  BGPSTREAM_READER_STATUS_FILTERED_DUMP, 
-  BGPSTREAM_READER_STATUS_EMPTY_DUMP, 
-  BGPSTREAM_READER_STATUS_CANT_OPEN_DUMP, 
-  BGPSTREAM_READER_STATUS_CORRUPTED_DUMP, 
+  BGPSTREAM_READER_STATUS_VALID_ENTRY,
+  BGPSTREAM_READER_STATUS_FILTERED_DUMP,
+  BGPSTREAM_READER_STATUS_EMPTY_DUMP,
+  BGPSTREAM_READER_STATUS_CANT_OPEN_DUMP,
+  BGPSTREAM_READER_STATUS_CORRUPTED_DUMP,
   BGPSTREAM_READER_STATUS_END_OF_DUMP
 } bgpstream_reader_status_t;
 
@@ -57,24 +56,25 @@ typedef struct struct_bgpstream_reader_mgr_t {
   bgpstream_reader_mgr_status_t status;
 } bgpstream_reader_mgr_t;
 
-
-
 /* create a new reader mgr */
-bgpstream_reader_mgr_t * bgpstream_reader_mgr_create(const bgpstream_filter_mgr_t * const filter_mgr);
+bgpstream_reader_mgr_t *
+bgpstream_reader_mgr_create(const bgpstream_filter_mgr_t *const filter_mgr);
 /* check if the readers' queue is empty  */
-bool bgpstream_reader_mgr_is_empty(const bgpstream_reader_mgr_t * const bs_reader_mgr);
+bool bgpstream_reader_mgr_is_empty(
+  const bgpstream_reader_mgr_t *const bs_reader_mgr);
 
 /* use a list of inputs to populate the readers' queue */
-void bgpstream_reader_mgr_add(bgpstream_reader_mgr_t * const bs_reader_mgr, 
-			      const bgpstream_input_t * const toprocess_queue,
-			      const bgpstream_filter_mgr_t * const filter_mgr);
+void bgpstream_reader_mgr_add(bgpstream_reader_mgr_t *const bs_reader_mgr,
+                              const bgpstream_input_t *const toprocess_queue,
+                              const bgpstream_filter_mgr_t *const filter_mgr);
 
 /* get the next available record (and update the reader mgr status) */
-int bgpstream_reader_mgr_get_next_record(bgpstream_reader_mgr_t * const bs_reader_mgr, 
-					 bgpstream_record_t *const bs_record,
-					 const bgpstream_filter_mgr_t * const filter_mgr);
+int bgpstream_reader_mgr_get_next_record(
+  bgpstream_reader_mgr_t *const bs_reader_mgr,
+  bgpstream_record_t *const bs_record,
+  const bgpstream_filter_mgr_t *const filter_mgr);
 
 /* destroy the reader manager */
-void bgpstream_reader_mgr_destroy(bgpstream_reader_mgr_t * const bs_reader_mgr);
+void bgpstream_reader_mgr_destroy(bgpstream_reader_mgr_t *const bs_reader_mgr);
 
 #endif /* _BGPSTREAM_READER_H */

--- a/lib/bgpstream_record.c
+++ b/lib/bgpstream_record.c
@@ -21,34 +21,34 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <assert.h>
 #include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 #include "bgpdump_lib.h"
 #include "bgpdump_process.h"
 
-#include "bgpstream_record.h"
-#include "bgpstream_elem_generator.h"
 #include "bgpstream_elem_int.h"
-#include "bgpstream_debug.h"
 #include "bgpstream_int.h"
-
+#include "bgpstream_debug.h"
+#include "bgpstream_elem_generator.h"
+#include "bgpstream_record.h"
 
 /* allocate memory for a bs_record */
-bgpstream_record_t *bgpstream_record_create() {
+bgpstream_record_t *bgpstream_record_create()
+{
   bgpstream_debug("BS: create record start");
   bgpstream_record_t *bs_record;
-  if((bs_record =
-      (bgpstream_record_t*)malloc(sizeof(bgpstream_record_t))) == NULL) {
+  if ((bs_record = (bgpstream_record_t *)malloc(sizeof(bgpstream_record_t))) ==
+      NULL) {
     return NULL; // can't allocate memory
   }
 
   bs_record->bs = NULL;
   bs_record->bd_entry = NULL;
 
-  if((bs_record->elem_generator = bgpstream_elem_generator_create()) == NULL) {
+  if ((bs_record->elem_generator = bgpstream_elem_generator_create()) == NULL) {
     bgpstream_record_destroy(bs_record);
     return NULL;
   }
@@ -60,19 +60,20 @@ bgpstream_record_t *bgpstream_record_create() {
 }
 
 /* free memory associated to a bs_record  */
-void bgpstream_record_destroy(bgpstream_record_t * const bs_record){
+void bgpstream_record_destroy(bgpstream_record_t *const bs_record)
+{
   bgpstream_debug("BS: destroy record start");
-  if(bs_record == NULL) {
+  if (bs_record == NULL) {
     bgpstream_debug("BS: record destroy end");
     return; // nothing to do
   }
-  if(bs_record->bd_entry != NULL){
+  if (bs_record->bd_entry != NULL) {
     bgpstream_debug("BS - free bs_record->bgpdump_entry");
     bgpdump_free_mem(bs_record->bd_entry);
     bs_record->bd_entry = NULL;
   }
 
-  if(bs_record->elem_generator != NULL) {
+  if (bs_record->elem_generator != NULL) {
     bgpstream_elem_generator_destroy(bs_record->elem_generator);
     bs_record->elem_generator = NULL;
   }
@@ -82,7 +83,8 @@ void bgpstream_record_destroy(bgpstream_record_t * const bs_record){
   bgpstream_debug("BS: destroy record end");
 }
 
-void bgpstream_record_clear(bgpstream_record_t *record) {
+void bgpstream_record_clear(bgpstream_record_t *record)
+{
   record->status = BGPSTREAM_RECORD_STATUS_EMPTY_SOURCE;
   record->dump_pos = BGPSTREAM_DUMP_START;
   record->attributes.dump_project[0] = '\0';
@@ -91,7 +93,7 @@ void bgpstream_record_clear(bgpstream_record_t *record) {
   record->attributes.dump_time = 0;
   record->attributes.record_time = 0;
 
-  if(record->bd_entry != NULL) {
+  if (record->bd_entry != NULL) {
     bgpdump_free_mem(record->bd_entry);
     record->bd_entry = NULL;
   }
@@ -100,111 +102,102 @@ void bgpstream_record_clear(bgpstream_record_t *record) {
   bgpstream_elem_generator_clear(record->elem_generator);
 }
 
-void bgpstream_record_print_mrt_data(bgpstream_record_t * const bs_record) {
+void bgpstream_record_print_mrt_data(bgpstream_record_t *const bs_record)
+{
   bgpdump_print_entry(bs_record->bd_entry);
 }
 
-
-
-static int bgpstream_elem_check_filters(bgpstream_filter_mgr_t *filter_mgr, bgpstream_elem_t *elem)
+static int bgpstream_elem_check_filters(bgpstream_filter_mgr_t *filter_mgr,
+                                        bgpstream_elem_t *elem)
 {
   int pass = 0;
 
-  /* Checking peer ASNs: if the filter is on and the peer asn is not in the 
+  /* Checking peer ASNs: if the filter is on and the peer asn is not in the
    * set, return 0 */
-  if(filter_mgr->peer_asns &&
-     bgpstream_id_set_exists(filter_mgr->peer_asns, elem->peer_asnumber) == 0)
-    {
-      return 0;
-    }
+  if (filter_mgr->peer_asns &&
+      bgpstream_id_set_exists(filter_mgr->peer_asns, elem->peer_asnumber) ==
+        0) {
+    return 0;
+  }
 
   /* Checking prefixes (unless it is a peer state message) */
-  if(elem->type == BGPSTREAM_ELEM_TYPE_PEERSTATE)
-    {
-      return 1;
-    }
+  if (elem->type == BGPSTREAM_ELEM_TYPE_PEERSTATE) {
+    return 1;
+  }
 
-  if(filter_mgr->prefixes &&
-    (bgpstream_patricia_tree_get_pfx_overlap_info(filter_mgr->prefixes,
-                                                  (bgpstream_pfx_t *) &elem->prefix) &
-     (BGPSTREAM_PATRICIA_EXACT_MATCH | BGPSTREAM_PATRICIA_LESS_SPECIFICS) ) == 0)
-    {
-      return 0;
-    }
+  if (filter_mgr->prefixes &&
+      (bgpstream_patricia_tree_get_pfx_overlap_info(
+         filter_mgr->prefixes, (bgpstream_pfx_t *)&elem->prefix) &
+       (BGPSTREAM_PATRICIA_EXACT_MATCH | BGPSTREAM_PATRICIA_LESS_SPECIFICS)) ==
+        0) {
+    return 0;
+  }
 
   /* Checking communities (unless it is a withdrawal message) */
-  if(elem->type == BGPSTREAM_ELEM_TYPE_WITHDRAWAL)
-    {
-      return 1;
-    }
+  if (elem->type == BGPSTREAM_ELEM_TYPE_WITHDRAWAL) {
+    return 1;
+  }
 
   pass = (filter_mgr->communities != NULL) ? 0 : 1;
-  if(filter_mgr->communities)
-    {
-      bgpstream_community_t *c;
-      khiter_t k;
-      for(k = kh_begin(filter_mgr->communities); k != kh_end(filter_mgr->communities); ++k)
-        {
-          if(kh_exist(filter_mgr->communities, k))
-            {
-              c = &(kh_key(filter_mgr->communities, k));
-              if(bgpstream_community_set_match(elem->communities, c,
-                                               kh_value(filter_mgr->communities, k)))
-                {
-                  pass = 1;
-                  break;
-                }
-            }
+  if (filter_mgr->communities) {
+    bgpstream_community_t *c;
+    khiter_t k;
+    for (k = kh_begin(filter_mgr->communities);
+         k != kh_end(filter_mgr->communities); ++k) {
+      if (kh_exist(filter_mgr->communities, k)) {
+        c = &(kh_key(filter_mgr->communities, k));
+        if (bgpstream_community_set_match(
+              elem->communities, c, kh_value(filter_mgr->communities, k))) {
+          pass = 1;
+          break;
         }
+      }
     }
+  }
   return pass;
 }
 
-bgpstream_elem_t *bgpstream_record_get_next_elem(bgpstream_record_t *record) {
-  if(bgpstream_elem_generator_is_populated(record->elem_generator) == 0 &&
-     bgpstream_elem_generator_populate(record->elem_generator, record) != 0)
-    {
-      return NULL;
-    }
-  bgpstream_elem_t *elem = bgpstream_elem_generator_get_next_elem(record->elem_generator);
+bgpstream_elem_t *bgpstream_record_get_next_elem(bgpstream_record_t *record)
+{
+  if (bgpstream_elem_generator_is_populated(record->elem_generator) == 0 &&
+      bgpstream_elem_generator_populate(record->elem_generator, record) != 0) {
+    return NULL;
+  }
+  bgpstream_elem_t *elem =
+    bgpstream_elem_generator_get_next_elem(record->elem_generator);
 
   /* if the elem is compatible with the current filters
    * then return elem, otherwise run again
    * bgpstream_record_get_next_elem(record) */
-  if(elem == NULL || bgpstream_elem_check_filters(record->bs->filter_mgr, elem) == 1)
-    {
-      return elem;
-    }
+  if (elem == NULL ||
+      bgpstream_elem_check_filters(record->bs->filter_mgr, elem) == 1) {
+    return elem;
+  }
 
   return bgpstream_record_get_next_elem(record);
 }
-
 
 int bgpstream_record_dump_type_snprintf(char *buf, size_t len,
                                         bgpstream_record_dump_type_t dump_type)
 {
   /* ensure we have enough bytes to write our single character */
-  if(len == 0)
-    {
-      return -1;
-    }
-  else if(len == 1)
-    {
-      buf[0] = '\0';
-      return -1;
-    }
-  switch(dump_type)
-    {
-    case BGPSTREAM_RIB:
-      buf[0] = 'R';
-      break;
-    case BGPSTREAM_UPDATE:
-      buf[0] = 'U';
-      break;
-    default:
-      buf[0] = '\0';
-      break;
-    }
+  if (len == 0) {
+    return -1;
+  } else if (len == 1) {
+    buf[0] = '\0';
+    return -1;
+  }
+  switch (dump_type) {
+  case BGPSTREAM_RIB:
+    buf[0] = 'R';
+    break;
+  case BGPSTREAM_UPDATE:
+    buf[0] = 'U';
+    break;
+  default:
+    buf[0] = '\0';
+    break;
+  }
   buf[1] = '\0';
   return 1;
 }
@@ -213,31 +206,27 @@ int bgpstream_record_dump_pos_snprintf(char *buf, size_t len,
                                        bgpstream_dump_position_t dump_pos)
 {
   /* ensure we have enough bytes to write our single character */
-  if(len == 0)
-    {
-      return -1;
-    }
-  else if(len == 1)
-    {
-      buf[0] = '\0';
-      return -1;
-    }
+  if (len == 0) {
+    return -1;
+  } else if (len == 1) {
+    buf[0] = '\0';
+    return -1;
+  }
 
-  switch(dump_pos)
-    {
-    case BGPSTREAM_DUMP_START:
-      buf[0] = 'B';
-      break;
-    case BGPSTREAM_DUMP_MIDDLE:
-      buf[0] = 'M';
-      break;
-    case BGPSTREAM_DUMP_END:
-      buf[0] = 'E';
-      break;
-    default:
-      buf[0] = '\0';
-      break;
-    }
+  switch (dump_pos) {
+  case BGPSTREAM_DUMP_START:
+    buf[0] = 'B';
+    break;
+  case BGPSTREAM_DUMP_MIDDLE:
+    buf[0] = 'M';
+    break;
+  case BGPSTREAM_DUMP_END:
+    buf[0] = 'E';
+    break;
+  default:
+    buf[0] = '\0';
+    break;
+  }
   buf[1] = '\0';
   return 1;
 }
@@ -246,111 +235,99 @@ int bgpstream_record_status_snprintf(char *buf, size_t len,
                                      bgpstream_record_status_t status)
 {
   /* ensure we have enough bytes to write our single character */
-  if(len == 0)
-    {
-      return -1;
-    }
-  else if(len == 1)
-    {
-      buf[0] = '\0';
-      return -1;
-    }
+  if (len == 0) {
+    return -1;
+  } else if (len == 1) {
+    buf[0] = '\0';
+    return -1;
+  }
 
-  switch(status)
-    {
-    case BGPSTREAM_RECORD_STATUS_VALID_RECORD:
-      buf[0] = 'V';
-      break;
-    case BGPSTREAM_RECORD_STATUS_FILTERED_SOURCE:
-      buf[0] = 'F';
-      break;
-    case BGPSTREAM_RECORD_STATUS_EMPTY_SOURCE:
-      buf[0] = 'E';
-      break;
-    case BGPSTREAM_RECORD_STATUS_CORRUPTED_SOURCE:
-      buf[0] = 'S';
-      break;
-    case BGPSTREAM_RECORD_STATUS_CORRUPTED_RECORD:
-      buf[0] = 'R';
-      break;
-    default:
-      buf[0] = '\0';
-      break;
-    }
+  switch (status) {
+  case BGPSTREAM_RECORD_STATUS_VALID_RECORD:
+    buf[0] = 'V';
+    break;
+  case BGPSTREAM_RECORD_STATUS_FILTERED_SOURCE:
+    buf[0] = 'F';
+    break;
+  case BGPSTREAM_RECORD_STATUS_EMPTY_SOURCE:
+    buf[0] = 'E';
+    break;
+  case BGPSTREAM_RECORD_STATUS_CORRUPTED_SOURCE:
+    buf[0] = 'S';
+    break;
+  case BGPSTREAM_RECORD_STATUS_CORRUPTED_RECORD:
+    buf[0] = 'R';
+    break;
+  default:
+    buf[0] = '\0';
+    break;
+  }
   buf[1] = '\0';
   return 1;
 }
 
-#define B_REMAIN (len-written)
-#define B_FULL   (written >= len)
-#define ADD_PIPE                                \
-  do {                                          \
-  if(B_REMAIN > 1)                              \
-    {                                           \
-      *buf_p = '|';                             \
-      buf_p++;                                  \
-      *buf_p = '\0';                            \
-      written++;                                \
-    }                                           \
-  else                                          \
-    {                                           \
-      return NULL;                              \
-    }                                           \
-  } while(0)
-
+#define B_REMAIN (len - written)
+#define B_FULL (written >= len)
+#define ADD_PIPE                                                               \
+  do {                                                                         \
+    if (B_REMAIN > 1) {                                                        \
+      *buf_p = '|';                                                            \
+      buf_p++;                                                                 \
+      *buf_p = '\0';                                                           \
+      written++;                                                               \
+    } else {                                                                   \
+      return NULL;                                                             \
+    }                                                                          \
+  } while (0)
 
 char *bgpstream_record_elem_snprintf(char *buf, size_t len,
-                                     const bgpstream_record_t * bs_record,
-                                     const bgpstream_elem_t * elem)
+                                     const bgpstream_record_t *bs_record,
+                                     const bgpstream_elem_t *elem)
 {
   assert(bs_record);
   assert(elem);
 
   size_t written = 0; /* < how many bytes we wanted to write */
-  ssize_t c = 0; /* < how many chars were written */
+  ssize_t c = 0;      /* < how many chars were written */
   char *buf_p = buf;
 
   /* Record type */
-  if((c = bgpstream_record_dump_type_snprintf(buf_p, B_REMAIN, bs_record->attributes.dump_type)) < 0)
-    {
-      return NULL;
-    }
+  if ((c = bgpstream_record_dump_type_snprintf(
+         buf_p, B_REMAIN, bs_record->attributes.dump_type)) < 0) {
+    return NULL;
+  }
   written += c;
   buf_p += c;
   ADD_PIPE;
 
   /* Elem type */
-  if((c = bgpstream_elem_type_snprintf(buf_p, B_REMAIN, elem->type)) < 0)
-    {
-      return NULL;
-    }
+  if ((c = bgpstream_elem_type_snprintf(buf_p, B_REMAIN, elem->type)) < 0) {
+    return NULL;
+  }
   written += c;
   buf_p += c;
   ADD_PIPE;
 
   /* Record timestamp, project, collector */
-  c = snprintf(buf_p, B_REMAIN, "%ld|%s|%s",
-               bs_record->attributes.record_time,
+  c = snprintf(buf_p, B_REMAIN, "%ld|%s|%s", bs_record->attributes.record_time,
                bs_record->attributes.dump_project,
                bs_record->attributes.dump_collector);
   written += c;
   buf_p += c;
   ADD_PIPE;
 
-  if(B_FULL)
+  if (B_FULL)
     return NULL;
 
-  if(bgpstream_elem_custom_snprintf(buf_p, B_REMAIN, elem, 0) == NULL)
-    {
-      return NULL;
-    }
+  if (bgpstream_elem_custom_snprintf(buf_p, B_REMAIN, elem, 0) == NULL) {
+    return NULL;
+  }
 
   written += c;
   buf_p += c;
 
-  if(B_FULL)
+  if (B_FULL)
     return NULL;
 
   return buf;
 }
-

--- a/lib/bgpstream_record.h
+++ b/lib/bgpstream_record.h
@@ -24,8 +24,8 @@
 #ifndef __BGPSTREAM_RECORD_H
 #define __BGPSTREAM_RECORD_H
 
-#include "bgpstream_utils.h"
 #include "bgpstream_elem.h"
+#include "bgpstream_utils.h"
 
 /** @file
  *
@@ -69,7 +69,7 @@ typedef enum {
   BGPSTREAM_UPDATE = 0,
 
   /** The record contains data for a BGP RIB message */
-  BGPSTREAM_RIB    = 1,
+  BGPSTREAM_RIB = 1,
 
 } bgpstream_record_dump_type_t;
 
@@ -77,14 +77,14 @@ typedef enum {
 typedef enum {
 
   /** This is the first record of the dump */
-  BGPSTREAM_DUMP_START  = 0,
+  BGPSTREAM_DUMP_START = 0,
 
   /** This is a record in the middle of the dump. i.e. not the first or the last
       record of the dump */
   BGPSTREAM_DUMP_MIDDLE = 1,
 
   /** This is the last record of the dump */
-  BGPSTREAM_DUMP_END    = 2,
+  BGPSTREAM_DUMP_END = 2,
 
 } bgpstream_dump_position_t;
 
@@ -92,13 +92,13 @@ typedef enum {
 typedef enum {
 
   /** The record is valid and may be used */
-  BGPSTREAM_RECORD_STATUS_VALID_RECORD     = 0,
+  BGPSTREAM_RECORD_STATUS_VALID_RECORD = 0,
 
   /** Source is not empty, but no valid record was found */
-  BGPSTREAM_RECORD_STATUS_FILTERED_SOURCE  = 1,
+  BGPSTREAM_RECORD_STATUS_FILTERED_SOURCE = 1,
 
   /** Source has no entries */
-  BGPSTREAM_RECORD_STATUS_EMPTY_SOURCE     = 2,
+  BGPSTREAM_RECORD_STATUS_EMPTY_SOURCE = 2,
 
   /* Error in opening dump */
   BGPSTREAM_RECORD_STATUS_CORRUPTED_SOURCE = 3,
@@ -135,7 +135,6 @@ typedef struct struct_bgpstream_record_attributes_t {
   long record_time;
 
 } bgpstream_record_attributes_t;
-
 
 /** Record structure */
 typedef struct struct_bgpstream_record_t {
@@ -211,7 +210,7 @@ bgpstream_elem_t *bgpstream_record_get_next_elem(bgpstream_record_t *record);
  *
  * See https://bitbucket.org/ripencc/bgpdump for more information about bgpdump
  */
-void bgpstream_record_print_mrt_data(bgpstream_record_t * const bs_record);
+void bgpstream_record_print_mrt_data(bgpstream_record_t *const bs_record);
 
 /** Write the string representation of the record dump type into the provided
  *  buffer
@@ -225,7 +224,8 @@ void bgpstream_record_print_mrt_data(bgpstream_record_t * const bs_record);
 int bgpstream_record_dump_type_snprintf(char *buf, size_t len,
                                         bgpstream_record_dump_type_t dump_type);
 
-/** Write the string representation of the record dump position into the provided
+/** Write the string representation of the record dump position into the
+ * provided
  *  buffer
  *
  * @param buf           pointer to a char array
@@ -235,7 +235,7 @@ int bgpstream_record_dump_type_snprintf(char *buf, size_t len,
  * unlimited
  */
 int bgpstream_record_dump_pos_snprintf(char *buf, size_t len,
-                                        bgpstream_dump_position_t dump_pos);
+                                       bgpstream_dump_position_t dump_pos);
 
 /** Write the string representation of the record status into the provided
  *  buffer
@@ -258,8 +258,8 @@ int bgpstream_record_status_snprintf(char *buf, size_t len,
  * @return pointer to the start of the buffer if successful, NULL otherwise
  */
 char *bgpstream_record_elem_snprintf(char *buf, size_t len,
-                                     const bgpstream_record_t * bs_record,
-                                     const bgpstream_elem_t * elem);
+                                     const bgpstream_record_t *bs_record,
+                                     const bgpstream_elem_t *elem);
 
 /** @} */
 

--- a/lib/datasources/bgpstream_datasource_broker.h
+++ b/lib/datasources/bgpstream_datasource_broker.h
@@ -25,27 +25,25 @@
 #define _BGPSTREAM_DATASOURCE_BROKER_H
 
 #include "bgpstream_constants.h"
-#include "bgpstream_input.h"
 #include "bgpstream_filter.h"
+#include "bgpstream_input.h"
 
-#include <stdlib.h>
 #include <stdio.h>
-
+#include <stdlib.h>
 
 /** Opaque handle that represents the broker data source */
-typedef struct struct_bgpstream_broker_datasource_t bgpstream_broker_datasource_t;
+typedef struct struct_bgpstream_broker_datasource_t
+  bgpstream_broker_datasource_t;
 
 bgpstream_broker_datasource_t *
 bgpstream_broker_datasource_create(bgpstream_filter_mgr_t *filter_mgr,
-                                   char *broker_url,
-                                   char **params, int params_cnt);
+                                   char *broker_url, char **params,
+                                   int params_cnt);
 
-int
-bgpstream_broker_datasource_update_input_queue(bgpstream_broker_datasource_t* broker_ds,
-                                                bgpstream_input_mgr_t *input_mgr);
+int bgpstream_broker_datasource_update_input_queue(
+  bgpstream_broker_datasource_t *broker_ds, bgpstream_input_mgr_t *input_mgr);
 
-void
-bgpstream_broker_datasource_destroy(bgpstream_broker_datasource_t* broker_ds);
-
+void bgpstream_broker_datasource_destroy(
+  bgpstream_broker_datasource_t *broker_ds);
 
 #endif /* _BGPSTREAM_DATASOURCE_BROKER_H */

--- a/lib/datasources/bgpstream_datasource_csvfile.c
+++ b/lib/datasources/bgpstream_datasource_csvfile.c
@@ -21,45 +21,44 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include "bgpstream_datasource_csvfile.h"
 #include "bgpstream_debug.h"
-#include "libcsv/csv.h"
+#include "config.h"
 #include "utils.h"
+#include "libcsv/csv.h"
+#include <assert.h>
 #include <inttypes.h>
-#include <sys/types.h>
-#include <sys/time.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <stdlib.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
 #include <wandio.h>
-#include <assert.h>
 
-#define BUFFER_LEN  1024
+#define BUFFER_LEN 1024
 
 typedef enum {
-  
-  CSVFILE_PATH      = 0,
-  CSVFILE_PROJECT   = 1,
-  CSVFILE_BGPTYPE   = 2,
+
+  CSVFILE_PATH = 0,
+  CSVFILE_PROJECT = 1,
+  CSVFILE_BGPTYPE = 2,
   CSVFILE_COLLECTOR = 3,
-  CSVFILE_FILETIME  = 4,
-  CSVFILE_TIMESPAN  = 5,
+  CSVFILE_FILETIME = 4,
+  CSVFILE_TIMESPAN = 5,
   CSVFILE_TIMESTAMP = 6,
-  
-  CSVFILE_FIELDCNT  = 7
+
+  CSVFILE_FIELDCNT = 7
 } csvfile_field_t;
 
-
-struct struct_bgpstream_csvfile_datasource_t {  
+struct struct_bgpstream_csvfile_datasource_t {
   char *csvfile_file;
   struct csv_parser parser;
   int current_field;
   int num_results;
-  bgpstream_filter_mgr_t * filter_mgr;
+  bgpstream_filter_mgr_t *filter_mgr;
   bgpstream_input_mgr_t *input_mgr;
-  
+
   /* bgp record metadata */
   char filename[BGPSTREAM_DUMP_MAX_LEN];
   char project[BGPSTREAM_PAR_MAX_LEN];
@@ -77,41 +76,39 @@ struct struct_bgpstream_csvfile_datasource_t {
   uint32_t max_accepted_ts;
 };
 
-
-
 bgpstream_csvfile_datasource_t *
-bgpstream_csvfile_datasource_create(bgpstream_filter_mgr_t *filter_mgr, 
+bgpstream_csvfile_datasource_create(bgpstream_filter_mgr_t *filter_mgr,
                                     char *csvfile_file)
 {
-  bgpstream_debug("\t\tBSDS_CSVFILE: create csvfile_ds start");  
-  bgpstream_csvfile_datasource_t *csvfile_ds = (bgpstream_csvfile_datasource_t*) malloc_zero(sizeof(bgpstream_csvfile_datasource_t));
-  if(csvfile_ds == NULL) {
-    bgpstream_log_err("\t\tBSDS_CSVFILE: create csvfile_ds can't allocate memory");    
+  bgpstream_debug("\t\tBSDS_CSVFILE: create csvfile_ds start");
+  bgpstream_csvfile_datasource_t *csvfile_ds =
+    (bgpstream_csvfile_datasource_t *)malloc_zero(
+      sizeof(bgpstream_csvfile_datasource_t));
+  if (csvfile_ds == NULL) {
+    bgpstream_log_err(
+      "\t\tBSDS_CSVFILE: create csvfile_ds can't allocate memory");
     goto err;
-  }  
-  if(csvfile_file == NULL)
-    {
-      bgpstream_log_err("\t\tBSDS_CSVFILE: create csvfile_ds no file provided");    
-      goto err;
-    }
-  if((csvfile_ds->csvfile_file = strdup(csvfile_file)) == NULL)
-    {
-      bgpstream_log_err("\t\tBSDS_CSVFILE: can't allocate memory for filename");    
-      goto err;
-    }
-  
+  }
+  if (csvfile_file == NULL) {
+    bgpstream_log_err("\t\tBSDS_CSVFILE: create csvfile_ds no file provided");
+    goto err;
+  }
+  if ((csvfile_ds->csvfile_file = strdup(csvfile_file)) == NULL) {
+    bgpstream_log_err("\t\tBSDS_CSVFILE: can't allocate memory for filename");
+    goto err;
+  }
+
   /* cvs file parser options */
   unsigned char options = CSV_STRICT | CSV_REPALL_NL | CSV_STRICT_FINI |
-                CSV_APPEND_NULL | CSV_EMPTY_IS_NULL;
+                          CSV_APPEND_NULL | CSV_EMPTY_IS_NULL;
 
-  if(csv_init(&(csvfile_ds->parser), options) !=0)
-    {
-      bgpstream_log_err("\t\tBSDS_CSVFILE: can't initialize csv parser");    
-      goto err;
-    }
+  if (csv_init(&(csvfile_ds->parser), options) != 0) {
+    bgpstream_log_err("\t\tBSDS_CSVFILE: can't initialize csv parser");
+    goto err;
+  }
 
   csvfile_ds->current_field = CSVFILE_PATH;
-  
+
   csvfile_ds->filter_mgr = filter_mgr;
   csvfile_ds->input_mgr = NULL;
 
@@ -123,247 +120,230 @@ bgpstream_csvfile_datasource_create(bgpstream_filter_mgr_t *filter_mgr,
 
   bgpstream_debug("\t\tBSDS_CSVFILE: create csvfile_ds end");
   return csvfile_ds;
-  
- err:
+
+err:
   bgpstream_csvfile_datasource_destroy(csvfile_ds);
   return NULL;
 }
 
-
-static bool
-bgpstream_csvfile_datasource_filter_ok(bgpstream_csvfile_datasource_t* csvfile_ds) {
+static bool bgpstream_csvfile_datasource_filter_ok(
+  bgpstream_csvfile_datasource_t *csvfile_ds)
+{
   bgpstream_debug("\t\tBSDS_CSVFILE: csvfile_ds apply filter start");
 
   /* fprintf(stderr, "%s %s %s %s\n", */
-  /*         csvfile_ds->filename, csvfile_ds->project, csvfile_ds->collector, csvfile_ds->bgp_type); */
+  /*         csvfile_ds->filename, csvfile_ds->project, csvfile_ds->collector,
+   * csvfile_ds->bgp_type); */
 
-  bgpstream_interval_filter_t * tif;
+  bgpstream_interval_filter_t *tif;
   bool all_false;
-  
-  char *f;  
-  
+
+  char *f;
+
   // projects
   all_false = true;
-  if(csvfile_ds->filter_mgr->projects != NULL) {
-    bgpstream_str_set_rewind(csvfile_ds->filter_mgr->projects);    
-    while((f = bgpstream_str_set_next(csvfile_ds->filter_mgr->projects)) != NULL)
-      {
-        if(strcmp(f, csvfile_ds->project) == 0) {
-          all_false = false;
-          break;
-        }
-      }    
-    if(all_false) {
-      return false; 
+  if (csvfile_ds->filter_mgr->projects != NULL) {
+    bgpstream_str_set_rewind(csvfile_ds->filter_mgr->projects);
+    while ((f = bgpstream_str_set_next(csvfile_ds->filter_mgr->projects)) !=
+           NULL) {
+      if (strcmp(f, csvfile_ds->project) == 0) {
+        all_false = false;
+        break;
+      }
+    }
+    if (all_false) {
+      return false;
     }
   }
   // collectors
   all_false = true;
-  if(csvfile_ds->filter_mgr->collectors != NULL) {
-    bgpstream_str_set_rewind(csvfile_ds->filter_mgr->collectors);    
-    while((f = bgpstream_str_set_next(csvfile_ds->filter_mgr->collectors)) != NULL)
-      {
-        if(strcmp(f, csvfile_ds->collector) == 0) {
-          all_false = false;
-          break;
-        }
-      }    
-    if(all_false) {
-      return false; 
+  if (csvfile_ds->filter_mgr->collectors != NULL) {
+    bgpstream_str_set_rewind(csvfile_ds->filter_mgr->collectors);
+    while ((f = bgpstream_str_set_next(csvfile_ds->filter_mgr->collectors)) !=
+           NULL) {
+      if (strcmp(f, csvfile_ds->collector) == 0) {
+        all_false = false;
+        break;
+      }
+    }
+    if (all_false) {
+      return false;
     }
   }
 
   // bgp_types
   all_false = true;
-  if(csvfile_ds->filter_mgr->bgp_types != NULL) {
-    bgpstream_str_set_rewind(csvfile_ds->filter_mgr->bgp_types);    
-    while((f = bgpstream_str_set_next(csvfile_ds->filter_mgr->bgp_types)) != NULL)
-      {
-        if(strcmp(f, csvfile_ds->bgp_type) == 0) {
-          all_false = false;
-          break;
-        }
-      }    
-    if(all_false) {
-      return false; 
+  if (csvfile_ds->filter_mgr->bgp_types != NULL) {
+    bgpstream_str_set_rewind(csvfile_ds->filter_mgr->bgp_types);
+    while ((f = bgpstream_str_set_next(csvfile_ds->filter_mgr->bgp_types)) !=
+           NULL) {
+      if (strcmp(f, csvfile_ds->bgp_type) == 0) {
+        all_false = false;
+        break;
+      }
+    }
+    if (all_false) {
+      return false;
     }
   }
 
   // time_intervals
   all_false = true;
-  if(csvfile_ds->filter_mgr->time_intervals != NULL) {
+  if (csvfile_ds->filter_mgr->time_intervals != NULL) {
     tif = csvfile_ds->filter_mgr->time_intervals;
-    while(tif != NULL) {      
+    while (tif != NULL) {
       // filetime (we consider 15 mins before to consider routeviews updates
       // and 120 seconds to have some margins)
-      if(csvfile_ds->filetime >= (tif->begin_time - 15*60 - 120) &&
-         (tif->end_time == BGPSTREAM_FOREVER ||
-          csvfile_ds->filetime <= tif->end_time)) {
-	all_false = false;
-	break;
+      if (csvfile_ds->filetime >= (tif->begin_time - 15 * 60 - 120) &&
+          (tif->end_time == BGPSTREAM_FOREVER ||
+           csvfile_ds->filetime <= tif->end_time)) {
+        all_false = false;
+        break;
       }
       tif = tif->next;
     }
-    if(all_false) {
-      return false; 
+    if (all_false) {
+      return false;
     }
   }
   // if all the filters are passed
   return true;
 }
 
-
-static void
-parse_csvfile_field(void *field, size_t i, void *user_data)
+static void parse_csvfile_field(void *field, size_t i, void *user_data)
 {
-  
-  char *field_str = (char *) field;
-  bgpstream_csvfile_datasource_t *csvfile_ds = (bgpstream_csvfile_datasource_t *) user_data;
+
+  char *field_str = (char *)field;
+  bgpstream_csvfile_datasource_t *csvfile_ds =
+    (bgpstream_csvfile_datasource_t *)user_data;
 
   /* fprintf(stderr, "%s\n", field_str); */
 
-  switch(csvfile_ds->current_field)
-    {
-    case CSVFILE_PATH:
-      assert(i < BGPSTREAM_DUMP_MAX_LEN-1);
-      strncpy(csvfile_ds->filename, field_str, i);
-      csvfile_ds->filename[i] = '\0';
-      break;
-    case CSVFILE_PROJECT:
-      assert(i < BGPSTREAM_PAR_MAX_LEN-1);
-      strncpy(csvfile_ds->project, field_str, i);     
-      csvfile_ds->project[i] = '\0';
-      break;
-    case CSVFILE_BGPTYPE:
-      assert(i < BGPSTREAM_PAR_MAX_LEN-1);
-      strncpy(csvfile_ds->bgp_type, field_str, i);     
-      csvfile_ds->bgp_type[i] = '\0';
-      break;
-    case CSVFILE_COLLECTOR:
-      assert(i < BGPSTREAM_PAR_MAX_LEN-1);
-      strncpy(csvfile_ds->collector, field_str, i);     
-      csvfile_ds->collector[i] = '\0';
-      break;
-    case CSVFILE_FILETIME:
-      csvfile_ds->filetime = atoi(field_str);
-      break;
-    case CSVFILE_TIMESPAN:
-      csvfile_ds->time_span = atoi(field_str);
-      break;
-    case CSVFILE_TIMESTAMP:
-      csvfile_ds->timestamp = atoi(field_str);
-      break;      
-    }
+  switch (csvfile_ds->current_field) {
+  case CSVFILE_PATH:
+    assert(i < BGPSTREAM_DUMP_MAX_LEN - 1);
+    strncpy(csvfile_ds->filename, field_str, i);
+    csvfile_ds->filename[i] = '\0';
+    break;
+  case CSVFILE_PROJECT:
+    assert(i < BGPSTREAM_PAR_MAX_LEN - 1);
+    strncpy(csvfile_ds->project, field_str, i);
+    csvfile_ds->project[i] = '\0';
+    break;
+  case CSVFILE_BGPTYPE:
+    assert(i < BGPSTREAM_PAR_MAX_LEN - 1);
+    strncpy(csvfile_ds->bgp_type, field_str, i);
+    csvfile_ds->bgp_type[i] = '\0';
+    break;
+  case CSVFILE_COLLECTOR:
+    assert(i < BGPSTREAM_PAR_MAX_LEN - 1);
+    strncpy(csvfile_ds->collector, field_str, i);
+    csvfile_ds->collector[i] = '\0';
+    break;
+  case CSVFILE_FILETIME:
+    csvfile_ds->filetime = atoi(field_str);
+    break;
+  case CSVFILE_TIMESPAN:
+    csvfile_ds->time_span = atoi(field_str);
+    break;
+  case CSVFILE_TIMESTAMP:
+    csvfile_ds->timestamp = atoi(field_str);
+    break;
+  }
 
   /* one more field read */
   csvfile_ds->current_field++;
 }
 
-static void
-parse_csvfile_rowend(int c, void *user_data)
+static void parse_csvfile_rowend(int c, void *user_data)
 {
-  bgpstream_csvfile_datasource_t *csvfile_ds = (bgpstream_csvfile_datasource_t *) user_data;
+  bgpstream_csvfile_datasource_t *csvfile_ds =
+    (bgpstream_csvfile_datasource_t *)user_data;
 
   /* if the number of fields read is compliant with the expected file format */
-  if(csvfile_ds->current_field == CSVFILE_FIELDCNT)
-    {
-      /* check if the timestamp is acceptable */
-      if(csvfile_ds->timestamp > csvfile_ds->last_processed_ts && 
-         csvfile_ds->timestamp <= csvfile_ds->max_accepted_ts)
-        {
-          /* update max in file timestamp */
-          if(csvfile_ds->timestamp > csvfile_ds->max_ts_infile)
-            {
-              csvfile_ds->max_ts_infile = csvfile_ds->timestamp;
-            }
-            if(bgpstream_csvfile_datasource_filter_ok(csvfile_ds))
-              {
-              csvfile_ds->num_results += bgpstream_input_mgr_push_sorted_input(csvfile_ds->input_mgr,
-                                                                               strdup(csvfile_ds->filename),
-                                                                               strdup(csvfile_ds->project),
-                                                                               strdup(csvfile_ds->collector),
-                                                                               strdup(csvfile_ds->bgp_type),
-                                                                               csvfile_ds->filetime,
-                                                                               csvfile_ds->time_span);
-            }          
-        }      
+  if (csvfile_ds->current_field == CSVFILE_FIELDCNT) {
+    /* check if the timestamp is acceptable */
+    if (csvfile_ds->timestamp > csvfile_ds->last_processed_ts &&
+        csvfile_ds->timestamp <= csvfile_ds->max_accepted_ts) {
+      /* update max in file timestamp */
+      if (csvfile_ds->timestamp > csvfile_ds->max_ts_infile) {
+        csvfile_ds->max_ts_infile = csvfile_ds->timestamp;
+      }
+      if (bgpstream_csvfile_datasource_filter_ok(csvfile_ds)) {
+        csvfile_ds->num_results += bgpstream_input_mgr_push_sorted_input(
+          csvfile_ds->input_mgr, strdup(csvfile_ds->filename),
+          strdup(csvfile_ds->project), strdup(csvfile_ds->collector),
+          strdup(csvfile_ds->bgp_type), csvfile_ds->filetime,
+          csvfile_ds->time_span);
+      }
     }
+  }
   csvfile_ds->current_field = 0;
 }
 
-
-int
-bgpstream_csvfile_datasource_update_input_queue(bgpstream_csvfile_datasource_t* csvfile_ds,
-                                                bgpstream_input_mgr_t *input_mgr) {
+int bgpstream_csvfile_datasource_update_input_queue(
+  bgpstream_csvfile_datasource_t *csvfile_ds, bgpstream_input_mgr_t *input_mgr)
+{
   bgpstream_debug("\t\tBSDS_CSVFILE: csvfile_ds update input queue start");
-  
+
   io_t *file_io = NULL;
   char buffer[BUFFER_LEN];
   int read = 0;
 
   struct timeval tv;
   gettimeofday(&tv, NULL);
-  
+
   /* we accept all timestamp earlier than now() - 1 second */
   csvfile_ds->max_accepted_ts = tv.tv_sec - 1;
 
   csvfile_ds->num_results = 0;
   csvfile_ds->max_ts_infile = 0;
   csvfile_ds->input_mgr = input_mgr;
-  
-  if((file_io = wandio_create(csvfile_ds->csvfile_file)) == NULL)
-    {
-      bgpstream_log_err("\t\tBSDS_CSVFILE: create csvfile_ds can't open file %s", csvfile_ds->csvfile_file);    
+
+  if ((file_io = wandio_create(csvfile_ds->csvfile_file)) == NULL) {
+    bgpstream_log_err("\t\tBSDS_CSVFILE: create csvfile_ds can't open file %s",
+                      csvfile_ds->csvfile_file);
+    return -1;
+  }
+
+  while ((read = wandio_read(file_io, &buffer, BUFFER_LEN)) > 0) {
+    if (csv_parse(&(csvfile_ds->parser), buffer, read, parse_csvfile_field,
+                  parse_csvfile_rowend, csvfile_ds) != read) {
+      bgpstream_log_err("\t\tBSDS_CSVFILE: CSV error %s",
+                        csv_strerror(csv_error(&(csvfile_ds->parser))));
       return -1;
     }
+  }
 
-    while((read = wandio_read(file_io, &buffer, BUFFER_LEN)) > 0)
-    {
-      if(csv_parse(&(csvfile_ds->parser), buffer, read,
-		   parse_csvfile_field,
-		   parse_csvfile_rowend,
-		   csvfile_ds) != read)
-	{
-          bgpstream_log_err("\t\tBSDS_CSVFILE: CSV error %s", csv_strerror(csv_error(&(csvfile_ds->parser))));         
-	  return -1;
-	}
-    }
+  if (csv_fini(&(csvfile_ds->parser), parse_csvfile_field, parse_csvfile_rowend,
+               csvfile_ds) != 0) {
+    bgpstream_log_err("\t\tBSDS_CSVFILE: CSV error %s",
+                      csv_strerror(csv_error(&(csvfile_ds->parser))));
+    return -1;
+  }
 
-  if(csv_fini(&(csvfile_ds->parser),
-	      parse_csvfile_field,
-	      parse_csvfile_rowend,
-	      csvfile_ds) != 0)
-    {
-      bgpstream_log_err("\t\tBSDS_CSVFILE: CSV error %s", csv_strerror(csv_error(&(csvfile_ds->parser))));         
-      return -1;
-    }
-  
   wandio_destroy(file_io);
   csvfile_ds->input_mgr = NULL;
   csvfile_ds->last_processed_ts = csvfile_ds->max_ts_infile;
-  
+
   bgpstream_debug("\t\tBSDS_CSVFILE: csvfile_ds update input queue end");
   return csvfile_ds->num_results;
 }
 
-
-
-void
-bgpstream_csvfile_datasource_destroy(bgpstream_csvfile_datasource_t* csvfile_ds) {
-  bgpstream_debug("\t\tBSDS_CSVFILE: destroy csvfile_ds start");  
-  if(csvfile_ds == NULL) {
+void bgpstream_csvfile_datasource_destroy(
+  bgpstream_csvfile_datasource_t *csvfile_ds)
+{
+  bgpstream_debug("\t\tBSDS_CSVFILE: destroy csvfile_ds start");
+  if (csvfile_ds == NULL) {
     return; // nothing to destroy
   }
   csvfile_ds->filter_mgr = NULL;
-  if(csvfile_ds->csvfile_file !=NULL)
-    {
-      free(csvfile_ds->csvfile_file);
-    }
-  if(&(csvfile_ds->parser) != NULL)
-    {
-      csv_free(&(csvfile_ds->parser));
-    }
+  if (csvfile_ds->csvfile_file != NULL) {
+    free(csvfile_ds->csvfile_file);
+  }
+  if (&(csvfile_ds->parser) != NULL) {
+    csv_free(&(csvfile_ds->parser));
+  }
   free(csvfile_ds);
-  bgpstream_debug("\t\tBSDS_CSVFILE: destroy csvfile_ds end");  
+  bgpstream_debug("\t\tBSDS_CSVFILE: destroy csvfile_ds end");
 }
-

--- a/lib/datasources/bgpstream_datasource_csvfile.h
+++ b/lib/datasources/bgpstream_datasource_csvfile.h
@@ -25,27 +25,24 @@
 #define _BGPSTREAM_DATASOURCE_CSVFILE_H
 
 #include "bgpstream_constants.h"
-#include "bgpstream_input.h"
 #include "bgpstream_filter.h"
+#include "bgpstream_input.h"
 
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 /** Opaque handle that represents the csvfile data source */
-typedef struct struct_bgpstream_csvfile_datasource_t bgpstream_csvfile_datasource_t;
+typedef struct struct_bgpstream_csvfile_datasource_t
+  bgpstream_csvfile_datasource_t;
 
 bgpstream_csvfile_datasource_t *
 bgpstream_csvfile_datasource_create(bgpstream_filter_mgr_t *filter_mgr,
-                                    char * csvfile_file);
+                                    char *csvfile_file);
 
-int
-bgpstream_csvfile_datasource_update_input_queue(bgpstream_csvfile_datasource_t* csvfile_ds,
-                                                bgpstream_input_mgr_t *input_mgr);
+int bgpstream_csvfile_datasource_update_input_queue(
+  bgpstream_csvfile_datasource_t *csvfile_ds, bgpstream_input_mgr_t *input_mgr);
 
-void
-bgpstream_csvfile_datasource_destroy(bgpstream_csvfile_datasource_t* csvfile_ds);
-
-
-
+void bgpstream_csvfile_datasource_destroy(
+  bgpstream_csvfile_datasource_t *csvfile_ds);
 
 #endif /* _BGPSTREAM_DATASOURCE_CSVFILE_H */

--- a/lib/datasources/bgpstream_datasource_singlefile.c
+++ b/lib/datasources/bgpstream_datasource_singlefile.c
@@ -21,28 +21,28 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include "bgpstream_datasource_singlefile.h"
 #include "bgpstream_debug.h"
+#include "config.h"
 #include <inttypes.h>
-#include <sys/types.h>
-#include <sys/time.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <string.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
 #include <wandio.h>
 
-/* check for new ribs once every 30 mins */ 
-#define RIB_FREQUENCY_CHECK 1800 
+/* check for new ribs once every 30 mins */
+#define RIB_FREQUENCY_CHECK 1800
 /* check for new updates once every 2 minutes */
-#define UPDATE_FREQUENCY_CHECK 120 
+#define UPDATE_FREQUENCY_CHECK 120
 
 #define MAX_HEADER_READ_BYTES 1024
 static unsigned char buffer[MAX_HEADER_READ_BYTES];
 
 struct struct_bgpstream_singlefile_datasource_t {
-  bgpstream_filter_mgr_t * filter_mgr;  
+  bgpstream_filter_mgr_t *filter_mgr;
   char rib_filename[BGPSTREAM_DUMP_MAX_LEN];
   unsigned char rib_header[MAX_HEADER_READ_BYTES];
   uint32_t last_rib_filetime;
@@ -51,126 +51,111 @@ struct struct_bgpstream_singlefile_datasource_t {
   uint32_t last_update_filetime;
 };
 
-
 bgpstream_singlefile_datasource_t *
 bgpstream_singlefile_datasource_create(bgpstream_filter_mgr_t *filter_mgr,
                                        char *singlefile_rib_mrtfile,
                                        char *singlefile_upd_mrtfile)
 {
-  bgpstream_debug("\t\tBSDS_CLIST: create singlefile_ds start");  
-  bgpstream_singlefile_datasource_t *singlefile_ds = (bgpstream_singlefile_datasource_t*) malloc(sizeof(bgpstream_singlefile_datasource_t));
-  if(singlefile_ds == NULL) {
-    bgpstream_log_err("\t\tBSDS_CLIST: create singlefile_ds can't allocate memory");    
+  bgpstream_debug("\t\tBSDS_CLIST: create singlefile_ds start");
+  bgpstream_singlefile_datasource_t *singlefile_ds =
+    (bgpstream_singlefile_datasource_t *)malloc(
+      sizeof(bgpstream_singlefile_datasource_t));
+  if (singlefile_ds == NULL) {
+    bgpstream_log_err(
+      "\t\tBSDS_CLIST: create singlefile_ds can't allocate memory");
     return NULL; // can't allocate memory
   }
   singlefile_ds->filter_mgr = filter_mgr;
   singlefile_ds->rib_filename[0] = '\0';
   singlefile_ds->rib_header[0] = '\0';
   singlefile_ds->last_rib_filetime = 0;
-  if(singlefile_rib_mrtfile != NULL)
-    {
-      strcpy(singlefile_ds->rib_filename, singlefile_rib_mrtfile);
-    }
+  if (singlefile_rib_mrtfile != NULL) {
+    strcpy(singlefile_ds->rib_filename, singlefile_rib_mrtfile);
+  }
   singlefile_ds->update_filename[0] = '\0';
   singlefile_ds->update_header[0] = '\0';
   singlefile_ds->last_update_filetime = 0;
-  if(singlefile_upd_mrtfile != NULL)
-    {
-      strcpy(singlefile_ds->update_filename, singlefile_upd_mrtfile);
-    }
+  if (singlefile_upd_mrtfile != NULL) {
+    strcpy(singlefile_ds->update_filename, singlefile_upd_mrtfile);
+  }
   bgpstream_debug("\t\tBSDS_CLIST: create customlist_ds end");
   return singlefile_ds;
 }
 
-
-
-static int
-same_header(char *mrt_filename, unsigned char *previous_header)
+static int same_header(char *mrt_filename, unsigned char *previous_header)
 {
   off_t read_bytes;
   io_t *io_h = wandio_create(mrt_filename);
-  if(io_h == NULL)
-    {
-      bgpstream_log_err("\t\tBSDS_SINGLEFILE: can't open file!");    
-      return -1;
-    }
-  
-  read_bytes = wandio_read(io_h, (void *) &(buffer[0]),  MAX_HEADER_READ_BYTES);
-  if(read_bytes < 0)
-    {
-      bgpstream_log_err("\t\tBSDS_SINGLEFILE: can't read file!");
-      wandio_destroy(io_h);
-      return -1;
-    }
+  if (io_h == NULL) {
+    bgpstream_log_err("\t\tBSDS_SINGLEFILE: can't open file!");
+    return -1;
+  }
+
+  read_bytes = wandio_read(io_h, (void *)&(buffer[0]), MAX_HEADER_READ_BYTES);
+  if (read_bytes < 0) {
+    bgpstream_log_err("\t\tBSDS_SINGLEFILE: can't read file!");
+    wandio_destroy(io_h);
+    return -1;
+  }
 
   int ret = memcmp(buffer, previous_header, sizeof(unsigned char) * read_bytes);
   wandio_destroy(io_h);
   /* if there is no difference, then they have the same header */
-  if(ret == 0)
-    {
-      /* fprintf(stderr, "same header\n"); */
-      return 1;
-    }
+  if (ret == 0) {
+    /* fprintf(stderr, "same header\n"); */
+    return 1;
+  }
   memcpy(previous_header, buffer, sizeof(unsigned char) * read_bytes);
   return 0;
 }
 
-
-
-int
-bgpstream_singlefile_datasource_update_input_queue(bgpstream_singlefile_datasource_t* singlefile_ds,
-                                                   bgpstream_input_mgr_t *input_mgr)
+int bgpstream_singlefile_datasource_update_input_queue(
+  bgpstream_singlefile_datasource_t *singlefile_ds,
+  bgpstream_input_mgr_t *input_mgr)
 {
-    bgpstream_debug("\t\tBSDS_CLIST: singlefile_ds update input queue start");
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    uint32_t now  = tv.tv_sec;
-    int num_results = 0;
-    
-    /* check digest, if different (or first) then add files to input queue) */
-    if(singlefile_ds->rib_filename[0] != '\0' &&
-       now - singlefile_ds->last_rib_filetime > RIB_FREQUENCY_CHECK  &&
-       same_header(singlefile_ds->rib_filename, singlefile_ds->rib_header) == 0)
-      {
-        /* fprintf(stderr, "new RIB at: %"PRIu32"\n", now); */
-        singlefile_ds->last_rib_filetime = now;
-        num_results += bgpstream_input_mgr_push_sorted_input(input_mgr, strdup(singlefile_ds->rib_filename),
-							     strdup("singlefile_ds"),
-							     strdup("singlefile_ds"),
-                                                             strdup("ribs"),
-							     singlefile_ds->last_rib_filetime,
-                                                             RIB_FREQUENCY_CHECK);
-      }
+  bgpstream_debug("\t\tBSDS_CLIST: singlefile_ds update input queue start");
+  struct timeval tv;
+  gettimeofday(&tv, NULL);
+  uint32_t now = tv.tv_sec;
+  int num_results = 0;
 
-    if(singlefile_ds->update_filename[0] != '\0' &&
-       now - singlefile_ds->last_update_filetime > UPDATE_FREQUENCY_CHECK  &&
-       same_header(singlefile_ds->update_filename, singlefile_ds->update_header) == 0)
-      {
-        /* fprintf(stderr, "new updates at: %"PRIu32"\n", now); */
-        singlefile_ds->last_update_filetime = now;
-        num_results += bgpstream_input_mgr_push_sorted_input(input_mgr, strdup(singlefile_ds->update_filename),
-							     strdup("singlefile_ds"),
-							     strdup("singlefile_ds"),
-                                                             strdup("updates"),
-							     singlefile_ds->last_update_filetime,
-                                                             UPDATE_FREQUENCY_CHECK);
-      }
-    
-    bgpstream_debug("\t\tBSDS_CLIST: singlefile_ds update input queue end");  
-    return num_results;
+  /* check digest, if different (or first) then add files to input queue) */
+  if (singlefile_ds->rib_filename[0] != '\0' &&
+      now - singlefile_ds->last_rib_filetime > RIB_FREQUENCY_CHECK &&
+      same_header(singlefile_ds->rib_filename, singlefile_ds->rib_header) ==
+        0) {
+    /* fprintf(stderr, "new RIB at: %"PRIu32"\n", now); */
+    singlefile_ds->last_rib_filetime = now;
+    num_results += bgpstream_input_mgr_push_sorted_input(
+      input_mgr, strdup(singlefile_ds->rib_filename), strdup("singlefile_ds"),
+      strdup("singlefile_ds"), strdup("ribs"), singlefile_ds->last_rib_filetime,
+      RIB_FREQUENCY_CHECK);
+  }
+
+  if (singlefile_ds->update_filename[0] != '\0' &&
+      now - singlefile_ds->last_update_filetime > UPDATE_FREQUENCY_CHECK &&
+      same_header(singlefile_ds->update_filename,
+                  singlefile_ds->update_header) == 0) {
+    /* fprintf(stderr, "new updates at: %"PRIu32"\n", now); */
+    singlefile_ds->last_update_filetime = now;
+    num_results += bgpstream_input_mgr_push_sorted_input(
+      input_mgr, strdup(singlefile_ds->update_filename),
+      strdup("singlefile_ds"), strdup("singlefile_ds"), strdup("updates"),
+      singlefile_ds->last_update_filetime, UPDATE_FREQUENCY_CHECK);
+  }
+
+  bgpstream_debug("\t\tBSDS_CLIST: singlefile_ds update input queue end");
+  return num_results;
 }
 
-
-void
-bgpstream_singlefile_datasource_destroy(bgpstream_singlefile_datasource_t* singlefile_ds)
+void bgpstream_singlefile_datasource_destroy(
+  bgpstream_singlefile_datasource_t *singlefile_ds)
 {
-  bgpstream_debug("\t\tBSDS_CLIST: destroy singlefile_ds start");  
-  if(singlefile_ds == NULL) {
+  bgpstream_debug("\t\tBSDS_CLIST: destroy singlefile_ds start");
+  if (singlefile_ds == NULL) {
     return; // nothing to destroy
   }
   singlefile_ds->filter_mgr = NULL;
   free(singlefile_ds);
-  bgpstream_debug("\t\tBSDS_CLIST: destroy singlefile_ds end");  
+  bgpstream_debug("\t\tBSDS_CLIST: destroy singlefile_ds end");
 }
-
-

--- a/lib/datasources/bgpstream_datasource_singlefile.h
+++ b/lib/datasources/bgpstream_datasource_singlefile.h
@@ -25,29 +25,26 @@
 #define _BGPSTREAM_DATASOURCE_SINGLEFILE_H
 
 #include "bgpstream_constants.h"
-#include "bgpstream_input.h"
 #include "bgpstream_filter.h"
+#include "bgpstream_input.h"
 
-#include <stdlib.h>
 #include <stdio.h>
-
+#include <stdlib.h>
 
 /** Opaque handle that represents the single-file data source */
-typedef struct struct_bgpstream_singlefile_datasource_t bgpstream_singlefile_datasource_t;
-
-
-
+typedef struct struct_bgpstream_singlefile_datasource_t
+  bgpstream_singlefile_datasource_t;
 
 bgpstream_singlefile_datasource_t *
 bgpstream_singlefile_datasource_create(bgpstream_filter_mgr_t *filter_mgr,
                                        char *singlefile_rib_mrtfile,
                                        char *singlefile_upd_mrtfile);
 
-int
-bgpstream_singlefile_datasource_update_input_queue(bgpstream_singlefile_datasource_t* singlefile_ds,
-                                                   bgpstream_input_mgr_t *input_mgr);
+int bgpstream_singlefile_datasource_update_input_queue(
+  bgpstream_singlefile_datasource_t *singlefile_ds,
+  bgpstream_input_mgr_t *input_mgr);
 
-void
-bgpstream_singlefile_datasource_destroy(bgpstream_singlefile_datasource_t* singlefile_ds);
+void bgpstream_singlefile_datasource_destroy(
+  bgpstream_singlefile_datasource_t *singlefile_ds);
 
 #endif /* _BGPSTREAM_DATASOURCE_SINGLEFILE_H */

--- a/lib/datasources/bgpstream_datasource_sqlite.c
+++ b/lib/datasources/bgpstream_datasource_sqlite.c
@@ -25,85 +25,80 @@
 #include "bgpstream_debug.h"
 #include "utils.h"
 
+#include <assert.h>
 #include <inttypes.h>
-#include <sys/types.h>
-#include <sys/time.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
-#include <assert.h>
-#include <stdint.h>
 #include <string.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-
-#define MAX_QUERY_LEN    2048
+#define MAX_QUERY_LEN 2048
 #define MAX_INTERVAL_LEN 16
 
-
-#define APPEND_STR(str)                                                 \
-  do {                                                                  \
-    size_t len = strlen(str);                                           \
-    if(rem_buf_space < len+1)                                           \
-      {                                                                 \
-        return NULL;                                                    \
-      }                                                                 \
-    strncat(sqlite_ds->sql_query, str, rem_buf_space);                  \
-    rem_buf_space -= len;                                               \
-  } while(0)
-
-
-
+#define APPEND_STR(str)                                                        \
+  do {                                                                         \
+    size_t len = strlen(str);                                                  \
+    if (rem_buf_space < len + 1) {                                             \
+      return NULL;                                                             \
+    }                                                                          \
+    strncat(sqlite_ds->sql_query, str, rem_buf_space);                         \
+    rem_buf_space -= len;                                                      \
+  } while (0)
 
 struct struct_bgpstream_sqlite_datasource_t {
-  bgpstream_filter_mgr_t * filter_mgr;
+  bgpstream_filter_mgr_t *filter_mgr;
   /* sqlite connection handler */
   sqlite3 *db;
   sqlite3_stmt *stmt;
   char sql_query[MAX_QUERY_LEN];
-  char * sqlite_file;
+  char *sqlite_file;
   uint32_t current_ts;
   uint32_t last_ts;
 };
 
-
-static int
-prepare_db(bgpstream_sqlite_datasource_t * sqlite_ds)
+static int prepare_db(bgpstream_sqlite_datasource_t *sqlite_ds)
 {
   assert(sqlite_ds);
   int rc = 0;
-  if(sqlite3_open_v2(sqlite_ds->sqlite_file, &sqlite_ds->db, SQLITE_OPEN_READONLY, NULL) != SQLITE_OK)
-    {
-      bgpstream_log_err("\t\tBSDS_SQLITE: can't open database: %s", sqlite3_errmsg(sqlite_ds->db));  
-      sqlite3_close(sqlite_ds->db);
-      return -1;
-    }
+  if (sqlite3_open_v2(sqlite_ds->sqlite_file, &sqlite_ds->db,
+                      SQLITE_OPEN_READONLY, NULL) != SQLITE_OK) {
+    bgpstream_log_err("\t\tBSDS_SQLITE: can't open database: %s",
+                      sqlite3_errmsg(sqlite_ds->db));
+    sqlite3_close(sqlite_ds->db);
+    return -1;
+  }
 
-  rc = sqlite3_prepare_v2(sqlite_ds->db, sqlite_ds->sql_query, -1, &sqlite_ds->stmt, NULL);
+  rc = sqlite3_prepare_v2(sqlite_ds->db, sqlite_ds->sql_query, -1,
+                          &sqlite_ds->stmt, NULL);
   if (rc != SQLITE_OK) {
-    bgpstream_log_err("\t\tBSDS_SQLITE: failed to execute statement: %s", sqlite3_errmsg(sqlite_ds->db));
+    bgpstream_log_err("\t\tBSDS_SQLITE: failed to execute statement: %s",
+                      sqlite3_errmsg(sqlite_ds->db));
     return -1;
   }
   return 0;
 }
-  
-
 
 bgpstream_sqlite_datasource_t *
 bgpstream_sqlite_datasource_create(bgpstream_filter_mgr_t *filter_mgr,
-                                   char * sqlite_file)
+                                   char *sqlite_file)
 {
 
-  bgpstream_debug("\t\tBSDS_SQLITE: create sqlite_ds start");  
-  bgpstream_sqlite_datasource_t *sqlite_ds = (bgpstream_sqlite_datasource_t*) malloc_zero(sizeof(bgpstream_sqlite_datasource_t));
-  if(sqlite_ds == NULL) {
-    bgpstream_log_err("\t\tBSDS_SQLITE: create sqlite_ds can't allocate memory");
+  bgpstream_debug("\t\tBSDS_SQLITE: create sqlite_ds start");
+  bgpstream_sqlite_datasource_t *sqlite_ds =
+    (bgpstream_sqlite_datasource_t *)malloc_zero(
+      sizeof(bgpstream_sqlite_datasource_t));
+  if (sqlite_ds == NULL) {
+    bgpstream_log_err(
+      "\t\tBSDS_SQLITE: create sqlite_ds can't allocate memory");
     goto err;
-  }  
-  if(sqlite_file == NULL)
-    {
-      bgpstream_log_err("\t\tBSDS_SQLITE: create sqlite_ds no file provided");
-      goto err;
-    }
+  }
+  if (sqlite_file == NULL) {
+    bgpstream_log_err("\t\tBSDS_SQLITE: create sqlite_ds no file provided");
+    goto err;
+  }
   sqlite_ds->sqlite_file = strdup(sqlite_file);
 
   sqlite_ds->filter_mgr = filter_mgr;
@@ -115,119 +110,109 @@ bgpstream_sqlite_datasource_create(bgpstream_filter_mgr_t *filter_mgr,
   sqlite_ds->sql_query[0] = '\0';
   char interval_str[MAX_INTERVAL_LEN];
 
-  APPEND_STR("SELECT bgp_data.file_path, collectors.project, collectors.name, "
-             "bgp_types.name, time_span.time_span, bgp_data.file_time, bgp_data.ts "
-             "FROM  collectors JOIN bgp_data JOIN bgp_types JOIN time_span " 
-             "WHERE bgp_data.collector_id = collectors.id  AND "
-             "bgp_data.collector_id = time_span.collector_id AND "
-             "bgp_data.type_id = bgp_types.id AND "
-             "bgp_data.type_id = time_span.bgp_type_id ");
+  APPEND_STR(
+    "SELECT bgp_data.file_path, collectors.project, collectors.name, "
+    "bgp_types.name, time_span.time_span, bgp_data.file_time, bgp_data.ts "
+    "FROM  collectors JOIN bgp_data JOIN bgp_types JOIN time_span "
+    "WHERE bgp_data.collector_id = collectors.id  AND "
+    "bgp_data.collector_id = time_span.collector_id AND "
+    "bgp_data.type_id = bgp_types.id AND "
+    "bgp_data.type_id = time_span.bgp_type_id ");
 
   // projects, collectors, bgp_types, and time_intervals are used as filters
   // only if they are provided by the user
-  bgpstream_interval_filter_t * tif;
+  bgpstream_interval_filter_t *tif;
   bool first;
   char *f;
-  
+
   // projects
   first = true;
-  if(filter_mgr->projects != NULL) {
+  if (filter_mgr->projects != NULL) {
     APPEND_STR(" AND collectors.project IN (");
-    bgpstream_str_set_rewind(filter_mgr->projects);    
-    while((f = bgpstream_str_set_next(filter_mgr->projects)) != NULL)
-      {
-        if(!first)
-          {
-            APPEND_STR(", ");
-          }
-        APPEND_STR("'");
-        APPEND_STR(f);
-        APPEND_STR("'");
-        first = false;
-      }    
+    bgpstream_str_set_rewind(filter_mgr->projects);
+    while ((f = bgpstream_str_set_next(filter_mgr->projects)) != NULL) {
+      if (!first) {
+        APPEND_STR(", ");
+      }
+      APPEND_STR("'");
+      APPEND_STR(f);
+      APPEND_STR("'");
+      first = false;
+    }
     APPEND_STR(" ) ");
   }
 
   // collectors
   first = true;
-  if(filter_mgr->collectors != NULL) {
+  if (filter_mgr->collectors != NULL) {
     APPEND_STR(" AND collectors.name IN (");
-    bgpstream_str_set_rewind(filter_mgr->collectors);    
-    while((f = bgpstream_str_set_next(filter_mgr->collectors)) != NULL)
-      {
-        if(!first)
-          {
-            APPEND_STR(", ");
-          }
-        APPEND_STR("'");
-        APPEND_STR(f);
-        APPEND_STR("'");
-        first = false;
-      }    
+    bgpstream_str_set_rewind(filter_mgr->collectors);
+    while ((f = bgpstream_str_set_next(filter_mgr->collectors)) != NULL) {
+      if (!first) {
+        APPEND_STR(", ");
+      }
+      APPEND_STR("'");
+      APPEND_STR(f);
+      APPEND_STR("'");
+      first = false;
+    }
     APPEND_STR(" ) ");
   }
 
   // bgp_types
   first = true;
-  if(filter_mgr->bgp_types != NULL) {
+  if (filter_mgr->bgp_types != NULL) {
     APPEND_STR(" AND bgp_types.name IN (");
-    bgpstream_str_set_rewind(filter_mgr->bgp_types);    
-    while((f = bgpstream_str_set_next(filter_mgr->bgp_types)) != NULL)
-      {
-        if(!first)
-          {
-            APPEND_STR(", ");
-          }
-        APPEND_STR("'");
-        APPEND_STR(f);
-        APPEND_STR("'");
-        first = false;
-      }    
+    bgpstream_str_set_rewind(filter_mgr->bgp_types);
+    while ((f = bgpstream_str_set_next(filter_mgr->bgp_types)) != NULL) {
+      if (!first) {
+        APPEND_STR(", ");
+      }
+      APPEND_STR("'");
+      APPEND_STR(f);
+      APPEND_STR("'");
+      first = false;
+    }
     APPEND_STR(" ) ");
   }
 
   // time_intervals
   int written = 0;
-  if(filter_mgr->time_intervals != NULL) {
+  if (filter_mgr->time_intervals != NULL) {
     tif = filter_mgr->time_intervals;
     APPEND_STR(" AND ( ");
 
-    while(tif != NULL) {
+    while (tif != NULL) {
       APPEND_STR(" ( ");
 
       // BEGIN TIME
       APPEND_STR(" (bgp_data.file_time >=  ");
       interval_str[0] = '\0';
-      if((written =
-          snprintf(interval_str, MAX_INTERVAL_LEN,
-                   "%"PRIu32, tif->begin_time)) < MAX_INTERVAL_LEN)
-        {
-          APPEND_STR(interval_str);
-        }
+      if ((written = snprintf(interval_str, MAX_INTERVAL_LEN, "%" PRIu32,
+                              tif->begin_time)) < MAX_INTERVAL_LEN) {
+        APPEND_STR(interval_str);
+      }
       APPEND_STR("  - time_span.time_span - 120 )");
       APPEND_STR("  AND  ");
 
       // END TIME
-      if(tif->end_time != BGPSTREAM_FOREVER)
-        {
-          APPEND_STR(" (bgp_data.file_time <=  ");
-          interval_str[0] = '\0';
-          if((written =
-              snprintf(interval_str, MAX_INTERVAL_LEN,
-                       "%"PRIu32, tif->end_time)) < MAX_INTERVAL_LEN)
-            {
-              APPEND_STR(interval_str);
-            }
-          APPEND_STR(") ");
-          APPEND_STR(" ) ");
+      if (tif->end_time != BGPSTREAM_FOREVER) {
+        APPEND_STR(" (bgp_data.file_time <=  ");
+        interval_str[0] = '\0';
+        if ((written = snprintf(interval_str, MAX_INTERVAL_LEN, "%" PRIu32,
+                                tif->end_time)) < MAX_INTERVAL_LEN) {
+          APPEND_STR(interval_str);
         }
+        APPEND_STR(") ");
+        APPEND_STR(" ) ");
+      }
 
       tif = tif->next;
-      if(tif!= NULL) {
+      if (tif != NULL) {
         APPEND_STR(" OR ");
       }
     }
-      APPEND_STR(" )");
+    APPEND_STR(" )");
   }
 
   /*  comment on 120 seconds: */
@@ -239,29 +224,27 @@ bgpstream_sqlite_datasource_create(bgpstream_filter_mgr_t *filter_mgr,
 
   // minimum timestamp and current timestamp are the two placeholders
   APPEND_STR(" AND bgp_data.ts > ? AND bgp_data.ts <= ?");
-  // order by filetime and bgptypes in reverse order: this way the 
+  // order by filetime and bgptypes in reverse order: this way the
   // input insertions are always "head" insertions, i.e. queue insertion is
   // faster
   APPEND_STR(" ORDER BY file_time DESC, bgp_types.name DESC");
-  
-  if(prepare_db(sqlite_ds) != 0)
-    {
-      goto err;
-    }
 
-  // printf("%s\n", sqlite_ds->sql_query); 
-  
+  if (prepare_db(sqlite_ds) != 0) {
+    goto err;
+  }
+
+  // printf("%s\n", sqlite_ds->sql_query);
+
   bgpstream_debug("\t\tBSDS_SQLITE: create sqlite_ds end");
 
   return sqlite_ds;
- err:
+err:
   bgpstream_sqlite_datasource_destroy(sqlite_ds);
   return NULL;
 }
 
-int
-bgpstream_sqlite_datasource_update_input_queue(bgpstream_sqlite_datasource_t* sqlite_ds,
-                                                bgpstream_input_mgr_t *input_mgr)
+int bgpstream_sqlite_datasource_update_input_queue(
+  bgpstream_sqlite_datasource_t *sqlite_ds, bgpstream_input_mgr_t *input_mgr)
 {
   int rc;
   int num_results = 0;
@@ -270,51 +253,48 @@ bgpstream_sqlite_datasource_update_input_queue(bgpstream_sqlite_datasource_t* sq
   gettimeofday(&tv, NULL);
   // update current_timestamp - we always ask for data 1 second old at least
   sqlite_ds->current_ts = tv.tv_sec - 1; // now() - 1 second
-  
+
   sqlite3_bind_int(sqlite_ds->stmt, 1, sqlite_ds->last_ts);
   sqlite3_bind_int(sqlite_ds->stmt, 2, sqlite_ds->current_ts);
 
   /* printf("%d - %d \n", sqlite_ds->last_ts, sqlite_ds->current_ts); */
-  while((rc = sqlite3_step(sqlite_ds->stmt)) != SQLITE_DONE)
-    {
-      if(rc == SQLITE_ROW)
-        {
-          /* printf("%s: %d\n", sqlite3_column_text(sqlite_ds->stmt, 0), sqlite3_column_int(sqlite_ds->stmt, 6)); */
-          num_results +=
-            bgpstream_input_mgr_push_sorted_input(input_mgr,
-                                                  strdup((const char *)sqlite3_column_text(sqlite_ds->stmt, 0)) /* path */,
-                                                  strdup((const char *)sqlite3_column_text(sqlite_ds->stmt, 1)) /* project */,
-                                                  strdup((const char *)sqlite3_column_text(sqlite_ds->stmt, 2)) /* collector */,
-                                                  strdup((const char *)sqlite3_column_text(sqlite_ds->stmt, 3)) /* type */,
-                                                  sqlite3_column_int(sqlite_ds->stmt, 5) /* file time */,
-                                                  sqlite3_column_int(sqlite_ds->stmt, 4) /* time span */ );
-          
-        }
-      else
-        {
-          bgpstream_log_err("\t\tBSDS_SQLITE: error while stepping through results");
-          return -1;
-        }
+  while ((rc = sqlite3_step(sqlite_ds->stmt)) != SQLITE_DONE) {
+    if (rc == SQLITE_ROW) {
+      /* printf("%s: %d\n", sqlite3_column_text(sqlite_ds->stmt, 0),
+       * sqlite3_column_int(sqlite_ds->stmt, 6)); */
+      num_results += bgpstream_input_mgr_push_sorted_input(
+        input_mgr, strdup((const char *)sqlite3_column_text(sqlite_ds->stmt,
+                                                            0)) /* path */,
+        strdup(
+          (const char *)sqlite3_column_text(sqlite_ds->stmt, 1)) /* project */,
+        strdup((const char *)sqlite3_column_text(sqlite_ds->stmt,
+                                                 2)) /* collector */,
+        strdup(
+          (const char *)sqlite3_column_text(sqlite_ds->stmt, 3)) /* type */,
+        sqlite3_column_int(sqlite_ds->stmt, 5) /* file time */,
+        sqlite3_column_int(sqlite_ds->stmt, 4) /* time span */);
+
+    } else {
+      bgpstream_log_err(
+        "\t\tBSDS_SQLITE: error while stepping through results");
+      return -1;
     }
+  }
   sqlite3_reset(sqlite_ds->stmt);
   return num_results;
 }
 
-
-void
-bgpstream_sqlite_datasource_destroy(bgpstream_sqlite_datasource_t* sqlite_ds)
+void bgpstream_sqlite_datasource_destroy(
+  bgpstream_sqlite_datasource_t *sqlite_ds)
 {
-  if(sqlite_ds != NULL)
-    {
-      if(sqlite_ds->sqlite_file != NULL)
-        {
-          free(sqlite_ds->sqlite_file);
-          sqlite_ds->sqlite_file = NULL;
-        }
-      
-      sqlite3_finalize(sqlite_ds->stmt);
-      sqlite3_close(sqlite_ds->db);
-      free(sqlite_ds);
+  if (sqlite_ds != NULL) {
+    if (sqlite_ds->sqlite_file != NULL) {
+      free(sqlite_ds->sqlite_file);
+      sqlite_ds->sqlite_file = NULL;
     }
-}
 
+    sqlite3_finalize(sqlite_ds->stmt);
+    sqlite3_close(sqlite_ds->db);
+    free(sqlite_ds);
+  }
+}

--- a/lib/datasources/bgpstream_datasource_sqlite.h
+++ b/lib/datasources/bgpstream_datasource_sqlite.h
@@ -25,27 +25,25 @@
 #define _BGPSTREAM_DATASOURCE_SQLITE_H
 
 #include "bgpstream_constants.h"
-#include "bgpstream_input.h"
 #include "bgpstream_filter.h"
+#include "bgpstream_input.h"
 
-#include <stdlib.h>
-#include <stdio.h>
 #include <sqlite3.h>
-
+#include <stdio.h>
+#include <stdlib.h>
 
 /** Opaque handle that represents the sqlite data source */
-typedef struct struct_bgpstream_sqlite_datasource_t bgpstream_sqlite_datasource_t;
+typedef struct struct_bgpstream_sqlite_datasource_t
+  bgpstream_sqlite_datasource_t;
 
 bgpstream_sqlite_datasource_t *
 bgpstream_sqlite_datasource_create(bgpstream_filter_mgr_t *filter_mgr,
-                                    char * sqlite_file);
+                                   char *sqlite_file);
 
-int
-bgpstream_sqlite_datasource_update_input_queue(bgpstream_sqlite_datasource_t* sqlite_ds,
-                                                bgpstream_input_mgr_t *input_mgr);
+int bgpstream_sqlite_datasource_update_input_queue(
+  bgpstream_sqlite_datasource_t *sqlite_ds, bgpstream_input_mgr_t *input_mgr);
 
-void
-bgpstream_sqlite_datasource_destroy(bgpstream_sqlite_datasource_t* sqlite_ds);
-
+void bgpstream_sqlite_datasource_destroy(
+  bgpstream_sqlite_datasource_t *sqlite_ds);
 
 #endif /* _BGPSTREAM_DATASOURCE_SQLITE_H */

--- a/lib/utils/bgpstream_utils.h
+++ b/lib/utils/bgpstream_utils.h
@@ -21,7 +21,6 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #ifndef __BGPSTREAM_UTILS_H
 #define __BGPSTREAM_UTILS_H
 
@@ -51,11 +50,10 @@
 #include "bgpstream_utils_community.h"     /*< Community utilities */
 #include "bgpstream_utils_id_set.h"        /*< ID Set utilities */
 #include "bgpstream_utils_ip_counter.h"    /*< IP Overlap Counter */
+#include "bgpstream_utils_patricia.h"      /*< Patricia Tree utilities */
 #include "bgpstream_utils_peer_sig_map.h"  /*< Peer Signature utilities */
 #include "bgpstream_utils_pfx.h"           /*< Prefix utilities */
 #include "bgpstream_utils_pfx_set.h"       /*< Prefix Set utilities */
 #include "bgpstream_utils_str_set.h"       /*< String Set utilities */
-#include "bgpstream_utils_patricia.h"      /*< Patricia Tree utilities */
 
 #endif /* __BGPSTREAM_UTILS_H */
-

--- a/lib/utils/bgpstream_utils_addr.c
+++ b/lib/utils/bgpstream_utils_addr.c
@@ -21,14 +21,14 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "utils.h"
 #include <assert.h>
 #include <limits.h>
-#include <stdint.h>
-#include <sys/types.h>
-#include <sys/socket.h>
 #include <netdb.h>
+#include <stdint.h>
 #include <stdio.h>
-#include "utils.h"
+#include <sys/socket.h>
+#include <sys/types.h>
 
 #include "khash.h"
 
@@ -44,7 +44,6 @@ bgpstream_ipv4_addr_hash(bgpstream_ipv4_addr_t *addr)
   return __ac_Wang_hash(addr->ipv4.s_addr);
 }
 
-
 #if ULONG_MAX == ULLONG_MAX
 unsigned long
 #else
@@ -52,10 +51,9 @@ unsigned long long
 #endif
 bgpstream_ipv6_addr_hash(bgpstream_ipv6_addr_t *addr)
 {
-  unsigned char *s6 =  &(addr->ipv6.s6_addr[0]);
-  return __ac_Wang_hash(*((khint64_t *) s6));
+  unsigned char *s6 = &(addr->ipv6.s6_addr[0]);
+  return __ac_Wang_hash(*((khint64_t *)s6));
 }
-
 
 #if ULONG_MAX == ULLONG_MAX
 unsigned long
@@ -64,47 +62,42 @@ unsigned long long
 #endif
 bgpstream_addr_storage_hash(bgpstream_addr_storage_t *addr)
 {
-  switch(addr->version)
-    {
-    case BGPSTREAM_ADDR_VERSION_IPV4:
-      return bgpstream_ipv4_addr_hash((bgpstream_ipv4_addr_t*)addr);
-      break;
+  switch (addr->version) {
+  case BGPSTREAM_ADDR_VERSION_IPV4:
+    return bgpstream_ipv4_addr_hash((bgpstream_ipv4_addr_t *)addr);
+    break;
 
-    case BGPSTREAM_ADDR_VERSION_IPV6:
-      return bgpstream_ipv6_addr_hash((bgpstream_ipv6_addr_t*)addr);
-      break;
+  case BGPSTREAM_ADDR_VERSION_IPV6:
+    return bgpstream_ipv6_addr_hash((bgpstream_ipv6_addr_t *)addr);
+    break;
 
-    default:
-      return 0;
-      break;
-    }
+  default:
+    return 0;
+    break;
+  }
 }
 
-int bgpstream_addr_equal(bgpstream_ip_addr_t *addr1,
-                         bgpstream_ip_addr_t *addr2)
+int bgpstream_addr_equal(bgpstream_ip_addr_t *addr1, bgpstream_ip_addr_t *addr2)
 {
-  if(addr1->version == BGPSTREAM_ADDR_VERSION_IPV4 &&
-     addr2->version == BGPSTREAM_ADDR_VERSION_IPV4)
-    {
-      return bgpstream_ipv4_addr_equal((bgpstream_ipv4_addr_t *)addr1,
-                                       (bgpstream_ipv4_addr_t *)addr2);
-    }
-  if(addr1->version == BGPSTREAM_ADDR_VERSION_IPV6 &&
-     addr2->version == BGPSTREAM_ADDR_VERSION_IPV6)
-    {
-      return bgpstream_ipv6_addr_equal((bgpstream_ipv6_addr_t *)addr1,
-                                       (bgpstream_ipv6_addr_t *)addr2);
-    }
+  if (addr1->version == BGPSTREAM_ADDR_VERSION_IPV4 &&
+      addr2->version == BGPSTREAM_ADDR_VERSION_IPV4) {
+    return bgpstream_ipv4_addr_equal((bgpstream_ipv4_addr_t *)addr1,
+                                     (bgpstream_ipv4_addr_t *)addr2);
+  }
+  if (addr1->version == BGPSTREAM_ADDR_VERSION_IPV6 &&
+      addr2->version == BGPSTREAM_ADDR_VERSION_IPV6) {
+    return bgpstream_ipv6_addr_equal((bgpstream_ipv6_addr_t *)addr1,
+                                     (bgpstream_ipv6_addr_t *)addr2);
+  }
   return 0;
 }
 
 int bgpstream_addr_storage_equal(bgpstream_addr_storage_t *addr1,
                                  bgpstream_addr_storage_t *addr2)
 {
-  return bgpstream_addr_equal((bgpstream_ip_addr_t*)addr1,
-                              (bgpstream_ip_addr_t*)addr2);
+  return bgpstream_addr_equal((bgpstream_ip_addr_t *)addr1,
+                              (bgpstream_ip_addr_t *)addr2);
 }
-
 
 int bgpstream_ipv4_addr_equal(bgpstream_ipv4_addr_t *addr1,
                               bgpstream_ipv4_addr_t *addr2)
@@ -112,41 +105,35 @@ int bgpstream_ipv4_addr_equal(bgpstream_ipv4_addr_t *addr1,
   return addr1->ipv4.s_addr == addr2->ipv4.s_addr;
 }
 
-
 int bgpstream_ipv6_addr_equal(bgpstream_ipv6_addr_t *addr1,
                               bgpstream_ipv6_addr_t *addr2)
 {
-  return ((memcmp(&(addr1->ipv6.s6_addr[0]),
-                  &(addr2->ipv6.s6_addr[0]),
+  return ((memcmp(&(addr1->ipv6.s6_addr[0]), &(addr2->ipv6.s6_addr[0]),
                   sizeof(uint64_t)) == 0) &&
-          (memcmp(&(addr1->ipv6.s6_addr[8]),
-                  &(addr2->ipv6.s6_addr[8]),
+          (memcmp(&(addr1->ipv6.s6_addr[8]), &(addr2->ipv6.s6_addr[8]),
                   sizeof(uint64_t)) == 0));
 }
 
 bgpstream_ip_addr_t *bgpstream_addr_mask(bgpstream_ip_addr_t *addr,
                                          uint8_t mask_len)
 {
-  if(addr->version == BGPSTREAM_ADDR_VERSION_IPV4)
-    {
-      return (bgpstream_ip_addr_t*)
-        bgpstream_ipv4_addr_mask((bgpstream_ipv4_addr_t *)addr, mask_len);
-    }
-  if(addr->version == BGPSTREAM_ADDR_VERSION_IPV6)
-    {
-      return (bgpstream_ip_addr_t*)
-        bgpstream_ipv6_addr_mask((bgpstream_ipv6_addr_t *)addr, mask_len);
-    }
+  if (addr->version == BGPSTREAM_ADDR_VERSION_IPV4) {
+    return (bgpstream_ip_addr_t *)bgpstream_ipv4_addr_mask(
+      (bgpstream_ipv4_addr_t *)addr, mask_len);
+  }
+  if (addr->version == BGPSTREAM_ADDR_VERSION_IPV6) {
+    return (bgpstream_ip_addr_t *)bgpstream_ipv6_addr_mask(
+      (bgpstream_ipv6_addr_t *)addr, mask_len);
+  }
   return NULL;
 }
 
 bgpstream_ipv4_addr_t *bgpstream_ipv4_addr_mask(bgpstream_ipv4_addr_t *addr,
                                                 uint8_t mask_len)
 {
-  if(mask_len > 32)
-    {
-      mask_len = 32;
-    }
+  if (mask_len > 32) {
+    mask_len = 32;
+  }
 
   addr->ipv4.s_addr &= htonl(~(((uint64_t)1 << (32 - mask_len)) - 1));
   return addr;
@@ -157,145 +144,123 @@ bgpstream_ipv6_addr_t *bgpstream_ipv6_addr_mask(bgpstream_ipv6_addr_t *addr,
 {
   uint64_t *ptr;
 
-  if(mask_len > 128)
-    {
-      mask_len = 128;
-    }
+  if (mask_len > 128) {
+    mask_len = 128;
+  }
 
-  if(mask_len <= 64)
-    {
-      /* mask the bottom 64bits and zero the top 64bits */
-      ptr = (uint64_t*)&(addr->ipv6.s6_addr[8]);
-      *ptr = 0;
-      ptr = (uint64_t*)&(addr->ipv6.s6_addr[0]);
-      *ptr &= htonll((uint64_t)(~0) << (64 - mask_len));
-    }
-  else
-    {
-      /* mask the top 64 bits */
-      mask_len -= 64;
-      ptr = (uint64_t*)&(addr->ipv6.s6_addr[8]);
-      *ptr &= htonll((uint64_t)(~0) << (64 - mask_len - 64));
-    }
+  if (mask_len <= 64) {
+    /* mask the bottom 64bits and zero the top 64bits */
+    ptr = (uint64_t *)&(addr->ipv6.s6_addr[8]);
+    *ptr = 0;
+    ptr = (uint64_t *)&(addr->ipv6.s6_addr[0]);
+    *ptr &= htonll((uint64_t)(~0) << (64 - mask_len));
+  } else {
+    /* mask the top 64 bits */
+    mask_len -= 64;
+    ptr = (uint64_t *)&(addr->ipv6.s6_addr[8]);
+    *ptr &= htonll((uint64_t)(~0) << (64 - mask_len - 64));
+  }
 
   return addr;
 }
 
 void bgpstream_addr_copy(bgpstream_ip_addr_t *dst, bgpstream_ip_addr_t *src)
 {
-  if(src->version == BGPSTREAM_ADDR_VERSION_IPV4)
-    {
-      memcpy(dst, src, sizeof(bgpstream_ipv4_addr_t));
-    }
-  if(src->version == BGPSTREAM_ADDR_VERSION_IPV6)
-    {
-      memcpy(dst, src, sizeof(bgpstream_ipv6_addr_t));
-    }
+  if (src->version == BGPSTREAM_ADDR_VERSION_IPV4) {
+    memcpy(dst, src, sizeof(bgpstream_ipv4_addr_t));
+  }
+  if (src->version == BGPSTREAM_ADDR_VERSION_IPV6) {
+    memcpy(dst, src, sizeof(bgpstream_ipv6_addr_t));
+  }
 }
 
-
-bgpstream_addr_storage_t *
-bgpstream_str2addr(char *addr_str, bgpstream_addr_storage_t *addr)
+bgpstream_addr_storage_t *bgpstream_str2addr(char *addr_str,
+                                             bgpstream_addr_storage_t *addr)
 {
-  if(addr_str == NULL || addr == NULL)
-    {
-      return NULL;
-    }
+  if (addr_str == NULL || addr == NULL) {
+    return NULL;
+  }
 
   /* http://man7.org/linux/man-pages/man3/getaddrinfo.3.html */
 
   struct addrinfo *result;
   int s;
   s = getaddrinfo(addr_str, NULL /*service*/, NULL /*hints*/, &result);
-  if (s != 0)
-    {
-      fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(s));
-      return NULL;
-    }
+  if (s != 0) {
+    fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(s));
+    return NULL;
+  }
 
   /* selecting the first result */
-  if(result != NULL)
-    {
-      addr->version = result->ai_family;
-      switch(addr->version)
-        {
-        case BGPSTREAM_ADDR_VERSION_IPV4:
-          addr->ipv4 = ((struct sockaddr_in*) result->ai_addr)->sin_addr;
-          break;
-        case BGPSTREAM_ADDR_VERSION_IPV6:
-          addr->ipv6 = ((struct sockaddr_in6*) result->ai_addr)->sin6_addr;
-          break;
-        default:
-          fprintf(stderr, "Unknown family\n");
-          freeaddrinfo(result);
-          return NULL;
-        }
-      freeaddrinfo(result);      
-      return addr;
+  if (result != NULL) {
+    addr->version = result->ai_family;
+    switch (addr->version) {
+    case BGPSTREAM_ADDR_VERSION_IPV4:
+      addr->ipv4 = ((struct sockaddr_in *)result->ai_addr)->sin_addr;
+      break;
+    case BGPSTREAM_ADDR_VERSION_IPV6:
+      addr->ipv6 = ((struct sockaddr_in6 *)result->ai_addr)->sin6_addr;
+      break;
+    default:
+      fprintf(stderr, "Unknown family\n");
+      freeaddrinfo(result);
+      return NULL;
     }
-  
+    freeaddrinfo(result);
+    return addr;
+  }
+
   return NULL;
 }
 
-uint8_t
-bgpstream_ipv2idx(bgpstream_addr_version_t v)
+uint8_t bgpstream_ipv2idx(bgpstream_addr_version_t v)
 {
-  switch(v)
-    {
-    case BGPSTREAM_ADDR_VERSION_IPV4:
-      return 0;
-    case BGPSTREAM_ADDR_VERSION_IPV6:
-      return 1;
-    default:
-      assert(0);
-    }
+  switch (v) {
+  case BGPSTREAM_ADDR_VERSION_IPV4:
+    return 0;
+  case BGPSTREAM_ADDR_VERSION_IPV6:
+    return 1;
+  default:
+    assert(0);
+  }
   return 255;
 }
 
-bgpstream_addr_version_t
-bgpstream_idx2ipv(uint8_t i)
+bgpstream_addr_version_t bgpstream_idx2ipv(uint8_t i)
 {
-  switch(i)
-    {
-    case 0:
-      return BGPSTREAM_ADDR_VERSION_IPV4;
-    case 1:
-      return BGPSTREAM_ADDR_VERSION_IPV6;
-    default:
-      assert(0);
-    }
+  switch (i) {
+  case 0:
+    return BGPSTREAM_ADDR_VERSION_IPV4;
+  case 1:
+    return BGPSTREAM_ADDR_VERSION_IPV6;
+  default:
+    assert(0);
+  }
   return BGPSTREAM_ADDR_VERSION_UNKNOWN;
-
 }
 
-
-uint8_t
-bgpstream_ipv2number(bgpstream_addr_version_t v)
+uint8_t bgpstream_ipv2number(bgpstream_addr_version_t v)
 {
-  switch(v)
-    {
-    case BGPSTREAM_ADDR_VERSION_IPV4:
-      return 4;
-    case BGPSTREAM_ADDR_VERSION_IPV6:
-      return 6;
-    default:
-      assert(0);
-    }
+  switch (v) {
+  case BGPSTREAM_ADDR_VERSION_IPV4:
+    return 4;
+  case BGPSTREAM_ADDR_VERSION_IPV6:
+    return 6;
+  default:
+    assert(0);
+  }
   return 255;
 }
 
-
-uint8_t
-bgpstream_idx2number(uint8_t i)
+uint8_t bgpstream_idx2number(uint8_t i)
 {
-  switch(i)
-    {
-    case 0:
-      return 4;
-    case 1:
-      return 6;
-    default:
-      assert(0);
-    }
+  switch (i) {
+  case 0:
+    return 4;
+  case 1:
+    return 6;
+  default:
+    assert(0);
+  }
   return 255;
 }

--- a/lib/utils/bgpstream_utils_addr.h
+++ b/lib/utils/bgpstream_utils_addr.h
@@ -21,15 +21,14 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #ifndef __BGPSTREAM_UTILS_ADDR_H
 #define __BGPSTREAM_UTILS_ADDR_H
 
-#include <limits.h>
-#include <stdlib.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
 #include <arpa/inet.h>
+#include <limits.h>
+#include <netinet/in.h>
+#include <stdlib.h>
+#include <sys/socket.h>
 
 /** @file
  *
@@ -45,7 +44,6 @@
  *
  * @{ */
 
-
 /** Version of a BGP Stream IP Address
  *
  * These share values with AF_INET and AF_INET6 so that the version field of a
@@ -55,13 +53,13 @@
 typedef enum {
 
   /** Address type unknown */
-  BGPSTREAM_ADDR_VERSION_UNKNOWN  = 0,
+  BGPSTREAM_ADDR_VERSION_UNKNOWN = 0,
 
   /** Address type IPv4 */
-  BGPSTREAM_ADDR_VERSION_IPV4          = AF_INET,
+  BGPSTREAM_ADDR_VERSION_IPV4 = AF_INET,
 
   /** Address type IPv6 */
-  BGPSTREAM_ADDR_VERSION_IPV6          = AF_INET6
+  BGPSTREAM_ADDR_VERSION_IPV6 = AF_INET6
 
 } bgpstream_addr_version_t;
 
@@ -125,7 +123,6 @@ typedef struct struct_bgpstream_addr_storage_t {
 
     /** IPv6 Address */
     struct in6_addr ipv6;
-
   };
 
 } bgpstream_addr_storage_t;
@@ -147,9 +144,8 @@ typedef struct struct_bgpstream_addr_storage_t {
  * You will likely want to use INET_ADDRSTRLEN or INET6_ADDRSTRLEN to dimension
  * the buffer.
  */
-#define bgpstream_addr_ntop(buf, len, bsaddr)                           \
-  inet_ntop((bsaddr)->version,                                          \
-            &(((bgpstream_ip_addr_t*)(bsaddr))->addr),                  \
+#define bgpstream_addr_ntop(buf, len, bsaddr)                                  \
+  inet_ntop((bsaddr)->version, &(((bgpstream_ip_addr_t *)(bsaddr))->addr),     \
             buf, len)
 
 /** Hash the given IPv4 address into a 32bit number
@@ -278,43 +274,36 @@ void bgpstream_addr_copy(bgpstream_ip_addr_t *dst, bgpstream_ip_addr_t *src);
  * @return the pointer to an initialized address storage, NULL if the
  *         address is not valid
  */
-bgpstream_addr_storage_t *
-bgpstream_str2addr(char *addr_str, bgpstream_addr_storage_t *addr);
-
-
+bgpstream_addr_storage_t *bgpstream_str2addr(char *addr_str,
+                                             bgpstream_addr_storage_t *addr);
 
 /** Returns the index associated to an IP version
  * @param v             enum rapresenting the IP address version
  * @return the index associated with the IP version, 255 if
  * there is an error in the translation
  */
-uint8_t
-bgpstream_ipv2idx(bgpstream_addr_version_t v);
+uint8_t bgpstream_ipv2idx(bgpstream_addr_version_t v);
 
 /** Returns the IP version associated with an index
  * @param i             index associated to the IP address version
  * @return the IP version associated with an index
  */
-bgpstream_addr_version_t
-bgpstream_idx2ipv(uint8_t i);
+bgpstream_addr_version_t bgpstream_idx2ipv(uint8_t i);
 
 /** Returns the number associated to an IP version
  * @param v             enum rapresenting the IP address version
  * @return the IP version number, 255 if there is an error in the
  * translation
  */
-uint8_t
-bgpstream_ipv2number(bgpstream_addr_version_t v);
+uint8_t bgpstream_ipv2number(bgpstream_addr_version_t v);
 
 /** Returns the number associated to the index (associated to an IP version)
  * @param i             index associated to the IP address version
  * @return the index number, 255 if there is an error in the
  * translation
  */
-uint8_t
-bgpstream_idx2number(uint8_t i);
+uint8_t bgpstream_idx2number(uint8_t i);
 
 /** @} */
 
 #endif /* __BGPSTREAM_UTILS_ADDR_H */
-

--- a/lib/utils/bgpstream_utils_addr_set.c
+++ b/lib/utils/bgpstream_utils_addr_set.c
@@ -32,58 +32,46 @@
 /* PRIVATE */
 
 #define STORAGE_HASH_VAL(arg) bgpstream_addr_storage_hash(&(arg))
-#define STORAGE_EQUAL_VAL(arg1, arg2) \
+#define STORAGE_EQUAL_VAL(arg1, arg2)                                          \
   bgpstream_addr_storage_equal(&(arg1), &(arg2))
 
 #define V4_HASH_VAL(arg) bgpstream_ipv4_addr_hash(&(arg))
-#define V4_EQUAL_VAL(arg1, arg2) \
-  bgpstream_ipv4_addr_equal(&(arg1), &(arg2))
+#define V4_EQUAL_VAL(arg1, arg2) bgpstream_ipv4_addr_equal(&(arg1), &(arg2))
 
 #define V6_HASH_VAL(arg) bgpstream_ipv6_addr_hash(&(arg))
-#define V6_EQUAL_VAL(arg1, arg2) \
-  bgpstream_ipv6_addr_equal(&(arg1), &(arg2))
+#define V6_EQUAL_VAL(arg1, arg2) bgpstream_ipv6_addr_equal(&(arg1), &(arg2))
 
 /* STORAGE */
 KHASH_INIT(bgpstream_addr_storage_set /* name */,
-	   bgpstream_addr_storage_t /* khkey_t */,
-	   char /* khval_t */,
-	   0  /* kh_is_set */,
-	   STORAGE_HASH_VAL /*__hash_func */,
-	   STORAGE_EQUAL_VAL /* __hash_equal */);
-
+           bgpstream_addr_storage_t /* khkey_t */, char /* khval_t */,
+           0 /* kh_is_set */, STORAGE_HASH_VAL /*__hash_func */,
+           STORAGE_EQUAL_VAL /* __hash_equal */);
 
 struct bgpstream_addr_storage_set {
-  khash_t(bgpstream_addr_storage_set) *hash;
+  khash_t(bgpstream_addr_storage_set) * hash;
 };
-
 
 /* IPv4 */
 KHASH_INIT(bgpstream_ipv4_addr_set /* name */,
-	   bgpstream_ipv4_addr_t /* khkey_t */,
-	   char /* khval_t */,
-	   0  /* kh_is_set */,
-	   V4_HASH_VAL /*__hash_func */,
-	   V4_EQUAL_VAL /* __hash_equal */);
+           bgpstream_ipv4_addr_t /* khkey_t */, char /* khval_t */,
+           0 /* kh_is_set */, V4_HASH_VAL /*__hash_func */,
+           V4_EQUAL_VAL /* __hash_equal */);
 
 struct bgpstream_ipv4_addr_set {
-  khash_t(bgpstream_ipv4_addr_set) *hash;
+  khash_t(bgpstream_ipv4_addr_set) * hash;
 };
-
 
 /* IPv6 */
 KHASH_INIT(bgpstream_ipv6_addr_set /* name */,
-	   bgpstream_ipv6_addr_t /* khkey_t */,
-	   char /* khval_t */,
-	   0  /* kh_is_set */,
-	   V6_HASH_VAL /*__hash_func */,
-	   V6_EQUAL_VAL /* __hash_equal */);
+           bgpstream_ipv6_addr_t /* khkey_t */, char /* khval_t */,
+           0 /* kh_is_set */, V6_HASH_VAL /*__hash_func */,
+           V6_EQUAL_VAL /* __hash_equal */);
 
 struct bgpstream_ipv6_addr_set {
-  khash_t(bgpstream_ipv6_addr_set) *hash;
+  khash_t(bgpstream_ipv6_addr_set) * hash;
 };
 
 /* PUBLIC FUNCTIONS */
-
 
 /* STORAGE */
 
@@ -91,18 +79,15 @@ bgpstream_addr_storage_set_t *bgpstream_addr_storage_set_create()
 {
   bgpstream_addr_storage_set_t *set;
 
-  if((set =
-      (bgpstream_addr_storage_set_t*)
-      malloc(sizeof(bgpstream_addr_storage_set_t))) == NULL)
-    {
-      return NULL;
-    }
+  if ((set = (bgpstream_addr_storage_set_t *)malloc(
+         sizeof(bgpstream_addr_storage_set_t))) == NULL) {
+    return NULL;
+  }
 
-  if((set->hash = kh_init(bgpstream_addr_storage_set)) == NULL)
-    {
-      bgpstream_addr_storage_set_destroy(set);
-      return NULL;
-    }
+  if ((set->hash = kh_init(bgpstream_addr_storage_set)) == NULL) {
+    bgpstream_addr_storage_set_destroy(set);
+    return NULL;
+  }
 
   return set;
 }
@@ -112,12 +97,11 @@ int bgpstream_addr_storage_set_insert(bgpstream_addr_storage_set_t *set,
 {
   int khret;
   khiter_t k;
-  if((k = kh_get(bgpstream_addr_storage_set, set->hash, *addr)) ==
-     kh_end(set->hash))
-    {
-      k = kh_put(bgpstream_addr_storage_set, set->hash, *addr, &khret);
-      return 1;
-    }
+  if ((k = kh_get(bgpstream_addr_storage_set, set->hash, *addr)) ==
+      kh_end(set->hash)) {
+    k = kh_put(bgpstream_addr_storage_set, set->hash, *addr, &khret);
+    return 1;
+  }
   return 0;
 }
 
@@ -130,17 +114,14 @@ int bgpstream_addr_storage_set_merge(bgpstream_addr_storage_set_t *dst_set,
                                      bgpstream_addr_storage_set_t *src_set)
 {
   khiter_t k;
-  for(k = kh_begin(src_set->hash); k != kh_end(src_set->hash); ++k)
-    {
-      if(kh_exist(src_set->hash, k))
-	{
-	  if(bgpstream_addr_storage_set_insert(dst_set,
-                                               &(kh_key(src_set->hash, k))) <0)
-            {
-              return -1;
-            }
-	}
+  for (k = kh_begin(src_set->hash); k != kh_end(src_set->hash); ++k) {
+    if (kh_exist(src_set->hash, k)) {
+      if (bgpstream_addr_storage_set_insert(dst_set,
+                                            &(kh_key(src_set->hash, k))) < 0) {
+        return -1;
+      }
     }
+  }
   return 0;
 }
 
@@ -155,41 +136,35 @@ void bgpstream_addr_storage_set_clear(bgpstream_addr_storage_set_t *set)
   kh_clear(bgpstream_addr_storage_set, set->hash);
 }
 
-
-
 /* IPv4 */
 
 bgpstream_ipv4_addr_set_t *bgpstream_ipv4_addr_set_create()
 {
   bgpstream_ipv4_addr_set_t *set;
 
-  if((set =
-      (bgpstream_ipv4_addr_set_t*)
-      malloc(sizeof(bgpstream_ipv4_addr_set_t))) == NULL)
-    {
-      return NULL;
-    }
+  if ((set = (bgpstream_ipv4_addr_set_t *)malloc(
+         sizeof(bgpstream_ipv4_addr_set_t))) == NULL) {
+    return NULL;
+  }
 
-  if((set->hash = kh_init(bgpstream_ipv4_addr_set)) == NULL)
-    {
-      bgpstream_ipv4_addr_set_destroy(set);
-      return NULL;
-    }
+  if ((set->hash = kh_init(bgpstream_ipv4_addr_set)) == NULL) {
+    bgpstream_ipv4_addr_set_destroy(set);
+    return NULL;
+  }
 
   return set;
 }
 
 int bgpstream_ipv4_addr_set_insert(bgpstream_ipv4_addr_set_t *set,
-                                      bgpstream_ipv4_addr_t *addr)
+                                   bgpstream_ipv4_addr_t *addr)
 {
   int khret;
   khiter_t k;
-  if((k = kh_get(bgpstream_ipv4_addr_set, set->hash, *addr)) ==
-     kh_end(set->hash))
-    {
-      k = kh_put(bgpstream_ipv4_addr_set, set->hash, *addr, &khret);
-      return 1;
-    }
+  if ((k = kh_get(bgpstream_ipv4_addr_set, set->hash, *addr)) ==
+      kh_end(set->hash)) {
+    k = kh_put(bgpstream_ipv4_addr_set, set->hash, *addr, &khret);
+    return 1;
+  }
   return 0;
 }
 
@@ -199,20 +174,17 @@ int bgpstream_ipv4_addr_set_size(bgpstream_ipv4_addr_set_t *set)
 }
 
 int bgpstream_ipv4_addr_set_merge(bgpstream_ipv4_addr_set_t *dst_set,
-                                     bgpstream_ipv4_addr_set_t *src_set)
+                                  bgpstream_ipv4_addr_set_t *src_set)
 {
   khiter_t k;
-  for(k = kh_begin(src_set->hash); k != kh_end(src_set->hash); ++k)
-    {
-      if(kh_exist(src_set->hash, k))
-	{
-	  if(bgpstream_ipv4_addr_set_insert(dst_set,
-                                               &(kh_key(src_set->hash, k))) <0)
-            {
-              return -1;
-            }
-	}
+  for (k = kh_begin(src_set->hash); k != kh_end(src_set->hash); ++k) {
+    if (kh_exist(src_set->hash, k)) {
+      if (bgpstream_ipv4_addr_set_insert(dst_set, &(kh_key(src_set->hash, k))) <
+          0) {
+        return -1;
+      }
     }
+  }
   return 0;
 }
 
@@ -227,41 +199,35 @@ void bgpstream_ipv4_addr_set_clear(bgpstream_ipv4_addr_set_t *set)
   kh_clear(bgpstream_ipv4_addr_set, set->hash);
 }
 
-
-
 /* IPv6 */
 
 bgpstream_ipv6_addr_set_t *bgpstream_ipv6_addr_set_create()
 {
   bgpstream_ipv6_addr_set_t *set;
 
-  if((set =
-      (bgpstream_ipv6_addr_set_t*)
-      malloc(sizeof(bgpstream_ipv6_addr_set_t))) == NULL)
-    {
-      return NULL;
-    }
+  if ((set = (bgpstream_ipv6_addr_set_t *)malloc(
+         sizeof(bgpstream_ipv6_addr_set_t))) == NULL) {
+    return NULL;
+  }
 
-  if((set->hash = kh_init(bgpstream_ipv6_addr_set)) == NULL)
-    {
-      bgpstream_ipv6_addr_set_destroy(set);
-      return NULL;
-    }
+  if ((set->hash = kh_init(bgpstream_ipv6_addr_set)) == NULL) {
+    bgpstream_ipv6_addr_set_destroy(set);
+    return NULL;
+  }
 
   return set;
 }
 
 int bgpstream_ipv6_addr_set_insert(bgpstream_ipv6_addr_set_t *set,
-                                      bgpstream_ipv6_addr_t *addr)
+                                   bgpstream_ipv6_addr_t *addr)
 {
   int khret;
   khiter_t k;
-  if((k = kh_get(bgpstream_ipv6_addr_set, set->hash, *addr)) ==
-     kh_end(set->hash))
-    {
-      k = kh_put(bgpstream_ipv6_addr_set, set->hash, *addr, &khret);
-      return 1;
-    }
+  if ((k = kh_get(bgpstream_ipv6_addr_set, set->hash, *addr)) ==
+      kh_end(set->hash)) {
+    k = kh_put(bgpstream_ipv6_addr_set, set->hash, *addr, &khret);
+    return 1;
+  }
   return 0;
 }
 
@@ -271,20 +237,17 @@ int bgpstream_ipv6_addr_set_size(bgpstream_ipv6_addr_set_t *set)
 }
 
 int bgpstream_ipv6_addr_set_merge(bgpstream_ipv6_addr_set_t *dst_set,
-                                     bgpstream_ipv6_addr_set_t *src_set)
+                                  bgpstream_ipv6_addr_set_t *src_set)
 {
   khiter_t k;
-  for(k = kh_begin(src_set->hash); k != kh_end(src_set->hash); ++k)
-    {
-      if(kh_exist(src_set->hash, k))
-	{
-	  if(bgpstream_ipv6_addr_set_insert(dst_set,
-                                               &(kh_key(src_set->hash, k))) <0)
-            {
-              return -1;
-            }
-	}
+  for (k = kh_begin(src_set->hash); k != kh_end(src_set->hash); ++k) {
+    if (kh_exist(src_set->hash, k)) {
+      if (bgpstream_ipv6_addr_set_insert(dst_set, &(kh_key(src_set->hash, k))) <
+          0) {
+        return -1;
+      }
     }
+  }
   return 0;
 }
 

--- a/lib/utils/bgpstream_utils_addr_set.h
+++ b/lib/utils/bgpstream_utils_addr_set.h
@@ -21,7 +21,6 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #ifndef __BGPSTREAM_UTILS_ADDR_SET_H
 #define __BGPSTREAM_UTILS_ADDR_SET_H
 
@@ -104,9 +103,6 @@ void bgpstream_addr_storage_set_destroy(bgpstream_addr_storage_set_t *set);
  */
 void bgpstream_addr_storage_set_clear(bgpstream_addr_storage_set_t *set);
 
-
-
-
 /* IPv4 */
 
 /** Create a new IPv4 Address set instance
@@ -125,7 +121,7 @@ bgpstream_ipv4_addr_set_t *bgpstream_ipv4_addr_set_create();
  * This function takes a copy of the address before it is inserted in the set.
  */
 int bgpstream_ipv4_addr_set_insert(bgpstream_ipv4_addr_set_t *set,
-                                      bgpstream_ipv4_addr_t *addr);
+                                   bgpstream_ipv4_addr_t *addr);
 
 /** Get the number of addresses in the given set
  *
@@ -155,8 +151,6 @@ void bgpstream_ipv4_addr_set_destroy(bgpstream_ipv4_addr_set_t *set);
  */
 void bgpstream_ipv4_addr_set_clear(bgpstream_ipv4_addr_set_t *set);
 
-
-
 /** Create a new IPv6 Address set instance
  *
  * @return a pointer to the structure, or NULL if an error occurred
@@ -171,7 +165,7 @@ bgpstream_ipv6_addr_set_t *bgpstream_ipv6_addr_set_create();
  * error occurred
  */
 int bgpstream_ipv6_addr_set_insert(bgpstream_ipv6_addr_set_t *set,
-                                      bgpstream_ipv6_addr_t *addr);
+                                   bgpstream_ipv6_addr_t *addr);
 
 /** Get the number of addresses in the given set
  *
@@ -202,5 +196,3 @@ void bgpstream_ipv6_addr_set_destroy(bgpstream_ipv6_addr_set_t *set);
 void bgpstream_ipv6_addr_set_clear(bgpstream_ipv6_addr_set_t *set);
 
 #endif /* __BGPSTREAM_UTILS_ADDR_SET_H */
-
-

--- a/lib/utils/bgpstream_utils_as_path.c
+++ b/lib/utils/bgpstream_utils_as_path.c
@@ -33,48 +33,47 @@
 
 #include "bgpstream_utils_as_path_int.h"
 
-#define SIZEOF_SEG_SET(segp)                                            \
-  (sizeof(bgpstream_as_path_seg_set_t) +                                \
-   (sizeof(uint32_t)*((bgpstream_as_path_seg_set_t*)(segp))->asn_cnt))
+#define SIZEOF_SEG_SET(segp)                                                   \
+  (sizeof(bgpstream_as_path_seg_set_t) +                                       \
+   (sizeof(uint32_t) * ((bgpstream_as_path_seg_set_t *)(segp))->asn_cnt))
 
-#define SIZEOF_SEG(segp)                        \
-  (((segp)->type == BGPSTREAM_AS_PATH_SEG_ASN) ?        \
-   sizeof(bgpstream_as_path_seg_asn_t) :                \
-   SIZEOF_SEG_SET(segp))
+#define SIZEOF_SEG(segp)                                                       \
+  (((segp)->type == BGPSTREAM_AS_PATH_SEG_ASN)                                 \
+     ? sizeof(bgpstream_as_path_seg_asn_t)                                     \
+     : SIZEOF_SEG_SET(segp))
 
-#define CUR_SEG(path, iter)                                     \
-  ((bgpstream_as_path_seg_t *)((path)->data+(iter)->cur_offset))
+#define CUR_SEG(path, iter)                                                    \
+  ((bgpstream_as_path_seg_t *)((path)->data + (iter)->cur_offset))
 
-static bgpstream_as_path_seg_asn_t *seg_asn_dup(bgpstream_as_path_seg_asn_t *src)
+static bgpstream_as_path_seg_asn_t *
+seg_asn_dup(bgpstream_as_path_seg_asn_t *src)
 {
   bgpstream_as_path_seg_asn_t *seg = NULL;
 
-  if((seg = malloc(sizeof(bgpstream_as_path_seg_asn_t))) == NULL)
-    {
-      return NULL;
-    }
+  if ((seg = malloc(sizeof(bgpstream_as_path_seg_asn_t))) == NULL) {
+    return NULL;
+  }
 
   *seg = *src;
 
   return seg;
 }
 
-static bgpstream_as_path_seg_set_t *seg_set_dup(bgpstream_as_path_seg_set_t *src)
+static bgpstream_as_path_seg_set_t *
+seg_set_dup(bgpstream_as_path_seg_set_t *src)
 {
   bgpstream_as_path_seg_set_t *seg = NULL;
   int i;
 
-  if((seg = malloc(SIZEOF_SEG_SET(src))) == NULL)
-    {
-      return NULL;
-    }
+  if ((seg = malloc(SIZEOF_SEG_SET(src))) == NULL) {
+    return NULL;
+  }
 
   *seg = *src;
 
-  for(i=0; i<src->asn_cnt; i++)
-    {
-      seg->asn[i] = src->asn[i];
-    }
+  for (i = 0; i < src->asn_cnt; i++) {
+    seg->asn[i] = src->asn[i];
+  }
 
   return seg;
 }
@@ -83,82 +82,76 @@ static bgpstream_as_path_seg_set_t *seg_set_dup(bgpstream_as_path_seg_set_t *src
 
 /* AS HOP FUNCTIONS */
 
-#define ADD_CHAR(chr)                           \
-  do {                                          \
-    if((len-written) > 0)                       \
-      {                                         \
-        *bufp = chr;                            \
-        bufp++;                                 \
-      }                                         \
-    written++;                                  \
-  } while(0)
+#define ADD_CHAR(chr)                                                          \
+  do {                                                                         \
+    if ((len - written) > 0) {                                                 \
+      *bufp = chr;                                                             \
+      bufp++;                                                                  \
+    }                                                                          \
+    written++;                                                                 \
+  } while (0)
 
-#define SET_SNPRINTF(fchr, lchr, schr)          \
-  do {                                          \
-    char *bufp = buf;                                                   \
-    bgpstream_as_path_seg_set_t *segset = (bgpstream_as_path_seg_set_t*)seg; \
-    ADD_CHAR(fchr);                                                     \
-    int i;                                                              \
-    for(i=0; i<segset->asn_cnt; i++)                                    \
-      {                                                                 \
-        written += snprintf(bufp, (len-written), "%"PRIu32, segset->asn[i]); \
-        bufp = buf + written;                                           \
-        if(i < segset->asn_cnt-1)                                       \
-          {                                                             \
-            ADD_CHAR(schr);                                             \
-          }                                                             \
-      }                                                                 \
-    ADD_CHAR(lchr);                                                     \
-    if((len-written) > 0) *bufp = '\0';                                 \
-  } while(0)
+#define SET_SNPRINTF(fchr, lchr, schr)                                         \
+  do {                                                                         \
+    char *bufp = buf;                                                          \
+    bgpstream_as_path_seg_set_t *segset = (bgpstream_as_path_seg_set_t *)seg;  \
+    ADD_CHAR(fchr);                                                            \
+    int i;                                                                     \
+    for (i = 0; i < segset->asn_cnt; i++) {                                    \
+      written += snprintf(bufp, (len - written), "%" PRIu32, segset->asn[i]);  \
+      bufp = buf + written;                                                    \
+      if (i < segset->asn_cnt - 1) {                                           \
+        ADD_CHAR(schr);                                                        \
+      }                                                                        \
+    }                                                                          \
+    ADD_CHAR(lchr);                                                            \
+    if ((len - written) > 0)                                                   \
+      *bufp = '\0';                                                            \
+  } while (0)
 
 int bgpstream_as_path_seg_snprintf(char *buf, size_t len,
                                    bgpstream_as_path_seg_t *seg)
 {
   size_t written = 0;
 
-  if(seg == NULL)
-    {
-      if(len > 0)
-        {
-          *buf = '\0';
-        }
-      return 0;
+  if (seg == NULL) {
+    if (len > 0) {
+      *buf = '\0';
     }
+    return 0;
+  }
 
-  switch(seg->type)
-    {
-    case BGPSTREAM_AS_PATH_SEG_ASN:
-      written = snprintf(buf, len, "%"PRIu32,
-                         ((bgpstream_as_path_seg_asn_t*)seg)->asn);
-      break;
+  switch (seg->type) {
+  case BGPSTREAM_AS_PATH_SEG_ASN:
+    written =
+      snprintf(buf, len, "%" PRIu32, ((bgpstream_as_path_seg_asn_t *)seg)->asn);
+    break;
 
-    case BGPSTREAM_AS_PATH_SEG_SET:
-      /* {A,B,C} */
-      SET_SNPRINTF('{', '}', ',');
-      break;
+  case BGPSTREAM_AS_PATH_SEG_SET:
+    /* {A,B,C} */
+    SET_SNPRINTF('{', '}', ',');
+    break;
 
-    case BGPSTREAM_AS_PATH_SEG_CONFED_SET:
-      /* [A,B,C] */
-      SET_SNPRINTF('[', ']', ',');
-      break;
+  case BGPSTREAM_AS_PATH_SEG_CONFED_SET:
+    /* [A,B,C] */
+    SET_SNPRINTF('[', ']', ',');
+    break;
 
-    case BGPSTREAM_AS_PATH_SEG_CONFED_SEQ:
-      /* (A B C) */
-      SET_SNPRINTF('(', ')', ' ');
-      break;
+  case BGPSTREAM_AS_PATH_SEG_CONFED_SEQ:
+    /* (A B C) */
+    SET_SNPRINTF('(', ')', ' ');
+    break;
 
-    default:
-      written = 0;
-      if(len > 0)
-        *buf = '\0';
-      break;
-    }
+  default:
+    written = 0;
+    if (len > 0)
+      *buf = '\0';
+    break;
+  }
 
-  if(written > len)
-    {
-      buf[len-1] = '\0';
-    }
+  if (written > len) {
+    buf[len - 1] = '\0';
+  }
 
   return written;
 }
@@ -169,16 +162,13 @@ bgpstream_as_path_seg_t *bgpstream_as_path_seg_dup(bgpstream_as_path_seg_t *src)
 
   assert(src->type != BGPSTREAM_AS_PATH_SEG_INVALID);
 
-  if(src->type == BGPSTREAM_AS_PATH_SEG_ASN)
-    {
-      return (bgpstream_as_path_seg_t*)
-        seg_asn_dup((bgpstream_as_path_seg_asn_t*)src);
-    }
-  else
-    {
-      return (bgpstream_as_path_seg_t*)
-        seg_set_dup((bgpstream_as_path_seg_set_t*)src);
-    }
+  if (src->type == BGPSTREAM_AS_PATH_SEG_ASN) {
+    return (bgpstream_as_path_seg_t *)seg_asn_dup(
+      (bgpstream_as_path_seg_asn_t *)src);
+  } else {
+    return (bgpstream_as_path_seg_t *)seg_set_dup(
+      (bgpstream_as_path_seg_set_t *)src);
+  }
 }
 
 void bgpstream_as_path_seg_destroy(bgpstream_as_path_seg_t *seg)
@@ -189,58 +179,50 @@ void bgpstream_as_path_seg_destroy(bgpstream_as_path_seg_t *seg)
 
 inline
 #if UINT_MAX == 0xffffffffu
-unsigned int
+  unsigned int
 #elif ULONG_MAX == 0xffffffffu
-unsigned long
+  unsigned long
 #endif
-bgpstream_as_path_seg_hash(bgpstream_as_path_seg_t *seg)
+  bgpstream_as_path_seg_hash(bgpstream_as_path_seg_t *seg)
 {
-  if(seg == NULL)
-    {
-      return -1;
-    }
+  if (seg == NULL) {
+    return -1;
+  }
 
-  if(seg->type == BGPSTREAM_AS_PATH_SEG_ASN)
-    {
-      return ((bgpstream_as_path_seg_asn_t*)seg)->asn;
-    }
+  if (seg->type == BGPSTREAM_AS_PATH_SEG_ASN) {
+    return ((bgpstream_as_path_seg_asn_t *)seg)->asn;
+  }
 
-  return ((bgpstream_as_path_seg_set_t*)seg)->asn[0];
+  return ((bgpstream_as_path_seg_set_t *)seg)->asn[0];
 }
 
 int bgpstream_as_path_seg_equal(bgpstream_as_path_seg_t *seg1,
                                 bgpstream_as_path_seg_t *seg2)
 {
-  if(seg1->type != seg2->type)
-    {
-      return 0;
-    }
+  if (seg1->type != seg2->type) {
+    return 0;
+  }
 
   assert(seg1->type != BGPSTREAM_AS_PATH_SEG_INVALID);
 
-  if(seg1->type == BGPSTREAM_AS_PATH_SEG_ASN)
-    {
-      return ((bgpstream_as_path_seg_asn_t*)seg1)->asn ==
-        ((bgpstream_as_path_seg_asn_t*)seg2)->asn;
+  if (seg1->type == BGPSTREAM_AS_PATH_SEG_ASN) {
+    return ((bgpstream_as_path_seg_asn_t *)seg1)->asn ==
+           ((bgpstream_as_path_seg_asn_t *)seg2)->asn;
+  } else {
+    if (((bgpstream_as_path_seg_set_t *)seg1)->asn_cnt !=
+        ((bgpstream_as_path_seg_set_t *)seg2)->asn_cnt) {
+      return 0;
     }
-  else
-    {
-      if(((bgpstream_as_path_seg_set_t*)seg1)->asn_cnt !=
-         ((bgpstream_as_path_seg_set_t*)seg2)->asn_cnt)
-        {
-          return 0;
-        }
-      return bcmp(((bgpstream_as_path_seg_set_t*)seg1)->asn,
-                  ((bgpstream_as_path_seg_set_t*)seg2)->asn,
-                  sizeof(uint32_t) *
-                  ((bgpstream_as_path_seg_set_t*)seg2)->asn_cnt) == 0;
-    }
+    return bcmp(((bgpstream_as_path_seg_set_t *)seg1)->asn,
+                ((bgpstream_as_path_seg_set_t *)seg2)->asn,
+                sizeof(uint32_t) *
+                  ((bgpstream_as_path_seg_set_t *)seg2)->asn_cnt) == 0;
+  }
 }
 
 /* AS PATH FUNCTIONS */
 
-int bgpstream_as_path_snprintf(char *buf, size_t len,
-                               bgpstream_as_path_t *path)
+int bgpstream_as_path_snprintf(char *buf, size_t len, bgpstream_as_path_t *path)
 {
   bgpstream_as_path_iter_t iter;
   size_t written = 0;
@@ -250,22 +232,19 @@ int bgpstream_as_path_snprintf(char *buf, size_t len,
 
   /* iterate through the path and print each segment */
   bgpstream_as_path_iter_reset(&iter);
-  while((seg = bgpstream_as_path_get_next_seg(path, &iter)) != NULL)
-    {
-      if(need_sep != 0)
-        {
-          ADD_CHAR(' ');
-        }
-      need_sep = 1;
-      written += bgpstream_as_path_seg_snprintf(bufp, (len-written), seg);
-      bufp = buf+written;
+  while ((seg = bgpstream_as_path_get_next_seg(path, &iter)) != NULL) {
+    if (need_sep != 0) {
+      ADD_CHAR(' ');
     }
+    need_sep = 1;
+    written += bgpstream_as_path_seg_snprintf(bufp, (len - written), seg);
+    bufp = buf + written;
+  }
   *bufp = '\0';
 
-  if(written > len)
-    {
-      buf[len-1] = '\0';
-    }
+  if (written > len) {
+    buf[len - 1] = '\0';
+  }
   return written;
 }
 
@@ -273,10 +252,9 @@ bgpstream_as_path_t *bgpstream_as_path_create()
 {
   bgpstream_as_path_t *path;
 
-  if((path = malloc_zero(sizeof(bgpstream_as_path_t))) == NULL)
-    {
-      return NULL;
-    }
+  if ((path = malloc_zero(sizeof(bgpstream_as_path_t))) == NULL) {
+    return NULL;
+  }
 
   path->origin_offset = UINT16_MAX;
 
@@ -292,10 +270,9 @@ void bgpstream_as_path_clear(bgpstream_as_path_t *path)
 
 void bgpstream_as_path_destroy(bgpstream_as_path_t *path)
 {
-  if(path->data_alloc_len != UINT16_MAX)
-    {
-      free(path->data);
-    }
+  if (path->data_alloc_len != UINT16_MAX) {
+    free(path->data);
+  }
   path->data = NULL;
   path->data_alloc_len = 0;
   bgpstream_as_path_clear(path);
@@ -304,19 +281,16 @@ void bgpstream_as_path_destroy(bgpstream_as_path_t *path)
 
 int bgpstream_as_path_copy(bgpstream_as_path_t *dst, bgpstream_as_path_t *src)
 {
-  if(dst->data_alloc_len == UINT16_MAX)
-    {
-      /* no longer points to external memory */
-      dst->data_alloc_len = 0;
+  if (dst->data_alloc_len == UINT16_MAX) {
+    /* no longer points to external memory */
+    dst->data_alloc_len = 0;
+  }
+  if (dst->data_alloc_len < src->data_len) {
+    if ((dst->data = realloc(dst->data, src->data_len)) == NULL) {
+      return -1;
     }
-  if(dst->data_alloc_len < src->data_len)
-    {
-      if((dst->data = realloc(dst->data, src->data_len)) == NULL)
-        {
-          return -1;
-        }
-      dst->data_alloc_len = src->data_len;
-    }
+    dst->data_alloc_len = src->data_len;
+  }
 
   memcpy(dst->data, src->data, src->data_len);
   dst->data_len = src->data_len;
@@ -418,26 +392,25 @@ bgpstream_as_path_get_origin_seg(bgpstream_as_path_t *path)
 {
   /*assert(path != NULL);*/
 
-  if(path->data_len == 0)
-    {
-      return NULL;
-    }
+  if (path->data_len == 0) {
+    return NULL;
+  }
 
   /*assert(path->data != NULL);*/
   /*assert(path->origin_offset != UINT16_MAX);*/
 
-  return (bgpstream_as_path_seg_t*)(path->data+path->origin_offset);
+  return (bgpstream_as_path_seg_t *)(path->data + path->origin_offset);
 }
 
 int bgpstream_as_path_get_origin_val(bgpstream_as_path_t *path, uint32_t *asn)
 {
-    bgpstream_as_path_seg_t *origin_seg = bgpstream_as_path_get_origin_seg(path);
-    if (origin_seg == NULL || origin_seg->type != BGPSTREAM_AS_PATH_SEG_ASN) {
-        return -1;
-    } else {
-        *asn = ((bgpstream_as_path_seg_asn_t*)origin_seg)->asn;
-        return 0;
-    }
+  bgpstream_as_path_seg_t *origin_seg = bgpstream_as_path_get_origin_seg(path);
+  if (origin_seg == NULL || origin_seg->type != BGPSTREAM_AS_PATH_SEG_ASN) {
+    return -1;
+  } else {
+    *asn = ((bgpstream_as_path_seg_asn_t *)origin_seg)->asn;
+    return 0;
+  }
 }
 
 void bgpstream_as_path_iter_reset(bgpstream_as_path_iter_t *iter)
@@ -452,10 +425,9 @@ bgpstream_as_path_get_next_seg(bgpstream_as_path_t *path,
   bgpstream_as_path_seg_t *cur_seg;
 
   /* end of path */
-  if(path->data_len == 0 || iter->cur_offset >= path->data_len)
-    {
-      return NULL;
-    }
+  if (path->data_len == 0 || iter->cur_offset >= path->data_len) {
+    return NULL;
+  }
 
   cur_seg = CUR_SEG(path, iter);
 
@@ -477,16 +449,13 @@ int bgpstream_as_path_get_len(bgpstream_as_path_t *path)
 uint16_t bgpstream_as_path_get_data(bgpstream_as_path_t *path, uint8_t **data)
 {
   assert(data != NULL);
-  if(path == NULL)
-    {
-      *data = NULL;
-      return 0;
-    }
-  else
-    {
-      *data = path->data;
-      return path->data_len;
-    }
+  if (path == NULL) {
+    *data = NULL;
+    return 0;
+  } else {
+    *data = path->data;
+    return path->data_len;
+  }
 }
 
 int bgpstream_as_path_populate_from_data(bgpstream_as_path_t *path,
@@ -496,21 +465,18 @@ int bgpstream_as_path_populate_from_data(bgpstream_as_path_t *path,
 
   bgpstream_as_path_clear(path);
 
-  if(path->data_alloc_len == UINT16_MAX)
-    {
-      /* the data is not owned by us */
-      path->data_alloc_len = 0;
-      path->data = NULL;
-    }
+  if (path->data_alloc_len == UINT16_MAX) {
+    /* the data is not owned by us */
+    path->data_alloc_len = 0;
+    path->data = NULL;
+  }
 
-  if(path->data_alloc_len < data_len)
-    {
-      if((path->data = realloc(path->data, data_len)) == NULL)
-        {
-          return -1;
-        }
-      path->data_alloc_len = data_len;
+  if (path->data_alloc_len < data_len) {
+    if ((path->data = realloc(path->data, data_len)) == NULL) {
+      return -1;
     }
+    path->data_alloc_len = data_len;
+  }
 
   memcpy(path->data, data, data_len);
   path->data_len = data_len;
@@ -538,13 +504,12 @@ int bgpstream_as_path_populate_from_data_zc(bgpstream_as_path_t *path,
 }
 
 /* from http://burtleburtle.net/bob/hash/integer.html */
-static inline uint32_t
-mixbits(uint32_t a)
+static inline uint32_t mixbits(uint32_t a)
 {
-    a = a ^ (a>>4);
-    a = (a^0xdeadbeef) + (a<<5);
-    a = a ^ (a>>11);
-    return a;
+  a = a ^ (a >> 4);
+  a = (a ^ 0xdeadbeef) + (a << 5);
+  a = a ^ (a >> 11);
+  return a;
 }
 
 #if UINT_MAX == 0xffffffffu
@@ -554,33 +519,27 @@ unsigned long
 #endif
 bgpstream_as_path_hash(bgpstream_as_path_t *path)
 {
-  if(path->data_len > 0)
-    {
-      /* put the peer (ish) hash into the top bits */
-      /* and put the origin hash into the bottom bits */
-      return
-        mixbits(
-          ((bgpstream_as_path_seg_hash((bgpstream_as_path_seg_t*)path->data)
-            & 0xFFFF) << 8)
-          |
-          (bgpstream_as_path_seg_hash(
-                     (bgpstream_as_path_seg_t*)(path->data+path->origin_offset))
-           & 0xFFFF)
-        );
-    }
-  else
-    {
-      return 0;
-    }
+  if (path->data_len > 0) {
+    /* put the peer (ish) hash into the top bits */
+    /* and put the origin hash into the bottom bits */
+    return mixbits(
+      ((bgpstream_as_path_seg_hash((bgpstream_as_path_seg_t *)path->data) &
+        0xFFFF)
+       << 8) |
+      (bgpstream_as_path_seg_hash(
+         (bgpstream_as_path_seg_t *)(path->data + path->origin_offset)) &
+       0xFFFF));
+  } else {
+    return 0;
+  }
 }
 
 inline int bgpstream_as_path_equal(bgpstream_as_path_t *path1,
                                    bgpstream_as_path_t *path2)
 {
   return (path1->data_len == path2->data_len) &&
-    !bcmp(path1->data, path2->data, path1->data_len);
+         !bcmp(path1->data, path2->data, path1->data_len);
 }
-
 
 /* ========== PRIVATE FUNCTIONS ========== */
 
@@ -609,12 +568,11 @@ static void test_path_copy(bgpstream_as_path_t *path)
   char buf3[8000];
   bgpstream_as_path_snprintf(buf3, 8000, corepath);
 
-  if(bgpstream_as_path_get_len(path) > 0 &&
-     bgpstream_as_path_equal(path, corepath) != 0)
-    {
-      fprintf(stderr, "ERROR: %s|%s\n", buf1, buf3);
-      assert(0);
-    }
+  if (bgpstream_as_path_get_len(path) > 0 &&
+      bgpstream_as_path_equal(path, corepath) != 0) {
+    fprintf(stderr, "ERROR: %s|%s\n", buf1, buf3);
+    assert(0);
+  }
 
   // orig, copy, core
   fprintf(stdout, "PATH_COPY|%s|%s|%s\n", buf1, buf2, buf3);
@@ -629,8 +587,8 @@ static void test_path_copy(bgpstream_as_path_t *path)
   char buf6[8000];
   bgpstream_as_path_seg_snprintf(buf6, 8000,
                                  bgpstream_as_path_get_origin_seg(corepath));
-  fprintf(stdout, "PATH_ORIGIN|%s:%s|%s:%s|%s:%s\n",
-          buf1, buf4, buf2, buf5, buf3, buf6);
+  fprintf(stdout, "PATH_ORIGIN|%s:%s|%s:%s|%s:%s\n", buf1, buf4, buf2, buf5,
+          buf3, buf6);
 
 #if 0
   // hashing
@@ -666,7 +624,7 @@ int bgpstream_as_path_populate(bgpstream_as_path_t *path,
   assert(path != NULL);
   assert(bd_path != NULL);
 
-  ptr = (uint8_t*)bd_path->data;
+  ptr = (uint8_t *)bd_path->data;
   end = ptr + bd_path->length;
 
   /* we are going to overwrite the current path */
@@ -675,153 +633,131 @@ int bgpstream_as_path_populate(bgpstream_as_path_t *path,
 
   bgpstream_as_path_seg_type_t last_type = BGPSTREAM_AS_PATH_SEG_ASN;
 
-  while(ptr < end)
-    {
-      bd_seg = (struct assegment *)ptr;
+  while (ptr < end) {
+    bd_seg = (struct assegment *)ptr;
 
-      /* Check AS type validity. */
-      if((bd_seg->type != AS_SET) &&
-         (bd_seg->type != AS_SEQUENCE) &&
-         (bd_seg->type != AS_CONFED_SET) &&
-         (bd_seg->type != AS_CONFED_SEQUENCE))
-        {
-          fprintf(stderr, "WARN: AS_PATH with segment type %d\n", bd_seg->type);
-          return -1;
-        }
+    /* Check AS type validity. */
+    if ((bd_seg->type != AS_SET) && (bd_seg->type != AS_SEQUENCE) &&
+        (bd_seg->type != AS_CONFED_SET) &&
+        (bd_seg->type != AS_CONFED_SEQUENCE)) {
+      fprintf(stderr, "WARN: AS_PATH with segment type %d\n", bd_seg->type);
+      return -1;
+    }
 
-      /* Check AS length. */
-      if ((ptr + (bd_seg->length * bd_path->asn_len) + AS_HEADER_SIZE) > end)
-      {
-        fprintf(stderr, "ERROR: Corrupted AS_PATH\n");
+    /* Check AS length. */
+    if ((ptr + (bd_seg->length * bd_path->asn_len) + AS_HEADER_SIZE) > end) {
+      fprintf(stderr, "ERROR: Corrupted AS_PATH\n");
+      return -1;
+    }
+
+    /* ensure that the data buffer is long enough */
+    if (bd_seg->type == AS_SEQUENCE) {
+      new_len =
+        path->data_len + (sizeof(bgpstream_as_path_seg_asn_t) * bd_seg->length);
+      assert(new_len < UINT16_MAX);
+    } else {
+      /* a set */
+      new_len = path->data_len + sizeof(bgpstream_as_path_seg_set_t) +
+                (sizeof(uint32_t) * bd_seg->length);
+      assert(new_len < UINT16_MAX);
+    }
+
+    if (path->data_alloc_len < new_len) {
+      if ((path->data = realloc(path->data, new_len)) == NULL) {
         return -1;
       }
+      path->data_alloc_len = new_len;
+    }
+    path->data_len = new_len;
 
-      /* ensure that the data buffer is long enough */
-      if(bd_seg->type == AS_SEQUENCE)
-        {
-          new_len = path->data_len +
-            (sizeof(bgpstream_as_path_seg_asn_t) * bd_seg->length);
-          assert(new_len < UINT16_MAX);
-        }
-      else
-        {
-          /* a set */
-          new_len = path->data_len + sizeof(bgpstream_as_path_seg_set_t) +
-            (sizeof(uint32_t) * bd_seg->length);
-          assert(new_len < UINT16_MAX);
-        }
+    seg = CUR_SEG(path, &iter);
+    switch (bd_seg->type) {
+    case AS_SET:
+      seg->type = BGPSTREAM_AS_PATH_SEG_SET;
+      break;
 
-      if(path->data_alloc_len < new_len)
-        {
-          if((path->data = realloc(path->data, new_len)) == NULL)
-            {
-              return -1;
-            }
-          path->data_alloc_len = new_len;
-        }
-      path->data_len = new_len;
+    case AS_SEQUENCE:
+      /* we break sequences into many segments */
+      break;
 
-      seg = CUR_SEG(path, &iter);
-      switch(bd_seg->type)
-        {
-        case AS_SET:
-          seg->type = BGPSTREAM_AS_PATH_SEG_SET;
-          break;
+    case AS_CONFED_SET:
+      seg->type = BGPSTREAM_AS_PATH_SEG_CONFED_SET;
+      break;
 
-        case AS_SEQUENCE:
-          /* we break sequences into many segments */
-          break;
-
-        case AS_CONFED_SET:
-          seg->type = BGPSTREAM_AS_PATH_SEG_CONFED_SET;
-          break;
-
-        case AS_CONFED_SEQUENCE:
-          seg->type = BGPSTREAM_AS_PATH_SEG_CONFED_SEQ;
-          break;
-        }
-
-      /** @todo consider merging consecutive segments of the same type? */
-      if(last_type != BGPSTREAM_AS_PATH_SEG_ASN && seg->type == last_type)
-        {
-          fprintf(stderr, "ERROR: Consecutive segments of identical type\n");
-          fprintf(stderr, "ERROR: This is an unhandled error.\n");
-          fprintf(stderr, "ERROR: Contact bgpstream-info@caida.org\n");
-          assert(0);
-          return -1;
-        }
-
-      if(bd_seg->type != AS_SEQUENCE)
-        {
-          path->origin_offset = iter.cur_offset;
-          ((bgpstream_as_path_seg_set_t*)seg)->asn_cnt = bd_seg->length;
-        }
-
-      for(i=0; i<bd_seg->length; i++)
-        {
-          switch(bd_path->asn_len)
-            {
-            case ASN16_LEN:
-              ptr16 = (uint16_t*) (bd_seg->data+(i*bd_path->asn_len));
-              asn = ntohs(*ptr16);
-              break;
-            case ASN32_LEN:
-              ptr32 = (uint32_t*) (bd_seg->data+(i*bd_path->asn_len));
-              asn = ntohl(*ptr32);
-              break;
-            default:
-              asn = 0;
-              assert(0);
-              return -1;
-            }
-
-          if(bd_seg->type == AS_SEQUENCE)
-            {
-              seg->type = BGPSTREAM_AS_PATH_SEG_ASN;
-              ((bgpstream_as_path_seg_asn_t*)seg)->asn = asn;
-
-              /* move on */
-              path->origin_offset = iter.cur_offset;
-              iter.cur_offset += sizeof(bgpstream_as_path_seg_asn_t);
-              path->seg_cnt++;
-              seg = CUR_SEG(path, &iter);
-            }
-          else
-            {
-              ((bgpstream_as_path_seg_set_t*)seg)->asn[i] = asn;
-            }
-        }
-
-      if(bd_seg->type != AS_SEQUENCE)
-        {
-          iter.cur_offset = new_len;
-          path->seg_cnt++;
-        }
-
-      ptr += (bd_seg->length * bd_path->asn_len) + AS_HEADER_SIZE;
+    case AS_CONFED_SEQUENCE:
+      seg->type = BGPSTREAM_AS_PATH_SEG_CONFED_SEQ;
+      break;
     }
 
-  /* the following will cause a performance hit. only enable if debugging path
-     parsing */
-#ifdef PATH_DEBUG
-  char buffer[8000];
-  size_t written = bgpstream_as_path_snprintf(buffer, 8000, path);
-  if(bd_path->str != NULL)
-    {
-      fprintf(stdout, "warn: as path string populated\n");
-    }
-  else
-    {
-      process_attr_aspath_string(bd_path);
-    }
-  if(written >= 8000 || strcmp(buffer, bd_path->str) != 0)
-    {
-      fprintf(stderr, "Written: %lu\n", written);
-      fprintf(stderr, "BS Path: >>%s<<\n", buffer);
-      fprintf(stderr, "BD Path: %s\n", bd_path->str);
+    /** @todo consider merging consecutive segments of the same type? */
+    if (last_type != BGPSTREAM_AS_PATH_SEG_ASN && seg->type == last_type) {
+      fprintf(stderr, "ERROR: Consecutive segments of identical type\n");
+      fprintf(stderr, "ERROR: This is an unhandled error.\n");
+      fprintf(stderr, "ERROR: Contact bgpstream-info@caida.org\n");
       assert(0);
       return -1;
     }
+
+    if (bd_seg->type != AS_SEQUENCE) {
+      path->origin_offset = iter.cur_offset;
+      ((bgpstream_as_path_seg_set_t *)seg)->asn_cnt = bd_seg->length;
+    }
+
+    for (i = 0; i < bd_seg->length; i++) {
+      switch (bd_path->asn_len) {
+      case ASN16_LEN:
+        ptr16 = (uint16_t *)(bd_seg->data + (i * bd_path->asn_len));
+        asn = ntohs(*ptr16);
+        break;
+      case ASN32_LEN:
+        ptr32 = (uint32_t *)(bd_seg->data + (i * bd_path->asn_len));
+        asn = ntohl(*ptr32);
+        break;
+      default:
+        asn = 0;
+        assert(0);
+        return -1;
+      }
+
+      if (bd_seg->type == AS_SEQUENCE) {
+        seg->type = BGPSTREAM_AS_PATH_SEG_ASN;
+        ((bgpstream_as_path_seg_asn_t *)seg)->asn = asn;
+
+        /* move on */
+        path->origin_offset = iter.cur_offset;
+        iter.cur_offset += sizeof(bgpstream_as_path_seg_asn_t);
+        path->seg_cnt++;
+        seg = CUR_SEG(path, &iter);
+      } else {
+        ((bgpstream_as_path_seg_set_t *)seg)->asn[i] = asn;
+      }
+    }
+
+    if (bd_seg->type != AS_SEQUENCE) {
+      iter.cur_offset = new_len;
+      path->seg_cnt++;
+    }
+
+    ptr += (bd_seg->length * bd_path->asn_len) + AS_HEADER_SIZE;
+  }
+
+/* the following will cause a performance hit. only enable if debugging path
+   parsing */
+#ifdef PATH_DEBUG
+  char buffer[8000];
+  size_t written = bgpstream_as_path_snprintf(buffer, 8000, path);
+  if (bd_path->str != NULL) {
+    fprintf(stdout, "warn: as path string populated\n");
+  } else {
+    process_attr_aspath_string(bd_path);
+  }
+  if (written >= 8000 || strcmp(buffer, bd_path->str) != 0) {
+    fprintf(stderr, "Written: %lu\n", written);
+    fprintf(stderr, "BS Path: >>%s<<\n", buffer);
+    fprintf(stderr, "BD Path: %s\n", bd_path->str);
+    assert(0);
+    return -1;
+  }
 #endif
 
 #ifdef PATH_COPY_DEBUG
@@ -841,10 +777,9 @@ void bgpstream_as_path_update_fields(bgpstream_as_path_t *path)
   bgpstream_as_path_iter_reset(&iter);
   path->seg_cnt = 0;
 
-  while((seg = bgpstream_as_path_get_next_seg(path, &iter)) != NULL)
-    {
-      path->origin_offset = offset;
-      path->seg_cnt++;
-      offset += SIZEOF_SEG(seg);
-    }
+  while ((seg = bgpstream_as_path_get_next_seg(path, &iter)) != NULL) {
+    path->origin_offset = offset;
+    path->seg_cnt++;
+    offset += SIZEOF_SEG(seg);
+  }
 }

--- a/lib/utils/bgpstream_utils_as_path.h
+++ b/lib/utils/bgpstream_utils_as_path.h
@@ -21,7 +21,6 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #ifndef __BGPSTREAM_UTILS_AS_PATH_H
 #define __BGPSTREAM_UTILS_AS_PATH_H
 
@@ -54,19 +53,19 @@
 typedef enum {
 
   /** Invalid Segment Type */
-  BGPSTREAM_AS_PATH_SEG_INVALID      = 0,
+  BGPSTREAM_AS_PATH_SEG_INVALID = 0,
 
   /** Simple ASN AS Path Segment */
-  BGPSTREAM_AS_PATH_SEG_ASN          = 1,
+  BGPSTREAM_AS_PATH_SEG_ASN = 1,
 
   /** AS Path Segment Set */
-  BGPSTREAM_AS_PATH_SEG_SET          = 2,
+  BGPSTREAM_AS_PATH_SEG_SET = 2,
 
   /** AS Path Segment Confederation Set */
-  BGPSTREAM_AS_PATH_SEG_CONFED_SET   = 3,
+  BGPSTREAM_AS_PATH_SEG_CONFED_SET = 3,
 
   /** AS Path Segment Confederation Sequence */
-  BGPSTREAM_AS_PATH_SEG_CONFED_SEQ   = 4,
+  BGPSTREAM_AS_PATH_SEG_CONFED_SEQ = 4,
 
   /** @todo etc */
 
@@ -88,7 +87,6 @@ typedef struct bgpstream_as_path bgpstream_as_path_t;
  * @name Public Data Structures
  *
  * @{ */
-
 
 /** Generic AS Path Segment.
  *
@@ -168,7 +166,8 @@ int bgpstream_as_path_seg_snprintf(char *buf, size_t len,
  * @note the returned segment must be destroyed using
  * bgpstream_as_path_seg_destroy
  */
-bgpstream_as_path_seg_t *bgpstream_as_path_seg_dup(bgpstream_as_path_seg_t *src);
+bgpstream_as_path_seg_t *
+bgpstream_as_path_seg_dup(bgpstream_as_path_seg_t *src);
 
 /** Destroy the given AS Path Segment
  *
@@ -188,7 +187,6 @@ unsigned long
 #endif
 bgpstream_as_path_seg_hash(bgpstream_as_path_seg_t *seg);
 
-
 /** Compare two AS path segments for equality
  *
  * @param seg1          pointer to the first AS path segment to compare
@@ -198,10 +196,10 @@ bgpstream_as_path_seg_hash(bgpstream_as_path_seg_t *seg);
 int bgpstream_as_path_seg_equal(bgpstream_as_path_seg_t *seg1,
                                 bgpstream_as_path_seg_t *seg2);
 
-
 /* AS PATH FUNCTIONS */
 
-/** Write the string representation of the given AS path into the given character
+/** Write the string representation of the given AS path into the given
+ * character
  *  buffer.
  *
  * @param buf           pointer to a character buffer at least len bytes long
@@ -358,9 +356,6 @@ bgpstream_as_path_hash(bgpstream_as_path_t *path);
 int bgpstream_as_path_equal(bgpstream_as_path_t *path1,
                             bgpstream_as_path_t *path2);
 
-
 /** @} */
 
-
 #endif /* __BGPSTREAM_UTILS_AS_PATH_H */
-

--- a/lib/utils/bgpstream_utils_as_path_int.h
+++ b/lib/utils/bgpstream_utils_as_path_int.h
@@ -21,7 +21,6 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #ifndef __BGPSTREAM_UTILS_AS_PATH_INT_H
 #define __BGPSTREAM_UTILS_AS_PATH_INT_H
 
@@ -57,7 +56,6 @@
  *
  * @{ */
 
-
 /** @} */
 
 /**
@@ -81,7 +79,6 @@ struct bgpstream_as_path {
 
   /* offset of the origin segment */
   uint16_t origin_offset;
-
 };
 
 /** @} */
@@ -108,6 +105,4 @@ void bgpstream_as_path_update_fields(bgpstream_as_path_t *path);
 
 /** @} */
 
-
 #endif /* __BGPSTREAM_UTILS_AS_PATH_INT_H */
-

--- a/lib/utils/bgpstream_utils_as_path_store.c
+++ b/lib/utils/bgpstream_utils_as_path_store.c
@@ -58,12 +58,12 @@ typedef struct pathset {
 
 } __attribute__((packed)) pathset_t;
 
-KHASH_INIT(pathset, uint32_t, pathset_t, 1,
-           kh_int_hash_func, kh_int_hash_equal);
+KHASH_INIT(pathset, uint32_t, pathset_t, 1, kh_int_hash_func,
+           kh_int_hash_equal);
 
 struct bgpstream_as_path_store {
 
-  khash_t(pathset) *path_set;
+  khash_t(pathset) * path_set;
 
   /** The total number of paths in the store */
   uint32_t paths_cnt;
@@ -73,15 +73,13 @@ struct bgpstream_as_path_store {
 
   /** The current path within the current pathset */
   int cur_path;
-
 };
 
 static void store_path_destroy(bgpstream_as_path_store_path_t *spath)
 {
-  if(spath == NULL)
-    {
-      return;
-    }
+  if (spath == NULL) {
+    return;
+  }
 
   /* destroy the path's data */
   assert(spath->path.data_alloc_len != UINT16_MAX);
@@ -90,47 +88,42 @@ static void store_path_destroy(bgpstream_as_path_store_path_t *spath)
   spath->path.data_alloc_len = 0;
 }
 
-int
-store_path_dup(bgpstream_as_path_store_path_t *dst,
-               bgpstream_as_path_store_path_t *src)
+int store_path_dup(bgpstream_as_path_store_path_t *dst,
+                   bgpstream_as_path_store_path_t *src)
 {
   *dst = *src;
 
   /* copy the path data */
   dst->path.data_alloc_len = 0;
-  if((dst->path.data = malloc(src->path.data_len)) == NULL)
-    {
-      goto err;
-    }
+  if ((dst->path.data = malloc(src->path.data_len)) == NULL) {
+    goto err;
+  }
   dst->path.data_alloc_len = src->path.data_len;
   dst->path.data_len = src->path.data_len;
   memcpy(dst->path.data, src->path.data, src->path.data_len);
 
   return 0;
 
- err:
+err:
   store_path_destroy(dst);
   return -1;
 }
 
-static inline int
-store_path_equal(bgpstream_as_path_store_path_t *sp1,
-                 bgpstream_as_path_store_path_t *sp2)
+static inline int store_path_equal(bgpstream_as_path_store_path_t *sp1,
+                                   bgpstream_as_path_store_path_t *sp2)
 {
   return (sp1->is_core == sp2->is_core) &&
-    bgpstream_as_path_equal(&sp1->path, &sp2->path);
+         bgpstream_as_path_equal(&sp1->path, &sp2->path);
 }
 
-static void
-pathset_destroy(pathset_t ps)
+static void pathset_destroy(pathset_t ps)
 {
   int i;
 
   /* destroy each store path */
-  for(i=0; i<ps.paths_cnt; i++)
-    {
-      store_path_destroy(&ps.paths[i]);
-    }
+  for (i = 0; i < ps.paths_cnt; i++) {
+    store_path_destroy(&ps.paths[i]);
+  }
 
   /* destroy the array of paths */
   free(ps.paths);
@@ -138,38 +131,32 @@ pathset_destroy(pathset_t ps)
   ps.paths_cnt = 0;
 }
 
-static uint16_t
-pathset_get_path_id(bgpstream_as_path_store_t *store,
-                    pathset_t *ps,
-                    bgpstream_as_path_store_path_t *findme)
+static uint16_t pathset_get_path_id(bgpstream_as_path_store_t *store,
+                                    pathset_t *ps,
+                                    bgpstream_as_path_store_path_t *findme)
 {
   int i;
   uint32_t path_id;
 
   /* check if it is already in the set */
-  for(i=0; i<ps->paths_cnt; i++)
-    {
-      if(store_path_equal(&ps->paths[i], findme) != 0)
-        {
-          return i;
-        }
+  for (i = 0; i < ps->paths_cnt; i++) {
+    if (store_path_equal(&ps->paths[i], findme) != 0) {
+      return i;
     }
+  }
 
   findme->idx = store->paths_cnt++;
 
   /* need to append this path */
-  if((ps->paths = realloc(ps->paths,
-                          sizeof(bgpstream_as_path_store_path_t) *
-                          (ps->paths_cnt+1))) == NULL)
-    {
-      fprintf(stderr, "ERROR: Could not realloc paths\n");
-      return UINT16_MAX;
-    }
-  if(store_path_dup(&ps->paths[ps->paths_cnt], findme) != 0)
-    {
-      fprintf(stderr, "ERROR: Could not create store path\n");
-      return UINT16_MAX;
-    }
+  if ((ps->paths = realloc(ps->paths, sizeof(bgpstream_as_path_store_path_t) *
+                                        (ps->paths_cnt + 1))) == NULL) {
+    fprintf(stderr, "ERROR: Could not realloc paths\n");
+    return UINT16_MAX;
+  }
+  if (store_path_dup(&ps->paths[ps->paths_cnt], findme) != 0) {
+    fprintf(stderr, "ERROR: Could not create store path\n");
+    return UINT16_MAX;
+  }
   path_id = ps->paths_cnt++;
   assert(ps->paths_cnt <= UINT16_MAX);
 
@@ -182,38 +169,34 @@ bgpstream_as_path_store_t *bgpstream_as_path_store_create()
 {
   bgpstream_as_path_store_t *store;
 
-  if((store = malloc_zero(sizeof(bgpstream_as_path_store_t))) == NULL)
-    {
-      return NULL;
-    }
+  if ((store = malloc_zero(sizeof(bgpstream_as_path_store_t))) == NULL) {
+    return NULL;
+  }
 
-  if((store->path_set = kh_init(pathset)) == NULL)
-    {
-      goto err;
-    }
+  if ((store->path_set = kh_init(pathset)) == NULL) {
+    goto err;
+  }
   /* pre-allocate to minimize resize events */
-  kh_resize(pathset, store->path_set, 1<<24); /* 2^24 = 16.8M buckets */
+  kh_resize(pathset, store->path_set, 1 << 24); /* 2^24 = 16.8M buckets */
 
   return store;
 
- err:
+err:
   bgpstream_as_path_store_destroy(store);
   return NULL;
 }
 
 void bgpstream_as_path_store_destroy(bgpstream_as_path_store_t *store)
 {
-  if(store == NULL)
-    {
-      return;
-    }
+  if (store == NULL) {
+    return;
+  }
 
-  if(store->path_set != NULL)
-    {
-      kh_free_vals(pathset, store->path_set, pathset_destroy);
-      kh_destroy(pathset, store->path_set);
-      store->path_set = NULL;
-    }
+  if (store->path_set != NULL) {
+    kh_free_vals(pathset, store->path_set, pathset_destroy);
+    kh_destroy(pathset, store->path_set);
+    store->path_set = NULL;
+  }
 
   free(store);
 }
@@ -223,10 +206,9 @@ uint32_t bgpstream_as_path_store_get_size(bgpstream_as_path_store_t *store)
   return store->paths_cnt;
 }
 
-static int
-get_path_id(bgpstream_as_path_store_t *store,
-            bgpstream_as_path_store_path_t *findme,
-            bgpstream_as_path_store_path_id_t *id)
+static int get_path_id(bgpstream_as_path_store_t *store,
+                       bgpstream_as_path_store_path_t *findme,
+                       bgpstream_as_path_store_path_id_t *id)
 {
   khiter_t k;
   int khret;
@@ -234,86 +216,77 @@ get_path_id(bgpstream_as_path_store_t *store,
   id->path_hash = bgpstream_as_path_hash(&findme->path);
 
   k = kh_put(pathset, store->path_set, id->path_hash, &khret);
-  if(khret == 1)
-    {
-      /* just added this pathset */
-      /* clear the pathset fields */
-      kh_val(store->path_set, k).paths = NULL;
-      kh_val(store->path_set, k).paths_cnt = 0;
-    }
-  else if(khret != 0)
-    {
-      fprintf(stderr, "ERROR: Could not add path set to the store\n");
-      goto err;
-    }
+  if (khret == 1) {
+    /* just added this pathset */
+    /* clear the pathset fields */
+    kh_val(store->path_set, k).paths = NULL;
+    kh_val(store->path_set, k).paths_cnt = 0;
+  } else if (khret != 0) {
+    fprintf(stderr, "ERROR: Could not add path set to the store\n");
+    goto err;
+  }
 
   /* now get the path id from the origin set */
-  if((id->path_id =
-      pathset_get_path_id(store, &kh_val(store->path_set, k), findme))
-     == UINT16_MAX)
-    {
-      fprintf(stderr, "ERROR: Could not add path to origin set\n");
-      goto err;
-    }
+  if ((id->path_id = pathset_get_path_id(store, &kh_val(store->path_set, k),
+                                         findme)) == UINT16_MAX) {
+    fprintf(stderr, "ERROR: Could not add path to origin set\n");
+    goto err;
+  }
 
   return 0;
 
- err:
+err:
   return -1;
 }
 
-int
-bgpstream_as_path_store_get_path_id(bgpstream_as_path_store_t *store,
-                                    bgpstream_as_path_t *path,
-                                    uint32_t peer_asn,
-                                    bgpstream_as_path_store_path_id_t *id)
+int bgpstream_as_path_store_get_path_id(bgpstream_as_path_store_t *store,
+                                        bgpstream_as_path_t *path,
+                                        uint32_t peer_asn,
+                                        bgpstream_as_path_store_path_id_t *id)
 {
-  /* shallow copy of the provided path, possibly with the peer segment removed */
+  /* shallow copy of the provided path, possibly with the peer segment removed
+   */
   bgpstream_as_path_store_path_t findme;
   bgpstream_as_path_seg_t *seg;
 
   /* special case for empty path */
-  if(path == NULL)
-    {
-      id->path_hash = UINT32_MAX;
-      id->path_id = UINT16_MAX;
-      return 0;
-    }
+  if (path == NULL) {
+    id->path_hash = UINT32_MAX;
+    id->path_id = UINT16_MAX;
+    return 0;
+  }
 
-  seg = (bgpstream_as_path_seg_t*)path->data;
+  seg = (bgpstream_as_path_seg_t *)path->data;
 
   /* perform a shallow copy of the path, only extracting the core path if
      needed */
-  if(path->data_len > 0 && /* empty path */
-     path->seg_cnt > 1 && /* peer seg != origin seg */
-     seg->type == BGPSTREAM_AS_PATH_SEG_ASN && /* simple ASN */
-     ((bgpstream_as_path_seg_asn_t*)seg)->asn == peer_asn) /* peer prepended */
-    {
-      /* just point to the core path */
-      findme.path.data = path->data+sizeof(bgpstream_as_path_seg_asn_t);
-      findme.path.data_len = path->data_len-sizeof(bgpstream_as_path_seg_asn_t);
-      findme.path.data_alloc_len = UINT16_MAX;
-      findme.path.seg_cnt = path->seg_cnt-1;
-      findme.path.origin_offset =
-        path->origin_offset-sizeof(bgpstream_as_path_seg_asn_t);
-      findme.is_core = 1;
-    }
-  else
-    {
-      /* empty path or no peer ASN */
-      findme.path = *path;
-      findme.is_core = 0;
-    }
+  if (path->data_len > 0 &&                     /* empty path */
+      path->seg_cnt > 1 &&                      /* peer seg != origin seg */
+      seg->type == BGPSTREAM_AS_PATH_SEG_ASN && /* simple ASN */
+      ((bgpstream_as_path_seg_asn_t *)seg)->asn ==
+        peer_asn) /* peer prepended */
+  {
+    /* just point to the core path */
+    findme.path.data = path->data + sizeof(bgpstream_as_path_seg_asn_t);
+    findme.path.data_len = path->data_len - sizeof(bgpstream_as_path_seg_asn_t);
+    findme.path.data_alloc_len = UINT16_MAX;
+    findme.path.seg_cnt = path->seg_cnt - 1;
+    findme.path.origin_offset =
+      path->origin_offset - sizeof(bgpstream_as_path_seg_asn_t);
+    findme.is_core = 1;
+  } else {
+    /* empty path or no peer ASN */
+    findme.path = *path;
+    findme.is_core = 0;
+  }
 
   return get_path_id(store, &findme, id);
 }
 
-int
-bgpstream_as_path_store_insert_path(bgpstream_as_path_store_t *store,
-                                    uint8_t *path_data,
-                                    uint16_t path_len,
-                                    int is_core,
-                                    bgpstream_as_path_store_path_id_t *id)
+int bgpstream_as_path_store_insert_path(bgpstream_as_path_store_t *store,
+                                        uint8_t *path_data, uint16_t path_len,
+                                        int is_core,
+                                        bgpstream_as_path_store_path_id_t *id)
 {
   bgpstream_as_path_store_path_t findme;
   findme.is_core = is_core;
@@ -323,47 +296,42 @@ bgpstream_as_path_store_insert_path(bgpstream_as_path_store_t *store,
   return get_path_id(store, &findme, id);
 }
 
-void
-bgpstream_as_path_store_iter_first_path(bgpstream_as_path_store_t *store)
+void bgpstream_as_path_store_iter_first_path(bgpstream_as_path_store_t *store)
 {
   store->cur_pathset = kh_begin(store->path_set);
 
-  while(!kh_exist(store->path_set, store->cur_pathset) &&
-        store->cur_pathset < kh_end(store->path_set))
-    {
-      store->cur_pathset++;
-    }
+  while (!kh_exist(store->path_set, store->cur_pathset) &&
+         store->cur_pathset < kh_end(store->path_set)) {
+    store->cur_pathset++;
+  }
 
   store->cur_path = 0;
 }
 
-void
-bgpstream_as_path_store_iter_next_path(bgpstream_as_path_store_t *store)
+void bgpstream_as_path_store_iter_next_path(bgpstream_as_path_store_t *store)
 {
-  pathset_t * pathset;
+  pathset_t *pathset;
 
-  if(store->cur_pathset >= kh_end(store->path_set))
-    {
-      return;
-    }
+  if (store->cur_pathset >= kh_end(store->path_set)) {
+    return;
+  }
 
   pathset = &kh_val(store->path_set, store->cur_pathset);
-  if(store->cur_path >= pathset->paths_cnt)
-    {
-      /* move to the next pathset */
-      do {
-        store->cur_pathset++;
-      } while(store->cur_pathset < kh_end(store->path_set) &&
-              !kh_exist(store->path_set, store->cur_pathset));
-      store->cur_path = 0;
-    }
+  if (store->cur_path >= pathset->paths_cnt) {
+    /* move to the next pathset */
+    do {
+      store->cur_pathset++;
+    } while (store->cur_pathset < kh_end(store->path_set) &&
+             !kh_exist(store->path_set, store->cur_pathset));
+    store->cur_path = 0;
+  }
 }
 
-int
-bgpstream_as_path_store_iter_has_more_path(bgpstream_as_path_store_t *store)
+int bgpstream_as_path_store_iter_has_more_path(bgpstream_as_path_store_t *store)
 {
   return (store->cur_pathset < kh_end(store->path_set)) &&
-    (store->cur_path < kh_val(store->path_set, store->cur_pathset).paths_cnt);
+         (store->cur_path <
+          kh_val(store->path_set, store->cur_pathset).paths_cnt);
 }
 
 bgpstream_as_path_store_path_t *
@@ -390,107 +358,95 @@ bgpstream_as_path_store_get_store_path(bgpstream_as_path_store_t *store,
   khiter_t k;
 
   /* special case for NULL path */
-  if(id.path_hash == UINT32_MAX && id.path_id == UINT16_MAX)
-    {
-      return NULL;
-    }
+  if (id.path_hash == UINT32_MAX && id.path_id == UINT16_MAX) {
+    return NULL;
+  }
 
-  if((k = kh_get(pathset, store->path_set, id.path_hash)) ==
-     kh_end(store->path_set))
-    {
-      return NULL;
-    }
+  if ((k = kh_get(pathset, store->path_set, id.path_hash)) ==
+      kh_end(store->path_set)) {
+    return NULL;
+  }
 
-  if(id.path_id > kh_val(store->path_set, k).paths_cnt-1)
-    {
-      return NULL;
-    }
+  if (id.path_id > kh_val(store->path_set, k).paths_cnt - 1) {
+    return NULL;
+  }
 
   return &kh_val(store->path_set, k).paths[id.path_id];
 }
 
-bgpstream_as_path_t *
-bgpstream_as_path_store_path_get_path(bgpstream_as_path_store_path_t *store_path,
-                                      uint32_t peer_asn)
+bgpstream_as_path_t *bgpstream_as_path_store_path_get_path(
+  bgpstream_as_path_store_path_t *store_path, uint32_t peer_asn)
 {
   bgpstream_as_path_t *pc = NULL;
 
-  if((pc = bgpstream_as_path_create()) == NULL)
-    {
-      goto err;
-    }
+  if ((pc = bgpstream_as_path_create()) == NULL) {
+    goto err;
+  }
 
   /* if it is not a core path, just use the native copy */
-  if(store_path->is_core == 0)
-    {
-      if(bgpstream_as_path_copy(pc, &store_path->path) != 0)
-        {
-          goto err;
-        }
-      return pc;
+  if (store_path->is_core == 0) {
+    if (bgpstream_as_path_copy(pc, &store_path->path) != 0) {
+      goto err;
     }
+    return pc;
+  }
 
   /* otherwise, do some manual copying */
   bgpstream_as_path_clear(pc);
 
   pc->data_alloc_len = pc->data_len =
     store_path->path.data_len + sizeof(bgpstream_as_path_seg_asn_t);
-  if((pc->data = malloc(pc->data_len)) == NULL)
-    {
-      goto err;
-    }
+  if ((pc->data = malloc(pc->data_len)) == NULL) {
+    goto err;
+  }
 
-  ((bgpstream_as_path_seg_asn_t*)pc->data)->type = BGPSTREAM_AS_PATH_SEG_ASN;
-  ((bgpstream_as_path_seg_asn_t*)pc->data)->asn = peer_asn;
+  ((bgpstream_as_path_seg_asn_t *)pc->data)->type = BGPSTREAM_AS_PATH_SEG_ASN;
+  ((bgpstream_as_path_seg_asn_t *)pc->data)->asn = peer_asn;
 
-  memcpy(pc->data+sizeof(bgpstream_as_path_seg_asn_t),
-         store_path->path.data,
+  memcpy(pc->data + sizeof(bgpstream_as_path_seg_asn_t), store_path->path.data,
          store_path->path.data_len);
 
   bgpstream_as_path_update_fields(pc);
 
   return pc;
 
- err:
+err:
   bgpstream_as_path_destroy(pc);
   return NULL;
 }
 
-bgpstream_as_path_seg_t *
-bgpstream_as_path_store_path_get_origin_seg(bgpstream_as_path_store_path_t *store_path)
+bgpstream_as_path_seg_t *bgpstream_as_path_store_path_get_origin_seg(
+  bgpstream_as_path_store_path_t *store_path)
 {
-  return ((store_path == NULL) || store_path->path.data_len == 0) ? NULL :
-    (bgpstream_as_path_seg_t*)(store_path->path.data+store_path->path.origin_offset);
+  return ((store_path == NULL) || store_path->path.data_len == 0)
+           ? NULL
+           : (bgpstream_as_path_seg_t *)(store_path->path.data +
+                                         store_path->path.origin_offset);
 }
 
-void
-bgpstream_as_path_store_path_iter_reset(bgpstream_as_path_store_path_t *store_path,
-                                        bgpstream_as_path_store_path_iter_t *iter,
-                                        uint32_t peer_asn)
+void bgpstream_as_path_store_path_iter_reset(
+  bgpstream_as_path_store_path_t *store_path,
+  bgpstream_as_path_store_path_iter_t *iter, uint32_t peer_asn)
 {
   iter->spath = store_path;
 
-  if(store_path->is_core == 0)
-    {
-      bgpstream_as_path_iter_reset(&iter->pi);
-    }
-  else
-    {
-      /* return fake peer seg next */
-      iter->pi.cur_offset = UINT16_MAX;
-      iter->peerseg.type = BGPSTREAM_AS_PATH_SEG_ASN;
-      iter->peerseg.asn = peer_asn;
-    }
+  if (store_path->is_core == 0) {
+    bgpstream_as_path_iter_reset(&iter->pi);
+  } else {
+    /* return fake peer seg next */
+    iter->pi.cur_offset = UINT16_MAX;
+    iter->peerseg.type = BGPSTREAM_AS_PATH_SEG_ASN;
+    iter->peerseg.asn = peer_asn;
+  }
 }
 
-bgpstream_as_path_seg_t *
-bgpstream_as_path_store_path_get_next_seg(bgpstream_as_path_store_path_iter_t *iter)
+bgpstream_as_path_seg_t *bgpstream_as_path_store_path_get_next_seg(
+  bgpstream_as_path_store_path_iter_t *iter)
 {
-  if(iter->pi.cur_offset == UINT16_MAX)
-    {
-      bgpstream_as_path_iter_reset(&iter->pi);
-      return (bgpstream_as_path_seg_t*)&iter->peerseg;
-    }
+  if (iter->pi.cur_offset == UINT16_MAX) {
+    bgpstream_as_path_iter_reset(&iter->pi);
+    return (bgpstream_as_path_seg_t *)&iter->peerseg;
+  }
   return bgpstream_as_path_get_next_seg(&iter->spath->path, &iter->pi);
 }
 
@@ -500,14 +456,14 @@ bgpstream_as_path_store_path_get_idx(bgpstream_as_path_store_path_t *store_path)
   return store_path->idx;
 }
 
-int
-bgpstream_as_path_store_path_is_core(bgpstream_as_path_store_path_t *store_path)
+int bgpstream_as_path_store_path_is_core(
+  bgpstream_as_path_store_path_t *store_path)
 {
   return store_path->is_core;
 }
 
-bgpstream_as_path_t *
-bgpstream_as_path_store_path_get_int_path(bgpstream_as_path_store_path_t *store_path)
+bgpstream_as_path_t *bgpstream_as_path_store_path_get_int_path(
+  bgpstream_as_path_store_path_t *store_path)
 {
   return &store_path->path;
 }

--- a/lib/utils/bgpstream_utils_as_path_store.h
+++ b/lib/utils/bgpstream_utils_as_path_store.h
@@ -21,7 +21,6 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #ifndef __BGPSTREAM_UTILS_AS_PATH_STORE_H
 #define __BGPSTREAM_UTILS_AS_PATH_STORE_H
 
@@ -47,7 +46,6 @@
  * @name Public Enums
  *
  * @{ */
-
 
 /** @} */
 
@@ -140,13 +138,10 @@ uint32_t bgpstream_as_path_store_get_size(bgpstream_as_path_store_t *store);
  * insertion. That is, if the is_core flag is set, the path is assumed to
  * already have had the peer segment removed.
  */
-int
-bgpstream_as_path_store_insert_path(bgpstream_as_path_store_t *store,
-                                    uint8_t *path_data,
-                                    uint16_t path_len,
-                                    int is_core,
-                                    bgpstream_as_path_store_path_id_t *id);
-
+int bgpstream_as_path_store_insert_path(bgpstream_as_path_store_t *store,
+                                        uint8_t *path_data, uint16_t path_len,
+                                        int is_core,
+                                        bgpstream_as_path_store_path_id_t *id);
 
 /** Get the ID of the given path from the store
  *
@@ -158,11 +153,10 @@ bgpstream_as_path_store_insert_path(bgpstream_as_path_store_t *store,
  *
  * If the path is not already in the store, it will be added
  */
-int
-bgpstream_as_path_store_get_path_id(bgpstream_as_path_store_t *store,
-                                    bgpstream_as_path_t *path,
-                                    uint32_t peer_asn,
-                                    bgpstream_as_path_store_path_id_t *id);
+int bgpstream_as_path_store_get_path_id(bgpstream_as_path_store_t *store,
+                                        bgpstream_as_path_t *path,
+                                        uint32_t peer_asn,
+                                        bgpstream_as_path_store_path_id_t *id);
 
 /** Get a (borrowed) pointer to the Store Path for the given Path ID
  *
@@ -181,23 +175,21 @@ bgpstream_as_path_store_get_store_path(bgpstream_as_path_store_t *store,
  *
  * @param store         pointer to the store
  */
-void
-bgpstream_as_path_store_iter_first_path(bgpstream_as_path_store_t *store);
+void bgpstream_as_path_store_iter_first_path(bgpstream_as_path_store_t *store);
 
 /** Advance the internal iterator to the next Path in the store
  *
  * @param store         pointer to the store
  */
-void
-bgpstream_as_path_store_iter_next_path(bgpstream_as_path_store_t *store);
+void bgpstream_as_path_store_iter_next_path(bgpstream_as_path_store_t *store);
 
 /** Check if the internal iterator is pointing to a valid path
  *
  * @param store         pointer to the store
  * @return 1 if the iterator is valid, 0 otherwise
  */
-int
-bgpstream_as_path_store_iter_has_more_path(bgpstream_as_path_store_t *store);
+int bgpstream_as_path_store_iter_has_more_path(
+  bgpstream_as_path_store_t *store);
 
 /** Get the current path from the iterator
  *
@@ -228,17 +220,16 @@ bgpstream_as_path_store_iter_get_path_id(bgpstream_as_path_store_t *store);
  * every time, it should be used sparingly. Consider using the store path
  * iterator functions wherever possible.
  */
-bgpstream_as_path_t *
-bgpstream_as_path_store_path_get_path(bgpstream_as_path_store_path_t *store_path,
-                                      uint32_t peer_asn);
+bgpstream_as_path_t *bgpstream_as_path_store_path_get_path(
+  bgpstream_as_path_store_path_t *store_path, uint32_t peer_asn);
 
 /** Get a borrowed pointer to the origin segment of the given store path
  *
  * @param store_path    pointer to a store path
  * @return a borrowed pointer to the origin segment
  */
-bgpstream_as_path_seg_t *
-bgpstream_as_path_store_path_get_origin_seg(bgpstream_as_path_store_path_t *store_path);
+bgpstream_as_path_seg_t *bgpstream_as_path_store_path_get_origin_seg(
+  bgpstream_as_path_store_path_t *store_path);
 
 /** Reset the given store path iterator
  *
@@ -246,10 +237,9 @@ bgpstream_as_path_store_path_get_origin_seg(bgpstream_as_path_store_path_t *stor
  * @param iter          pointer to the store path iterator to reset
  * @param peer_asn      ASN of the peer that this path was observed by
  */
-void
-bgpstream_as_path_store_path_iter_reset(bgpstream_as_path_store_path_t *store_path,
-                                        bgpstream_as_path_store_path_iter_t *iter,
-                                        uint32_t peer_asn);
+void bgpstream_as_path_store_path_iter_reset(
+  bgpstream_as_path_store_path_t *store_path,
+  bgpstream_as_path_store_path_iter_t *iter, uint32_t peer_asn);
 
 /** Get the next segment from the given store path
  *
@@ -261,8 +251,8 @@ bgpstream_as_path_store_path_iter_reset(bgpstream_as_path_store_path_t *store_pa
  * using bgpstream_as_path_seg_destroy. Also, it is only valid as long as the
  * store path is valid.
  */
-bgpstream_as_path_seg_t *
-bgpstream_as_path_store_path_get_next_seg(bgpstream_as_path_store_path_iter_t *iter);
+bgpstream_as_path_seg_t *bgpstream_as_path_store_path_get_next_seg(
+  bgpstream_as_path_store_path_iter_t *iter);
 
 /** Get the internal index of the given store path
  *
@@ -273,8 +263,8 @@ bgpstream_as_path_store_path_get_next_seg(bgpstream_as_path_store_path_iter_t *i
  * should be considered internal. The returned index is guaranteed to be in the
  * range [0 -> bgpstream_as_path_store_get_size).
  */
-uint32_t
-bgpstream_as_path_store_path_get_idx(bgpstream_as_path_store_path_t *store_path);
+uint32_t bgpstream_as_path_store_path_get_idx(
+  bgpstream_as_path_store_path_t *store_path);
 
 /** Check if the given store path is a core path (i.e. the peer segment has been
  * removed)
@@ -285,8 +275,8 @@ bgpstream_as_path_store_path_get_idx(bgpstream_as_path_store_path_t *store_path)
  * This function is designed to be used when serializing the entire store, and
  * should be considered internal.
  */
-int
-bgpstream_as_path_store_path_is_core(bgpstream_as_path_store_path_t *store_path);
+int bgpstream_as_path_store_path_is_core(
+  bgpstream_as_path_store_path_t *store_path);
 
 /** Get a pointer to the internal path structure from the store path
  *
@@ -296,11 +286,9 @@ bgpstream_as_path_store_path_is_core(bgpstream_as_path_store_path_t *store_path)
  * This function is designed to be used when serializing the entire store, and
  * should be considered internal.
  */
-bgpstream_as_path_t *
-bgpstream_as_path_store_path_get_int_path(bgpstream_as_path_store_path_t *store_path);
+bgpstream_as_path_t *bgpstream_as_path_store_path_get_int_path(
+  bgpstream_as_path_store_path_t *store_path);
 
 /** @} */
 
-
 #endif /* __BGPSTREAM_UTILS_AS_PATH_STORE_H */
-

--- a/lib/utils/bgpstream_utils_community.c
+++ b/lib/utils/bgpstream_utils_community.c
@@ -24,9 +24,9 @@
 #include "config.h"
 
 #include <assert.h>
+#include <errno.h>
 #include <inttypes.h>
 #include <stdio.h>
-#include <errno.h>
 
 #include "bgpdump_lib.h"
 #include "khash.h"
@@ -51,24 +51,21 @@ struct bgpstream_community_set {
   /** Communities hash (OR between
    *  all communities in the set) */
   uint32_t communities_hash;
-
 };
-
 
 /* ========== PUBLIC FUNCTIONS ========== */
 
 int bgpstream_community_snprintf(char *buf, size_t len,
                                  bgpstream_community_t *comm)
 {
-  return snprintf(buf, len, "%"PRIu16":%"PRIu16, comm->asn, comm->value);
+  return snprintf(buf, len, "%" PRIu16 ":%" PRIu16, comm->asn, comm->value);
 }
 
 int bgpstream_str2community(const char *buf, bgpstream_community_t *comm)
 {
-  if(buf  == NULL || comm == NULL)
-    {
-      return -1;
-    }
+  if (buf == NULL || comm == NULL) {
+    return -1;
+  }
   uint8_t mask = 0;
   char com_copy[COMMUNITY_MAX_STR_LEN];
   strncpy(com_copy, buf, COMMUNITY_MAX_STR_LEN);
@@ -78,50 +75,43 @@ int bgpstream_str2community(const char *buf, bgpstream_community_t *comm)
   char *endptr = NULL;
   char *found = strchr(com_copy, ':');
 
-  if(found == NULL)
-    {
-      return -1;
-    }
+  if (found == NULL) {
+    return -1;
+  }
   *found = '\0';
   errno = 0;
   comm->asn = 0;
-  if(com_copy[0] != '*')
-    {
-      mask = mask | BGPSTREAM_COMMUNITY_FILTER_ASN;
-      r = strtoul(com_copy, &endptr, 10);
-      ret = errno;
-      if(!(endptr != NULL && *endptr == '\0') || ret != 0)
-        {
-          return -1;
-        }
-      comm->asn = (uint32_t) r;
+  if (com_copy[0] != '*') {
+    mask = mask | BGPSTREAM_COMMUNITY_FILTER_ASN;
+    r = strtoul(com_copy, &endptr, 10);
+    ret = errno;
+    if (!(endptr != NULL && *endptr == '\0') || ret != 0) {
+      return -1;
     }
+    comm->asn = (uint32_t)r;
+  }
 
   endptr = NULL;
   comm->value = 0;
-  if(*(found+1) != '*')
-    {
-      mask = mask | BGPSTREAM_COMMUNITY_FILTER_VALUE;
-      r = strtoul(found+1, &endptr, 10);
-      ret = errno;
-      if(!(endptr != NULL && *endptr == '\0') || ret != 0)
-        {
-          return -1;
-        }
-      comm->value = (uint32_t) r;
+  if (*(found + 1) != '*') {
+    mask = mask | BGPSTREAM_COMMUNITY_FILTER_VALUE;
+    r = strtoul(found + 1, &endptr, 10);
+    ret = errno;
+    if (!(endptr != NULL && *endptr == '\0') || ret != 0) {
+      return -1;
     }
-  return (int )mask;
+    comm->value = (uint32_t)r;
+  }
+  return (int)mask;
 }
-
 
 bgpstream_community_t *bgpstream_community_dup(bgpstream_community_t *src)
 {
   bgpstream_community_t *dst = NULL;
 
-  if((dst = malloc(sizeof(bgpstream_community_t))) == NULL)
-    {
-      return NULL;
-    }
+  if ((dst = malloc(sizeof(bgpstream_community_t))) == NULL) {
+    return NULL;
+  }
 
   memcpy(dst, src, sizeof(bgpstream_community_t));
 
@@ -168,15 +158,14 @@ int bgpstream_community_equal_value(bgpstream_community_t comm1,
 
 /* SET FUNCTIONS */
 
-#define ADD_CHAR(chr)                           \
-  do {                                          \
-    if((len-written) > 0)                       \
-      {                                         \
-        *bufp = chr;                            \
-        bufp++;                                 \
-      }                                         \
-    written++;                                  \
-  } while(0)
+#define ADD_CHAR(chr)                                                          \
+  do {                                                                         \
+    if ((len - written) > 0) {                                                 \
+      *bufp = chr;                                                             \
+      bufp++;                                                                  \
+    }                                                                          \
+    written++;                                                                 \
+  } while (0)
 
 int bgpstream_community_set_snprintf(char *buf, size_t len,
                                      bgpstream_community_set_t *set)
@@ -186,24 +175,20 @@ int bgpstream_community_set_snprintf(char *buf, size_t len,
   int need_sep = 0;
   char *bufp = buf;
 
-  for(i=0; i < bgpstream_community_set_size(set); i++)
-    {
-      if(need_sep != 0)
-        {
-          ADD_CHAR(' ');
-        }
-      need_sep = 1;
-      written +=
-        bgpstream_community_snprintf(bufp, (len-written),
-                                     bgpstream_community_set_get(set, i));
-      bufp = buf+written;
+  for (i = 0; i < bgpstream_community_set_size(set); i++) {
+    if (need_sep != 0) {
+      ADD_CHAR(' ');
     }
+    need_sep = 1;
+    written += bgpstream_community_snprintf(
+      bufp, (len - written), bgpstream_community_set_get(set, i));
+    bufp = buf + written;
+  }
   *bufp = '\0';
 
-  if(written > len)
-    {
-      buf[len-1] = '\0';
-    }
+  if (written > len) {
+    buf[len - 1] = '\0';
+  }
   return written;
 }
 
@@ -211,10 +196,9 @@ bgpstream_community_set_t *bgpstream_community_set_create()
 {
   bgpstream_community_set_t *set = NULL;
 
-  if((set = malloc_zero(sizeof(bgpstream_community_set_t))) == NULL)
-    {
-      return NULL;
-    }
+  if ((set = malloc_zero(sizeof(bgpstream_community_set_t))) == NULL) {
+    return NULL;
+  }
 
   return set;
 }
@@ -228,7 +212,7 @@ void bgpstream_community_set_clear(bgpstream_community_set_t *set)
 void bgpstream_community_set_destroy(bgpstream_community_set_t *set)
 {
   /* alloc cnt is < 0 if owned externally */
-  if(set->communities_alloc_cnt > 0) {
+  if (set->communities_alloc_cnt > 0) {
     free(set->communities);
   }
   set->communities = NULL;
@@ -242,16 +226,14 @@ void bgpstream_community_set_destroy(bgpstream_community_set_t *set)
 int bgpstream_community_set_copy(bgpstream_community_set_t *dst,
                                  bgpstream_community_set_t *src)
 {
-  if(dst->communities_alloc_cnt < src->communities_cnt)
-    {
-      if((dst->communities =
-          realloc(dst->communities,
-                  sizeof(bgpstream_community_t) * src->communities_cnt)) == NULL)
-        {
-          return -1;
-        }
-      dst->communities_alloc_cnt = src->communities_cnt;
+  if (dst->communities_alloc_cnt < src->communities_cnt) {
+    if ((dst->communities =
+           realloc(dst->communities, sizeof(bgpstream_community_t) *
+                                       src->communities_cnt)) == NULL) {
+      return -1;
     }
+    dst->communities_alloc_cnt = src->communities_cnt;
+  }
 
   memcpy(dst->communities, src->communities,
          sizeof(bgpstream_community_t) * src->communities_cnt);
@@ -276,20 +258,18 @@ int bgpstream_community_set_size(bgpstream_community_set_t *set)
 int bgpstream_community_set_insert(bgpstream_community_set_t *set,
                                    bgpstream_community_t *comm)
 {
-  if(set->communities_cnt == set->communities_alloc_cnt)
-    {
-      if((set->communities =
-          realloc(set->communities, sizeof(bgpstream_community_t) *
-                  (set->communities_alloc_cnt + 1))) == NULL)
-        {
-          return -1;
-        }
-      set->communities_alloc_cnt++;
+  if (set->communities_cnt == set->communities_alloc_cnt) {
+    if ((set->communities = realloc(
+           set->communities, sizeof(bgpstream_community_t) *
+                               (set->communities_alloc_cnt + 1))) == NULL) {
+      return -1;
     }
+    set->communities_alloc_cnt++;
+  }
 
   set->communities[set->communities_cnt] = *comm;
   set->communities_cnt++;
-  set->communities_hash = set->communities_hash | *((uint32_t *) comm);
+  set->communities_hash = set->communities_hash | *((uint32_t *)comm);
   return 0;
 }
 
@@ -298,27 +278,25 @@ int bgpstream_community_set_populate_from_array(bgpstream_community_set_t *set,
                                                 int comms_cnt)
 {
   bgpstream_community_set_t tmp;
-  if(bgpstream_community_set_populate_from_array_zc(&tmp, comms,
-                                                    comms_cnt) != 0)
-    {
-      return -1;
-    }
+  if (bgpstream_community_set_populate_from_array_zc(&tmp, comms, comms_cnt) !=
+      0) {
+    return -1;
+  }
   return bgpstream_community_set_copy(set, &tmp);
 }
 
-int bgpstream_community_set_populate_from_array_zc(bgpstream_community_set_t *set,
-                                                   bgpstream_community_t *comms,
-                                                   int comms_cnt)
+int bgpstream_community_set_populate_from_array_zc(
+  bgpstream_community_set_t *set, bgpstream_community_t *comms, int comms_cnt)
 {
   set->communities_alloc_cnt = -1; /* signal that memory is not owned by us */
   set->communities = comms;
   set->communities_cnt = comms_cnt;
   set->communities_hash = 0;
   int i;
-  for(i=0; i < bgpstream_community_set_size(set); i++)
-    {
-      set->communities_hash = set->communities_hash | *((uint32_t *) &set->communities[i]);
-    }
+  for (i = 0; i < bgpstream_community_set_size(set); i++) {
+    set->communities_hash =
+      set->communities_hash | *((uint32_t *)&set->communities[i]);
+  }
   return 0;
 }
 
@@ -333,18 +311,16 @@ bgpstream_community_set_hash(bgpstream_community_set_t *set)
   uint32_t h;
   int cnt = bgpstream_community_set_size(set);
 
-  if(cnt == 0)
-    {
-      return 0;
-    }
+  if (cnt == 0) {
+    return 0;
+  }
 
   h = bgpstream_community_hash(bgpstream_community_set_get(set, 0));
 
-  for(i=1; i < cnt; i++)
-    {
-      h = (h << 5) - h +
+  for (i = 1; i < cnt; i++) {
+    h = (h << 5) - h +
         bgpstream_community_hash(bgpstream_community_set_get(set, i));
-    }
+  }
   return h;
 }
 
@@ -352,9 +328,9 @@ int bgpstream_community_set_equal(bgpstream_community_set_t *set1,
                                   bgpstream_community_set_t *set2)
 {
   return (set1->communities_hash == set2->communities_hash) &&
-    (set1->communities_cnt == set2->communities_cnt) &&
-    bcmp(set1->communities, set2->communities,
-         sizeof(bgpstream_community_t) * set1->communities_cnt);
+         (set1->communities_cnt == set2->communities_cnt) &&
+         bcmp(set1->communities, set2->communities,
+              sizeof(bgpstream_community_t) * set1->communities_cnt);
 }
 
 /* ========== PROTECTED FUNCTIONS ========== */
@@ -368,33 +344,29 @@ int bgpstream_community_set_populate(bgpstream_community_set_t *set,
 
   bgpstream_community_set_clear(set);
 
-  if(bd_comms == NULL)
-    {
-      return 0;
-    }
+  if (bd_comms == NULL) {
+    return 0;
+  }
 
-  if(set->communities_alloc_cnt < bd_comms->size)
-    {
-      if((set->communities =
-          realloc(set->communities,
-                  sizeof(bgpstream_community_t) * bd_comms->size)) == NULL)
-        {
-          return -1;
-        }
-      set->communities_alloc_cnt = bd_comms->size;
+  if (set->communities_alloc_cnt < bd_comms->size) {
+    if ((set->communities =
+           realloc(set->communities,
+                   sizeof(bgpstream_community_t) * bd_comms->size)) == NULL) {
+      return -1;
     }
+    set->communities_alloc_cnt = bd_comms->size;
+  }
 
-  for(i=0; i < bd_comms->size; i++)
-    {
-      c = &set->communities[i];
-      /* this could be made more efficient by manually copying each half and
-         then byte flipping... one day */
-      memcpy(&comval, &bd_comms->val[i], sizeof(uint32_t));
-      comval = ntohl(comval);
-      c->asn = (comval >> 16) & 0xFFFF;
-      c->value = comval & 0xFFFF;
-      set->communities_hash = set->communities_hash | *((uint32_t *) c);
-    }
+  for (i = 0; i < bd_comms->size; i++) {
+    c = &set->communities[i];
+    /* this could be made more efficient by manually copying each half and
+       then byte flipping... one day */
+    memcpy(&comval, &bd_comms->val[i], sizeof(uint32_t));
+    comval = ntohl(comval);
+    c->asn = (comval >> 16) & 0xFFFF;
+    c->value = comval & 0xFFFF;
+    set->communities_hash = set->communities_hash | *((uint32_t *)c);
+  }
 
   set->communities_cnt = bd_comms->size;
 
@@ -404,44 +376,39 @@ int bgpstream_community_set_populate(bgpstream_community_set_t *set,
 int bgpstream_community_set_exists(bgpstream_community_set_t *set,
                                    bgpstream_community_t *com)
 {
-  return bgpstream_community_set_match(set, com, BGPSTREAM_COMMUNITY_FILTER_EXACT);
+  return bgpstream_community_set_match(set, com,
+                                       BGPSTREAM_COMMUNITY_FILTER_EXACT);
 }
 
 int bgpstream_community_set_match(bgpstream_community_set_t *set,
-                                   bgpstream_community_t *com,
-                                   uint8_t mask)
+                                  bgpstream_community_t *com, uint8_t mask)
 {
-  bgpstream_community_t *hash = (bgpstream_community_t *) &set->communities_hash;
+  bgpstream_community_t *hash = (bgpstream_community_t *)&set->communities_hash;
 
   /* first we verify if the hash is compatible */
-  if( (!(mask & BGPSTREAM_COMMUNITY_FILTER_ASN) || hash->asn & com->asn) &&
-      (!(mask & BGPSTREAM_COMMUNITY_FILTER_VALUE) || hash->value & com->value) )
-    {
-      bgpstream_community_t *c;
-      int i;
-      int n = bgpstream_community_set_size(set);
-      for(i=0; i < n; i++)
-        {
-          c = bgpstream_community_set_get(set, i);
-          /* checking if asn match is requested and compatible */
-          if(mask & BGPSTREAM_COMMUNITY_FILTER_ASN)
-            {
-              if(c->asn != com->asn)
-                {
-                  continue;
-                }
-            }
-          /* checking if value match is requested and compatible */
-          if(mask & BGPSTREAM_COMMUNITY_FILTER_VALUE)
-            {
-              if(c->value != com->value)
-                {
-                  continue;
-                }
-            }
-
-          return 1;
+  if ((!(mask & BGPSTREAM_COMMUNITY_FILTER_ASN) || hash->asn & com->asn) &&
+      (!(mask & BGPSTREAM_COMMUNITY_FILTER_VALUE) ||
+       hash->value & com->value)) {
+    bgpstream_community_t *c;
+    int i;
+    int n = bgpstream_community_set_size(set);
+    for (i = 0; i < n; i++) {
+      c = bgpstream_community_set_get(set, i);
+      /* checking if asn match is requested and compatible */
+      if (mask & BGPSTREAM_COMMUNITY_FILTER_ASN) {
+        if (c->asn != com->asn) {
+          continue;
         }
+      }
+      /* checking if value match is requested and compatible */
+      if (mask & BGPSTREAM_COMMUNITY_FILTER_VALUE) {
+        if (c->value != com->value) {
+          continue;
+        }
+      }
+
+      return 1;
     }
+  }
   return 0;
 }

--- a/lib/utils/bgpstream_utils_community.h
+++ b/lib/utils/bgpstream_utils_community.h
@@ -21,7 +21,6 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #ifndef __BGPSTREAM_UTILS_COMMUNITY_H
 #define __BGPSTREAM_UTILS_COMMUNITY_H
 
@@ -50,18 +49,17 @@
 
 /** Well-known Community Types (see RFC 1997) */
 
-#define BGPSTREAM_COMMUNITY_NO_EXPORT            0xFFFFFF01
+#define BGPSTREAM_COMMUNITY_NO_EXPORT 0xFFFFFF01
 
-#define BGPSTREAM_COMMUNITY_NO_ADVERTISE         0xFFFFFF02
+#define BGPSTREAM_COMMUNITY_NO_ADVERTISE 0xFFFFFF02
 
-#define BGPSTREAM_COMMUNITY_NO_EXPORT_SUBCONFED  0xFFFFFF03
+#define BGPSTREAM_COMMUNITY_NO_EXPORT_SUBCONFED 0xFFFFFF03
 
 /** Community mask used for filtering */
 
-#define BGPSTREAM_COMMUNITY_FILTER_EXACT         0b0011
-#define BGPSTREAM_COMMUNITY_FILTER_ASN           0b0010
-#define BGPSTREAM_COMMUNITY_FILTER_VALUE         0b0001
-
+#define BGPSTREAM_COMMUNITY_FILTER_EXACT 0b0011
+#define BGPSTREAM_COMMUNITY_FILTER_ASN 0b0010
+#define BGPSTREAM_COMMUNITY_FILTER_VALUE 0b0001
 
 /** @} */
 
@@ -79,7 +77,6 @@ typedef struct bgpstream_community_set bgpstream_community_set_t;
  * @name Public Data Structures
  *
  * @{ */
-
 
 /** Community attribute value */
 typedef struct bgpstream_community {
@@ -145,7 +142,6 @@ unsigned int
 unsigned long
 #endif
 bgpstream_community_hash(bgpstream_community_t *comm);
-
 
 /** Hash the given community into a 32bit number
  *
@@ -271,9 +267,8 @@ int bgpstream_community_set_populate_from_array(bgpstream_community_set_t *set,
  * @note this function **does not** copy the data into the set. The set is
  * only valid as long as the comms array passed to this function is valid.
  */
-int bgpstream_community_set_populate_from_array_zc(bgpstream_community_set_t *set,
-                                                   bgpstream_community_t *comms,
-                                                   int comms_cnt);
+int bgpstream_community_set_populate_from_array_zc(
+  bgpstream_community_set_t *set, bgpstream_community_t *comms, int comms_cnt);
 
 /** Hash the given community set into a 32bit number
  *
@@ -299,7 +294,6 @@ bgpstream_community_set_hash(bgpstream_community_set_t *set);
 int bgpstream_community_set_equal(bgpstream_community_set_t *set1,
                                   bgpstream_community_set_t *set2);
 
-
 /** Check if a community is part of a community set
  *
  * @param set          pointer to the community set to check
@@ -324,6 +318,4 @@ int bgpstream_community_set_match(bgpstream_community_set_t *set,
 
 /** @} */
 
-
 #endif /* __BGPSTREAM_UTILS_COMMUNITY_H */
-

--- a/lib/utils/bgpstream_utils_community_int.h
+++ b/lib/utils/bgpstream_utils_community_int.h
@@ -21,7 +21,6 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #ifndef __BGPSTREAM_UTILS_COMMUNITY_INT_H
 #define __BGPSTREAM_UTILS_COMMUNITY_INT_H
 
@@ -57,7 +56,6 @@
  *
  * @{ */
 
-
 /** @} */
 
 /**
@@ -83,6 +81,4 @@ int bgpstream_community_set_populate(bgpstream_community_set_t *set,
 
 /** @} */
 
-
 #endif /* __BGPSTREAM_UTILS_COMMUNITY_INT_H */
-

--- a/lib/utils/bgpstream_utils_id_set.c
+++ b/lib/utils/bgpstream_utils_id_set.c
@@ -35,19 +35,15 @@
  *  this structure maintains a set of unique
  *  ids (using a uint32 type)
  */
-KHASH_INIT(bgpstream_id_set /* name */,
-	   uint32_t  /* khkey_t */,
-	   char /* khval_t */,
-	   0  /* kh_is_set */,
-	   kh_int_hash_func /*__hash_func */,
-	   kh_int_hash_equal /* __hash_equal */);
-
+KHASH_INIT(bgpstream_id_set /* name */, uint32_t /* khkey_t */,
+           char /* khval_t */, 0 /* kh_is_set */,
+           kh_int_hash_func /*__hash_func */,
+           kh_int_hash_equal /* __hash_equal */);
 
 struct bgpstream_id_set {
   khiter_t k;
-  khash_t(bgpstream_id_set) *hash;
+  khash_t(bgpstream_id_set) * hash;
 };
-
 
 /* PUBLIC FUNCTIONS */
 
@@ -55,40 +51,37 @@ bgpstream_id_set_t *bgpstream_id_set_create()
 {
   bgpstream_id_set_t *set;
 
-  if((set = (bgpstream_id_set_t*)malloc(sizeof(bgpstream_id_set_t))) == NULL)
-    {
-      return NULL;
-    }
+  if ((set = (bgpstream_id_set_t *)malloc(sizeof(bgpstream_id_set_t))) ==
+      NULL) {
+    return NULL;
+  }
 
-  if((set->hash = kh_init(bgpstream_id_set)) == NULL)
-    {
-      bgpstream_id_set_destroy(set);
-      return NULL;
-    }
+  if ((set->hash = kh_init(bgpstream_id_set)) == NULL) {
+    bgpstream_id_set_destroy(set);
+    return NULL;
+  }
   bgpstream_id_set_rewind(set);
   return set;
 }
 
-int bgpstream_id_set_insert(bgpstream_id_set_t *set,  uint32_t id)
+int bgpstream_id_set_insert(bgpstream_id_set_t *set, uint32_t id)
 {
   int khret;
   khiter_t k;
-  if((k = kh_get(bgpstream_id_set, set->hash, id)) == kh_end(set->hash))
-    {
-      /** @todo we should always check the return value from khash funcs */
-      k = kh_put(bgpstream_id_set, set->hash, id, &khret);
-      return 1;
-    }
+  if ((k = kh_get(bgpstream_id_set, set->hash, id)) == kh_end(set->hash)) {
+    /** @todo we should always check the return value from khash funcs */
+    k = kh_put(bgpstream_id_set, set->hash, id, &khret);
+    return 1;
+  }
   return 0;
 }
 
-int bgpstream_id_set_exists(bgpstream_id_set_t *set,  uint32_t id)
+int bgpstream_id_set_exists(bgpstream_id_set_t *set, uint32_t id)
 {
   khiter_t k;
-  if((k = kh_get(bgpstream_id_set, set->hash, id)) == kh_end(set->hash))
-    {
-      return 0;
-    }
+  if ((k = kh_get(bgpstream_id_set, set->hash, id)) == kh_end(set->hash)) {
+    return 0;
+  }
   return 1;
 }
 
@@ -96,16 +89,13 @@ int bgpstream_id_set_merge(bgpstream_id_set_t *dst_set,
                            bgpstream_id_set_t *src_set)
 {
   khiter_t k;
-  for(k = kh_begin(src_set->hash); k != kh_end(src_set->hash); ++k)
-    {
-      if(kh_exist(src_set->hash, k))
-	{
-	  if(bgpstream_id_set_insert(dst_set, kh_key(src_set->hash, k)) < 0)
-            {
-              return -1;
-            }
-	}
+  for (k = kh_begin(src_set->hash); k != kh_end(src_set->hash); ++k) {
+    if (kh_exist(src_set->hash, k)) {
+      if (bgpstream_id_set_insert(dst_set, kh_key(src_set->hash, k)) < 0) {
+        return -1;
+      }
     }
+  }
   bgpstream_id_set_rewind(dst_set);
   bgpstream_id_set_rewind(src_set);
   return 0;
@@ -116,18 +106,16 @@ void bgpstream_id_set_rewind(bgpstream_id_set_t *set)
   set->k = kh_begin(set->hash);
 }
 
-uint32_t* bgpstream_id_set_next(bgpstream_id_set_t *set)
+uint32_t *bgpstream_id_set_next(bgpstream_id_set_t *set)
 {
   uint32_t *v = NULL;
-  for( ; set->k != kh_end(set->hash); ++set->k)
-    {
-      if(kh_exist(set->hash, set->k))
-	{
-          v = &kh_key(set->hash, set->k);
-          set->k++;
-          return v;
-        }
+  for (; set->k != kh_end(set->hash); ++set->k) {
+    if (kh_exist(set->hash, set->k)) {
+      v = &kh_key(set->hash, set->k);
+      set->k++;
+      return v;
     }
+  }
   return NULL;
 }
 

--- a/lib/utils/bgpstream_utils_id_set.h
+++ b/lib/utils/bgpstream_utils_id_set.h
@@ -21,7 +21,6 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #ifndef __BGPSTREAM_UTILS_ID_SET_H
 #define __BGPSTREAM_UTILS_ID_SET_H
 
@@ -101,7 +100,7 @@ void bgpstream_id_set_rewind(bgpstream_id_set_t *set);
  *         (borrowed pointer), NULL if the end of the set
  *         has been reached
  */
-uint32_t* bgpstream_id_set_next(bgpstream_id_set_t *set);
+uint32_t *bgpstream_id_set_next(bgpstream_id_set_t *set);
 
 /** Destroy the given ID set
  *
@@ -116,4 +115,3 @@ void bgpstream_id_set_destroy(bgpstream_id_set_t *set);
 void bgpstream_id_set_clear(bgpstream_id_set_t *set);
 
 #endif /* __BGPSTREAM_UTILS_ID_SET_H */
-

--- a/lib/utils/bgpstream_utils_ip_counter.c
+++ b/lib/utils/bgpstream_utils_ip_counter.c
@@ -1,23 +1,21 @@
-#include <stdio.h>
-#include <inttypes.h>
-#include <stdio.h>
-#include <inttypes.h>
-#include <string.h>
-#include "utils.h"
-#include "bgpstream_utils_addr.h"
 #include "bgpstream_utils_ip_counter.h"
+#include "bgpstream_utils_addr.h"
+#include "utils.h"
+#include <inttypes.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdio.h>
+#include <string.h>
 
 /* static char buffer[INET6_ADDRSTRLEN]; */
 
-typedef struct struct_v4pfx_int_t
-{  
+typedef struct struct_v4pfx_int_t {
   uint32_t start;
   uint32_t end;
   struct struct_v4pfx_int_t *next;
 } v4pfx_int_t;
 
-typedef struct struct_v6pfx_int_t
-{  
+typedef struct struct_v6pfx_int_t {
   uint64_t start_ms;
   uint64_t start_ls;
   uint64_t end_ms;
@@ -25,13 +23,11 @@ typedef struct struct_v6pfx_int_t
   struct struct_v6pfx_int_t *next;
 } v6pfx_int_t;
 
-
 /* IP Counter Linked List */
 struct bgpstream_ip_counter {
   v4pfx_int_t *v4list;
   v6pfx_int_t *v6list;
 };
-
 
 /* static void */
 /* print_pfx_int_list(bgpstream_ip_counter_t *ipc) */
@@ -74,268 +70,222 @@ struct bgpstream_ip_counter {
 /*      } */
 /*  }  */
 
-static void
-one_step_merge4(v4pfx_int_t *pil)
+static void one_step_merge4(v4pfx_int_t *pil)
 {
   v4pfx_int_t *current = pil;
   v4pfx_int_t *previous = pil;
-  if(current->next == NULL)
-    {
-      return;
-    }
+  if (current->next == NULL) {
+    return;
+  }
   current = current->next;
 
-  while(current != NULL)
-    {
-      if(current->start <= previous->end)
-        {
-          if(current->end > previous->end)
-            {
-              previous->end = current->end;
-            }
-          previous->next = current->next;
-          free(current);
-          current = previous->next;
-        }
-      else
-        {
-          break;
-        }
+  while (current != NULL) {
+    if (current->start <= previous->end) {
+      if (current->end > previous->end) {
+        previous->end = current->end;
+      }
+      previous->next = current->next;
+      free(current);
+      current = previous->next;
+    } else {
+      break;
     }
+  }
 }
 
-static void
-one_step_merge6(v6pfx_int_t *pil)
+static void one_step_merge6(v6pfx_int_t *pil)
 {
   v6pfx_int_t *current = pil;
   v6pfx_int_t *previous = pil;
-  if(current->next == NULL)
-    {
-      return;
-    }
+  if (current->next == NULL) {
+    return;
+  }
   current = current->next;
 
-  while(current != NULL)
-    {
-      
-      /* current->start <= previous->end */
-      if(current->start_ms < previous->end_ms ||
-         (current->start_ms == previous->end_ms &&
-          current->start_ls <= previous->end_ls))        
-        {
-          /* current->end > previous->end */
-          if(current->end_ms > previous->end_ms ||
-             (current->end_ms == previous->end_ms &&
-              current->end_ls > previous->end_ls))                    
-            {
-              previous->end_ms = current->end_ms;
-              previous->end_ls = current->end_ls;
-            }
-          previous->next = current->next;
-          free(current);
-          current = previous->next;
-        }
-      else
-        {
-          break;
-        }
+  while (current != NULL) {
+
+    /* current->start <= previous->end */
+    if (current->start_ms < previous->end_ms ||
+        (current->start_ms == previous->end_ms &&
+         current->start_ls <= previous->end_ls)) {
+      /* current->end > previous->end */
+      if (current->end_ms > previous->end_ms ||
+          (current->end_ms == previous->end_ms &&
+           current->end_ls > previous->end_ls)) {
+        previous->end_ms = current->end_ms;
+        previous->end_ls = current->end_ls;
+      }
+      previous->next = current->next;
+      free(current);
+      current = previous->next;
+    } else {
+      break;
     }
+  }
 }
 
-
-static int
-merge_in_sorted_queue4(v4pfx_int_t **pil, uint32_t start, uint32_t end)
+static int merge_in_sorted_queue4(v4pfx_int_t **pil, uint32_t start,
+                                  uint32_t end)
 {
   // create new v4pfx_int_t
   v4pfx_int_t *p = NULL;
   v4pfx_int_t *previous = *pil;
   v4pfx_int_t *current = *pil;
 
-  while(current != NULL)
-    {      
-      if(start > current->end)
-        {
-          previous = current;
-          current = current->next;
-          continue;                   
-        }
-      if(end < current->start)
-        {
-          /* found a position where to insert  */
-          if((p = (v4pfx_int_t *)malloc_zero(sizeof(v4pfx_int_t))) == NULL)
-            {
-              fprintf(stderr,"ERROR: can't malloc v4pfx_int_t structure\n");
-              return -1;
-            }
-          p->start = start;
-          p->end = end;
-          p->next = NULL;
-          if(previous != current)
-            {
-              previous->next = p;              
-            }
-          else
-            {
-              *pil = p;              
-            }
-          p->next = current;
-          return 0;
-        }
-      /* At this point S <= cE and E >= cS
-       * so we can merge them */
-      if(current->start > start)
-        {
-          current->start = start;
-        }
-      if(current->end < end)
-        {
-          current->end = end;
-        }
-      /* Now check from here on if there are other things
-       * to merge */
-      one_step_merge4(current);
+  while (current != NULL) {
+    if (start > current->end) {
+      previous = current;
+      current = current->next;
+      continue;
+    }
+    if (end < current->start) {
+      /* found a position where to insert  */
+      if ((p = (v4pfx_int_t *)malloc_zero(sizeof(v4pfx_int_t))) == NULL) {
+        fprintf(stderr, "ERROR: can't malloc v4pfx_int_t structure\n");
+        return -1;
+      }
+      p->start = start;
+      p->end = end;
+      p->next = NULL;
+      if (previous != current) {
+        previous->next = p;
+      } else {
+        *pil = p;
+      }
+      p->next = current;
       return 0;
     }
-
-  /*   if here we didn't find a place where to insert the 
-   * interval, it is either the first position or the last */
-  if((p = (v4pfx_int_t *)malloc_zero(sizeof(v4pfx_int_t))) == NULL)
-    {
-      fprintf(stderr,"ERROR: can't malloc v4pfx_int_t structure\n");
-      return -1;
+    /* At this point S <= cE and E >= cS
+     * so we can merge them */
+    if (current->start > start) {
+      current->start = start;
     }
+    if (current->end < end) {
+      current->end = end;
+    }
+    /* Now check from here on if there are other things
+     * to merge */
+    one_step_merge4(current);
+    return 0;
+  }
+
+  /*   if here we didn't find a place where to insert the
+   * interval, it is either the first position or the last */
+  if ((p = (v4pfx_int_t *)malloc_zero(sizeof(v4pfx_int_t))) == NULL) {
+    fprintf(stderr, "ERROR: can't malloc v4pfx_int_t structure\n");
+    return -1;
+  }
   p->start = start;
   p->end = end;
-  p->next = NULL;  
+  p->next = NULL;
   /* adding at the beginning of the queue */
-  if (previous == current)
-    {
-      *pil = p;
-      return 0;
-    }
+  if (previous == current) {
+    *pil = p;
+    return 0;
+  }
   // adding at the end of the queue
   previous->next = p;
   return 0;
 }
 
-static int
-merge_in_sorted_queue6(v6pfx_int_t **pil,
-                       uint64_t start_ms, uint64_t start_ls,
-                       uint64_t end_ms, uint64_t end_ls)
+static int merge_in_sorted_queue6(v6pfx_int_t **pil, uint64_t start_ms,
+                                  uint64_t start_ls, uint64_t end_ms,
+                                  uint64_t end_ls)
 {
   // create new v4pfx_int_t
   v6pfx_int_t *p = NULL;
   v6pfx_int_t *previous = *pil;
   v6pfx_int_t *current = *pil;
 
-  while(current != NULL)
-    {      
-      /* start > current->end */
-      if(start_ms > current->end_ms ||
-         (start_ms == current->end_ms &&
-          start_ls > current->end_ls))
-        {
-          previous = current;
-          current = current->next;
-          continue;                   
-        }
-      /* end < current->start */
-      if(end_ms < current->start_ms ||
-         (end_ms == current->start_ms &&
-          end_ls < current->start_ls))
-        {
-          /* found a position where to insert  */
-          if((p = (v6pfx_int_t *)malloc_zero(sizeof(v6pfx_int_t))) == NULL)
-            {
-              fprintf(stderr,"ERROR: can't malloc v6pfx_int_t structure\n");
-              return -1;
-            }
-          p->start_ms = start_ms;
-          p->start_ls = start_ls;
-          p->end_ms = end_ms;
-          p->end_ls = end_ls;
-          p->next = NULL;
-          if(previous != current)
-            {
-              previous->next = p;              
-            }
-          else
-            {
-              *pil = p;              
-            }
-          p->next = current;
-          return 0;
-        }
-      /* At this point S <= cE and E >= cS
-       * so we can merge them */
-      /* current->start > start */
-      if(current->start_ms > start_ms ||
-         (current->start_ms == start_ms &&
-          current->start_ls > start_ls))
-        {
-          current->start_ms = start_ms;
-          current->start_ls = start_ls;
-        }
-      /* current->end < end */
-      if(current->end_ms < end_ms ||
-         (current->end_ms == end_ms &&
-          current->end_ls < end_ls))
-        {
-          current->end_ms = end_ms;
-          current->end_ls = end_ls;
-        }
-      /* Now check from here on if there are other things
-       * to merge */
-      one_step_merge6(current);
+  while (current != NULL) {
+    /* start > current->end */
+    if (start_ms > current->end_ms ||
+        (start_ms == current->end_ms && start_ls > current->end_ls)) {
+      previous = current;
+      current = current->next;
+      continue;
+    }
+    /* end < current->start */
+    if (end_ms < current->start_ms ||
+        (end_ms == current->start_ms && end_ls < current->start_ls)) {
+      /* found a position where to insert  */
+      if ((p = (v6pfx_int_t *)malloc_zero(sizeof(v6pfx_int_t))) == NULL) {
+        fprintf(stderr, "ERROR: can't malloc v6pfx_int_t structure\n");
+        return -1;
+      }
+      p->start_ms = start_ms;
+      p->start_ls = start_ls;
+      p->end_ms = end_ms;
+      p->end_ls = end_ls;
+      p->next = NULL;
+      if (previous != current) {
+        previous->next = p;
+      } else {
+        *pil = p;
+      }
+      p->next = current;
       return 0;
     }
-
-  /*   if here we didn't find a place where to insert the 
-   * interval, it is either the first position or the last */
-  if((p = (v6pfx_int_t *)malloc_zero(sizeof(v6pfx_int_t))) == NULL)
-    {
-      fprintf(stderr,"ERROR: can't malloc v6pfx_int_t structure\n");
-      return -1;
+    /* At this point S <= cE and E >= cS
+     * so we can merge them */
+    /* current->start > start */
+    if (current->start_ms > start_ms ||
+        (current->start_ms == start_ms && current->start_ls > start_ls)) {
+      current->start_ms = start_ms;
+      current->start_ls = start_ls;
     }
+    /* current->end < end */
+    if (current->end_ms < end_ms ||
+        (current->end_ms == end_ms && current->end_ls < end_ls)) {
+      current->end_ms = end_ms;
+      current->end_ls = end_ls;
+    }
+    /* Now check from here on if there are other things
+     * to merge */
+    one_step_merge6(current);
+    return 0;
+  }
+
+  /*   if here we didn't find a place where to insert the
+   * interval, it is either the first position or the last */
+  if ((p = (v6pfx_int_t *)malloc_zero(sizeof(v6pfx_int_t))) == NULL) {
+    fprintf(stderr, "ERROR: can't malloc v6pfx_int_t structure\n");
+    return -1;
+  }
   p->start_ms = start_ms;
   p->start_ls = start_ls;
   p->end_ms = end_ms;
   p->end_ls = end_ls;
-  p->next = NULL;  
+  p->next = NULL;
   /* adding at the beginning of the queue */
-  if (previous == current)
-    {
-      *pil = p;
-      return 0;
-    }
+  if (previous == current) {
+    *pil = p;
+    return 0;
+  }
   // adding at the end of the queue
   previous->next = p;
   return 0;
 }
 
-
-bgpstream_ip_counter_t *
-bgpstream_ip_counter_create()
+bgpstream_ip_counter_t *bgpstream_ip_counter_create()
 {
   bgpstream_ip_counter_t *ipc;
-  if((ipc = (bgpstream_ip_counter_t *)malloc_zero(sizeof(bgpstream_ip_counter_t))) == NULL)
-    {
-      fprintf(stderr,"ERROR: can't malloc bgpstream_ip_counter_t structure\n");
-      return NULL;
-    }
+  if ((ipc = (bgpstream_ip_counter_t *)malloc_zero(
+         sizeof(bgpstream_ip_counter_t))) == NULL) {
+    fprintf(stderr, "ERROR: can't malloc bgpstream_ip_counter_t structure\n");
+    return NULL;
+  }
   ipc->v4list = NULL;
   ipc->v6list = NULL;
   return ipc;
 }
 
-int
-bgpstream_ip_counter_add(bgpstream_ip_counter_t *ipc,
-                         bgpstream_pfx_t *pfx)
+int bgpstream_ip_counter_add(bgpstream_ip_counter_t *ipc, bgpstream_pfx_t *pfx)
 {
   uint32_t start;
   uint32_t end;
   uint32_t mask;
-  unsigned char * tmp;
+  unsigned char *tmp;
   uint64_t start_ms = 0;
   uint64_t start_ls = 0;
   uint64_t end_ms = 0;
@@ -343,63 +293,56 @@ bgpstream_ip_counter_add(bgpstream_ip_counter_t *ipc,
   uint64_t mask_ms;
   uint64_t mask_ls;
 
-  if(pfx->address.version == BGPSTREAM_ADDR_VERSION_IPV4)
-    {
-      mask = ~( ((uint64_t)1 << (32 - pfx->mask_len)) - 1);
-      start = ntohl(((bgpstream_ipv4_pfx_t *)pfx)->address.ipv4.s_addr);
-      start = start & mask;
-      end = start | (~mask);
-      return merge_in_sorted_queue4(&ipc->v4list, start, end);
-    }
-  else
-    {
-      if(pfx->address.version == BGPSTREAM_ADDR_VERSION_IPV6)
-        {
-          tmp = &((bgpstream_ipv6_pfx_t *)pfx)->address.ipv6.s6_addr[0];
-          start_ms = ntohll(*((uint64_t *)tmp));
-          tmp = &((bgpstream_ipv6_pfx_t *)pfx)->address.ipv6.s6_addr[8];
-          start_ls = ntohll(*((uint64_t *)tmp));
-          /* printf("+++++++++  %"PRIu64" %"PRIu64"\n", start_ms, start_ls); */
-          if(pfx->mask_len > 64)
-            {
-              /* len_ms = 0 */
-              mask_ms = ~((uint64_t)0);
-              /* len_ls = 64 - (pfx->mask_len - 64); */
-              mask_ls = ~( ((uint64_t)1 << (64 - (pfx->mask_len - 64))) - 1);
-            }
-          else
-            {
-              /* len_ms = 64 - pfx->mask_len; */
-              mask_ms = ~( ((uint64_t)1 << (64 - pfx->mask_len)) - 1);
-              /* len_ls = 64; */
-              /* mask_ls = ~( ((uint64_t)1 << 64) - 1); */
-              mask_ls = 0;
-            }
+  if (pfx->address.version == BGPSTREAM_ADDR_VERSION_IPV4) {
+    mask = ~(((uint64_t)1 << (32 - pfx->mask_len)) - 1);
+    start = ntohl(((bgpstream_ipv4_pfx_t *)pfx)->address.ipv4.s_addr);
+    start = start & mask;
+    end = start | (~mask);
+    return merge_in_sorted_queue4(&ipc->v4list, start, end);
+  } else {
+    if (pfx->address.version == BGPSTREAM_ADDR_VERSION_IPV6) {
+      tmp = &((bgpstream_ipv6_pfx_t *)pfx)->address.ipv6.s6_addr[0];
+      start_ms = ntohll(*((uint64_t *)tmp));
+      tmp = &((bgpstream_ipv6_pfx_t *)pfx)->address.ipv6.s6_addr[8];
+      start_ls = ntohll(*((uint64_t *)tmp));
+      /* printf("+++++++++  %"PRIu64" %"PRIu64"\n", start_ms, start_ls); */
+      if (pfx->mask_len > 64) {
+        /* len_ms = 0 */
+        mask_ms = ~((uint64_t)0);
+        /* len_ls = 64 - (pfx->mask_len - 64); */
+        mask_ls = ~(((uint64_t)1 << (64 - (pfx->mask_len - 64))) - 1);
+      } else {
+        /* len_ms = 64 - pfx->mask_len; */
+        mask_ms = ~(((uint64_t)1 << (64 - pfx->mask_len)) - 1);
+        /* len_ls = 64; */
+        /* mask_ls = ~( ((uint64_t)1 << 64) - 1); */
+        mask_ls = 0;
+      }
 
-          /* printf("MASKS:  %"PRIu64" %"PRIu64"\n", mask_ms, mask_ls); */
-          
-          /* most significant */
-          start_ms = start_ms & mask_ms;
-          end_ms = start_ms | (~mask_ms);
-          /* printf("MS:  %"PRIu64" %"PRIu64"\n", start_ms, end_ms); */
+      /* printf("MASKS:  %"PRIu64" %"PRIu64"\n", mask_ms, mask_ls); */
 
-          /* least significant */
-          start_ls = start_ls & mask_ls;
-          end_ls = start_ls | (~mask_ls);
-          /* printf("LS:  %"PRIu64" %"PRIu64"\n", start_ls, end_ls); */
-          
-          return merge_in_sorted_queue6(&ipc->v6list, start_ms, start_ls, end_ms, end_ls);
-        }
+      /* most significant */
+      start_ms = start_ms & mask_ms;
+      end_ms = start_ms | (~mask_ms);
+      /* printf("MS:  %"PRIu64" %"PRIu64"\n", start_ms, end_ms); */
+
+      /* least significant */
+      start_ls = start_ls & mask_ls;
+      end_ls = start_ls | (~mask_ls);
+      /* printf("LS:  %"PRIu64" %"PRIu64"\n", start_ls, end_ls); */
+
+      return merge_in_sorted_queue6(&ipc->v6list, start_ms, start_ls, end_ms,
+                                    end_ls);
     }
+  }
   /* print_pfx_int_list(ipc); */
   return 0;
 }
 
-uint32_t
-bgpstream_ip_counter_is_overlapping4(bgpstream_ip_counter_t *ipc,
-                                     bgpstream_ipv4_pfx_t *pfx,
-                                     uint8_t *more_specific)
-{  
+uint32_t bgpstream_ip_counter_is_overlapping4(bgpstream_ip_counter_t *ipc,
+                                              bgpstream_ipv4_pfx_t *pfx,
+                                              uint8_t *more_specific)
+{
   v4pfx_int_t *current = ipc->v4list;
   uint32_t start = 0;
   uint32_t end = 0;
@@ -418,45 +361,37 @@ bgpstream_ip_counter_is_overlapping4(bgpstream_ip_counter_t *ipc,
   /* intersection endpoints */
   uint32_t int_start;
   uint32_t int_end;
-  while(current != NULL)
-    {
-      if(current->start > end)
-        {
-          break;
-        }
-      if(current->end < start)
-        {
-          current = current->next;
-          continue;
-        }
-      /* there is some overlap 
-       * max(start) and min(end) */
-      int_start = current->start;
-      int_end = current->end;
-      if(current->start < start)
-        {
-          int_start = start;
-        }
-      if(current->end > end)
-        {
-          int_end = end;
-        }
-      if((int_end - int_start + 1) == pfx_size)
-        {
-          *more_specific = 1;
-        }
-      overlap_count += int_end - int_start + 1;
-      current = current->next;      
+  while (current != NULL) {
+    if (current->start > end) {
+      break;
     }
+    if (current->end < start) {
+      current = current->next;
+      continue;
+    }
+    /* there is some overlap
+     * max(start) and min(end) */
+    int_start = current->start;
+    int_end = current->end;
+    if (current->start < start) {
+      int_start = start;
+    }
+    if (current->end > end) {
+      int_end = end;
+    }
+    if ((int_end - int_start + 1) == pfx_size) {
+      *more_specific = 1;
+    }
+    overlap_count += int_end - int_start + 1;
+    current = current->next;
+  }
   return overlap_count;
 }
 
-
-uint64_t
-bgpstream_ip_counter_is_overlapping6(bgpstream_ip_counter_t *ipc,
-                                     bgpstream_ipv6_pfx_t *pfx,
-                                     uint8_t *more_specific)
-{  
+uint64_t bgpstream_ip_counter_is_overlapping6(bgpstream_ip_counter_t *ipc,
+                                              bgpstream_ipv6_pfx_t *pfx,
+                                              uint8_t *more_specific)
+{
   v6pfx_int_t *current = ipc->v6list;
   v6pfx_int_t *previous = ipc->v6list;
 
@@ -466,11 +401,10 @@ bgpstream_ip_counter_is_overlapping6(bgpstream_ip_counter_t *ipc,
   uint64_t end_ls = 0;
   uint64_t mask_ms;
   uint64_t mask_ls;
-  unsigned char * tmp;
+  unsigned char *tmp;
   uint64_t overlap_count = 0;
   uint64_t pfx_size;
   *more_specific = 0;
-    
 
   tmp = &(pfx->address.ipv6.s6_addr[0]);
   start_ms = ntohll(*((uint64_t *)tmp));
@@ -478,29 +412,26 @@ bgpstream_ip_counter_is_overlapping6(bgpstream_ip_counter_t *ipc,
   start_ls = ntohll(*((uint64_t *)tmp));
 
   /* printf("+++++++++  %"PRIu64" %"PRIu64"\n", start_ms, start_ls); */
-  if(pfx->mask_len > 64)
-    {
-      /* len_ms = 0 */
-      mask_ms = ~((uint64_t)0);
-      /* len_ls = 64 - (pfx->mask_len - 64); */
-      mask_ls = ~( ((uint64_t)1 << (64 - (pfx->mask_len - 64))) - 1);
-    }
-  else
-    {
-      /* len_ms = 64 - pfx->mask_len; */
-      mask_ms = ~( ((uint64_t)1 << (64 - pfx->mask_len)) - 1);
-      /* len_ls = 64; */
-      /* mask_ls = ~( ((uint64_t)1 << 64) - 1); */
-      mask_ls = 0;
-    }
-  
+  if (pfx->mask_len > 64) {
+    /* len_ms = 0 */
+    mask_ms = ~((uint64_t)0);
+    /* len_ls = 64 - (pfx->mask_len - 64); */
+    mask_ls = ~(((uint64_t)1 << (64 - (pfx->mask_len - 64))) - 1);
+  } else {
+    /* len_ms = 64 - pfx->mask_len; */
+    mask_ms = ~(((uint64_t)1 << (64 - pfx->mask_len)) - 1);
+    /* len_ls = 64; */
+    /* mask_ls = ~( ((uint64_t)1 << 64) - 1); */
+    mask_ls = 0;
+  }
+
   /* printf("MASKS:  %"PRIu64" %"PRIu64"\n", mask_ms, mask_ls); */
-  
+
   /* most significant */
   start_ms = start_ms & mask_ms;
   end_ms = start_ms | (~mask_ms);
   /* printf("MS:  %"PRIu64" %"PRIu64"\n", start_ms, end_ms); */
-  
+
   /* least significant */
   start_ls = start_ls & mask_ls;
   end_ls = start_ls | (~mask_ls);
@@ -508,176 +439,139 @@ bgpstream_ip_counter_is_overlapping6(bgpstream_ip_counter_t *ipc,
 
   pfx_size = end_ms - start_ms + 1;
 
-  /* intersection endpoints 
+  /* intersection endpoints
    * (only most significant)*/
-  uint64_t int_start_ms;  
+  uint64_t int_start_ms;
   uint64_t int_end_ms;
 
-  while(current != NULL)
-    {
-      /* current->start > end */
-      if(current->start_ms > end_ms ||
-         (current->start_ms == end_ms &&
-          current->start_ls > end_ls))
-        {
-          break;
-        }
-      /* current->end < start */
-      if(current->end_ms < start_ms ||
-         (current->end_ms == start_ms &&
-          current->end_ms < start_ls))
-        {
-          previous = current;
-          current = current->next;
-          continue;
-        }
-      /* there is some overlap 
-       * max(start) and min(end) */
-      int_start_ms = current->start_ms;
-      int_end_ms = current->end_ms;
-      /* int_start_ls = current->start_ls; */
-      /* int_end_ls = current->end_ls; */
-      /* current->start < start */
-      if(current->start_ms < start_ms ||
-         (current->start_ms == start_ms &&
-          current->start_ms < start_ls))
-        {
-          int_start_ms = start_ms;
-          /* int_start_ls = start_ls; */
-        }
-      /* current->end > end */
-      if(current->end_ms > end_ms ||
-         (current->end_ms == end_ms &&
-          current->end_ls > end_ls))
-        {
-          int_end_ms = end_ms;
-          /* int_end_ls = end_ls; */
-        }
-      if(previous != current)
-        {
-          if(current->start_ms != previous->start_ms ||
-             current->end_ms != previous->end_ms)
-            {
-              if((int_end_ms - int_start_ms + 1) == pfx_size)
-                {
-                  *more_specific = 1;
-                }
-              overlap_count += int_end_ms - int_start_ms + 1;
-            }
-        }
-      else
-        {
-          if((int_end_ms - int_start_ms + 1) == pfx_size)
-            {
-              *more_specific = 1;
-            }
-          overlap_count += int_end_ms - int_start_ms + 1;          
-        }
-      previous = current;
-      current = current->next;      
+  while (current != NULL) {
+    /* current->start > end */
+    if (current->start_ms > end_ms ||
+        (current->start_ms == end_ms && current->start_ls > end_ls)) {
+      break;
     }
+    /* current->end < start */
+    if (current->end_ms < start_ms ||
+        (current->end_ms == start_ms && current->end_ms < start_ls)) {
+      previous = current;
+      current = current->next;
+      continue;
+    }
+    /* there is some overlap
+     * max(start) and min(end) */
+    int_start_ms = current->start_ms;
+    int_end_ms = current->end_ms;
+    /* int_start_ls = current->start_ls; */
+    /* int_end_ls = current->end_ls; */
+    /* current->start < start */
+    if (current->start_ms < start_ms ||
+        (current->start_ms == start_ms && current->start_ms < start_ls)) {
+      int_start_ms = start_ms;
+      /* int_start_ls = start_ls; */
+    }
+    /* current->end > end */
+    if (current->end_ms > end_ms ||
+        (current->end_ms == end_ms && current->end_ls > end_ls)) {
+      int_end_ms = end_ms;
+      /* int_end_ls = end_ls; */
+    }
+    if (previous != current) {
+      if (current->start_ms != previous->start_ms ||
+          current->end_ms != previous->end_ms) {
+        if ((int_end_ms - int_start_ms + 1) == pfx_size) {
+          *more_specific = 1;
+        }
+        overlap_count += int_end_ms - int_start_ms + 1;
+      }
+    } else {
+      if ((int_end_ms - int_start_ms + 1) == pfx_size) {
+        *more_specific = 1;
+      }
+      overlap_count += int_end_ms - int_start_ms + 1;
+    }
+    previous = current;
+    current = current->next;
+  }
   return overlap_count;
 }
 
-uint64_t
-bgpstream_ip_counter_is_overlapping(bgpstream_ip_counter_t *ipc,
-                                    bgpstream_pfx_t *pfx, uint8_t *more_specific)
+uint64_t bgpstream_ip_counter_is_overlapping(bgpstream_ip_counter_t *ipc,
+                                             bgpstream_pfx_t *pfx,
+                                             uint8_t *more_specific)
 {
   *more_specific = 0;
-  if(pfx->address.version == BGPSTREAM_ADDR_VERSION_IPV4)
-    {
-      return bgpstream_ip_counter_is_overlapping4(ipc, (bgpstream_ipv4_pfx_t *)pfx, more_specific);
+  if (pfx->address.version == BGPSTREAM_ADDR_VERSION_IPV4) {
+    return bgpstream_ip_counter_is_overlapping4(
+      ipc, (bgpstream_ipv4_pfx_t *)pfx, more_specific);
+  } else {
+    if (pfx->address.version == BGPSTREAM_ADDR_VERSION_IPV6) {
+      return bgpstream_ip_counter_is_overlapping6(
+        ipc, (bgpstream_ipv6_pfx_t *)pfx, more_specific);
     }
-  else
-    {
-      if(pfx->address.version == BGPSTREAM_ADDR_VERSION_IPV6)
-        {
-          return bgpstream_ip_counter_is_overlapping6(ipc, (bgpstream_ipv6_pfx_t *)pfx, more_specific);
-        }
-    }
+  }
   return 0;
 }
 
-
-uint64_t
-bgpstream_ip_counter_get_ipcount(bgpstream_ip_counter_t *ipc,
-                                 bgpstream_addr_version_t v)
+uint64_t bgpstream_ip_counter_get_ipcount(bgpstream_ip_counter_t *ipc,
+                                          bgpstream_addr_version_t v)
 {
   uint64_t ip_count = 0;
-  
+
   v4pfx_int_t *current4 = ipc->v4list;
   v6pfx_int_t *current6 = ipc->v6list;
   v6pfx_int_t *previous6 = ipc->v6list;
 
-  if(v == BGPSTREAM_ADDR_VERSION_IPV4)
-    {
-      while(current4 != NULL)
-        {
-          ip_count += (current4->end - current4->start) + 1;
-          current4 = current4->next;
-        }
+  if (v == BGPSTREAM_ADDR_VERSION_IPV4) {
+    while (current4 != NULL) {
+      ip_count += (current4->end - current4->start) + 1;
+      current4 = current4->next;
     }
-  else
-    {
-      if(v == BGPSTREAM_ADDR_VERSION_IPV6)
-        {
-          while(current6 != NULL)
-            {
-              
-              if(previous6 != current6)
-                {
-                  /* add a new /64 to the count if the previous one
-                   * was different (it could have been a /64+ */                                                      
-                  if(current6->start_ms != previous6->start_ms ||
-                     current6->end_ms != previous6->end_ms)
-                    {
-                      ip_count += (current6->end_ms - current6->start_ms) + 1;
-                    }
-                }
-              else
-                { /* if it is the first interval, than we always add it */
-                  ip_count += (current6->end_ms - current6->start_ms) + 1;
-                }
-              previous6 = current6;
-              current6 = current6->next;
-            }
+  } else {
+    if (v == BGPSTREAM_ADDR_VERSION_IPV6) {
+      while (current6 != NULL) {
+
+        if (previous6 != current6) {
+          /* add a new /64 to the count if the previous one
+           * was different (it could have been a /64+ */
+          if (current6->start_ms != previous6->start_ms ||
+              current6->end_ms != previous6->end_ms) {
+            ip_count += (current6->end_ms - current6->start_ms) + 1;
+          }
+        } else { /* if it is the first interval, than we always add it */
+          ip_count += (current6->end_ms - current6->start_ms) + 1;
         }
+        previous6 = current6;
+        current6 = current6->next;
+      }
     }
+  }
   return ip_count;
 }
 
-
-
-void
-bgpstream_ip_counter_clear(bgpstream_ip_counter_t *ipc)
+void bgpstream_ip_counter_clear(bgpstream_ip_counter_t *ipc)
 {
   v4pfx_int_t *current4 = ipc->v4list;
   v4pfx_int_t *tmp4 = ipc->v4list;
   v6pfx_int_t *current6 = ipc->v6list;
   v6pfx_int_t *tmp6 = ipc->v6list;
-  
-  while(tmp4 != NULL)
-    {
-      current4 = tmp4;
-      tmp4 = tmp4->next;
-      free(current4);
-    }
+
+  while (tmp4 != NULL) {
+    current4 = tmp4;
+    tmp4 = tmp4->next;
+    free(current4);
+  }
   ipc->v4list = NULL;
 
-  while(tmp6 != NULL)
-    {
-      current6 = tmp6;
-      tmp6 = tmp6->next;
-      free(current6);
-    }
+  while (tmp6 != NULL) {
+    current6 = tmp6;
+    tmp6 = tmp6->next;
+    free(current6);
+  }
   ipc->v6list = NULL;
 }
 
-
-void
-bgpstream_ip_counter_destroy(bgpstream_ip_counter_t *ipc)
+void bgpstream_ip_counter_destroy(bgpstream_ip_counter_t *ipc)
 {
   bgpstream_ip_counter_clear(ipc);
   free(ipc);
 }
-

--- a/lib/utils/bgpstream_utils_ip_counter.h
+++ b/lib/utils/bgpstream_utils_ip_counter.h
@@ -21,14 +21,12 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #ifndef __BGPSTREAM_UTILS_IPCNT_H
 #define __BGPSTREAM_UTILS_IPCNT_H
 
 #include <stdint.h>
 
 #include "bgpstream_utils_pfx.h"
-
 
 /** @file
  *
@@ -39,7 +37,6 @@
  *
  */
 
-
 /**
  * @name Opaque Data Structures
  *
@@ -49,7 +46,6 @@
 typedef struct bgpstream_ip_counter bgpstream_ip_counter_t;
 
 /** @} */
-
 
 /**
  * @name Public API Functions
@@ -68,8 +64,7 @@ bgpstream_ip_counter_t *bgpstream_ip_counter_create();
  * @param pfx          prefix to insert in IP Counter
  * @return             0 if a prefix was added correctly, -1 otherwise
  */
-int bgpstream_ip_counter_add(bgpstream_ip_counter_t *ipc,
-                             bgpstream_pfx_t *pfx);
+int bgpstream_ip_counter_add(bgpstream_ip_counter_t *ipc, bgpstream_pfx_t *pfx);
 
 /** Get the number of unique IPs in the IP Counter
  *
@@ -87,11 +82,12 @@ uint64_t bgpstream_ip_counter_get_ipcount(bgpstream_ip_counter_t *ipc,
  * @param counter        pointer to the IP Counter
  * @param pfx            prefix to compare
  * @param more_specific  it is set to 1 if the prefix is a more specific
- * @return               number of unique IPs in the IP Counter that 
+ * @return               number of unique IPs in the IP Counter that
  *                       overlap with pfx
  */
 uint64_t bgpstream_ip_counter_is_overlapping(bgpstream_ip_counter_t *ipc,
-                                             bgpstream_pfx_t *pfx, uint8_t *more_specific);
+                                             bgpstream_pfx_t *pfx,
+                                             uint8_t *more_specific);
 
 /** Empty the IP Counter
  *
@@ -105,6 +101,4 @@ void bgpstream_ip_counter_clear(bgpstream_ip_counter_t *ipc);
  */
 void bgpstream_ip_counter_destroy(bgpstream_ip_counter_t *ipc);
 
-
 #endif /* __BGPSTREAM_UTILS_IPCNT_H */
-

--- a/lib/utils/bgpstream_utils_patricia.c
+++ b/lib/utils/bgpstream_utils_patricia.c
@@ -35,44 +35,39 @@
  * "demo.c" so that it could be used as a standalone API.
  */
 
-
+#include "khash.h" /* << kroundup32 */
 #include <assert.h>
 #include <limits.h>
-#include <stdint.h>
-#include <sys/types.h>
-#include <sys/socket.h>
 #include <netdb.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include "khash.h" /* << kroundup32 */
+#include <sys/socket.h>
+#include <sys/types.h>
 
-#include "utils.h"
 #include "bgpstream_utils_patricia.h"
 #include "bgpstream_utils_pfx.h"
+#include "utils.h"
 
 /* for debug purposes */
 /* DEBUG static char buffer[1024]; */
 
-
 #define BGPSTREAM_PATRICIA_MAXBITS 128
 
-#define BIT_TEST(f, b)  ((f) & (b))
+#define BIT_TEST(f, b) ((f) & (b))
 
-
-static int
-comp_with_mask (void *addr, void *dest, u_int mask)
+static int comp_with_mask(void *addr, void *dest, u_int mask)
 {
 
-    if ( /* mask/8 == 0 || */ memcmp (addr, dest, mask / 8) == 0) {
-	int n = mask / 8;
-	int m = ((-1) << (8 - (mask % 8)));
+  if (/* mask/8 == 0 || */ memcmp(addr, dest, mask / 8) == 0) {
+    int n = mask / 8;
+    int m = ((-1) << (8 - (mask % 8)));
 
-	if (mask % 8 == 0 || (((u_char *)addr)[n] & m) == (((u_char *)dest)[n] & m))
-	    return (1);
-    }
-    return (0);
+    if (mask % 8 == 0 || (((u_char *)addr)[n] & m) == (((u_char *)dest)[n] & m))
+      return (1);
+  }
+  return (0);
 }
-
 
 struct bgpstream_patricia_node {
 
@@ -91,9 +86,7 @@ struct bgpstream_patricia_node {
 
   /* pointer to user data */
   void *user;
-
 };
-
 
 struct bgpstream_patricia_tree {
 
@@ -112,7 +105,6 @@ struct bgpstream_patricia_tree {
   bgpstream_patricia_tree_destroy_user_t *node_user_destructor;
 };
 
-
 /** Data structure containing a list of pointers to Patricia Tree nodes
  *  that are returned as the result of a computation */
 struct bgpstream_patricia_tree_result_set {
@@ -126,61 +118,56 @@ struct bgpstream_patricia_tree_result_set {
   int _alloc_size;
 };
 
-
 /* ======================= UTILITY FUNCTIONS ======================= */
-
 
 static unsigned char *bgpstream_pfx_get_first_byte(bgpstream_pfx_t *pfx)
 {
-  switch(pfx->address.version)
-    {
-    case BGPSTREAM_ADDR_VERSION_IPV4:
-      return (unsigned char *) &((bgpstream_ipv4_pfx_t *)pfx)->address.ipv4.s_addr;
-    case BGPSTREAM_ADDR_VERSION_IPV6:
-      return (unsigned char *) &((bgpstream_ipv6_pfx_t *)pfx)->address.ipv6.s6_addr[0];
-    default:
-      assert(0);
-    }
+  switch (pfx->address.version) {
+  case BGPSTREAM_ADDR_VERSION_IPV4:
+    return (unsigned char *)&((bgpstream_ipv4_pfx_t *)pfx)->address.ipv4.s_addr;
+  case BGPSTREAM_ADDR_VERSION_IPV6:
+    return (unsigned char *)&((bgpstream_ipv6_pfx_t *)pfx)
+      ->address.ipv6.s6_addr[0];
+  default:
+    assert(0);
+  }
   return NULL;
 }
 
-
 /* ======================= RESULT SET FUNCTIONS  ======================= */
 
-static int bgpstream_patricia_tree_result_set_add_node(bgpstream_patricia_tree_result_set_t *set,
-                                                       bgpstream_patricia_node_t *node)
+static int bgpstream_patricia_tree_result_set_add_node(
+  bgpstream_patricia_tree_result_set_t *set, bgpstream_patricia_node_t *node)
 {
   set->n_recs++;
   /* Realloc if necessary */
-  if(set->_alloc_size < set->n_recs)
-    {
-      /* round n_recs up to next pow 2 */
-      set->_alloc_size = set->n_recs;
-      kroundup32(set->_alloc_size);
+  if (set->_alloc_size < set->n_recs) {
+    /* round n_recs up to next pow 2 */
+    set->_alloc_size = set->n_recs;
+    kroundup32(set->_alloc_size);
 
-      if((set->result_nodes =
-          realloc(set->result_nodes,
-                  sizeof(bgpstream_patricia_node_t*) * set->_alloc_size)) == NULL)
-        {
-          fprintf(stderr, "Error: could not realloc result_nodes in result set\n");
-          return -1;
-        }
+    if ((set->result_nodes =
+           realloc(set->result_nodes, sizeof(bgpstream_patricia_node_t *) *
+                                        set->_alloc_size)) == NULL) {
+      fprintf(stderr, "Error: could not realloc result_nodes in result set\n");
+      return -1;
     }
-  set->result_nodes[set->n_recs-1] = node;
+  }
+  set->result_nodes[set->n_recs - 1] = node;
   return 0;
 }
 
-static void bgpstream_patricia_tree_result_set_clear(bgpstream_patricia_tree_result_set_t *set)
+static void bgpstream_patricia_tree_result_set_clear(
+  bgpstream_patricia_tree_result_set_t *set)
 {
-  set->n_recs=0;
+  set->n_recs = 0;
 }
-
 
 /* ======================= PATRICIA NODE FUNCTIONS ======================= */
 
-
-static bgpstream_patricia_node_t *bgpstream_patricia_node_create(bgpstream_patricia_tree_t *pt,
-                                                                 bgpstream_pfx_t *pfx)
+static bgpstream_patricia_node_t *
+bgpstream_patricia_node_create(bgpstream_patricia_tree_t *pt,
+                               bgpstream_pfx_t *pfx)
 {
   bgpstream_patricia_node_t *node;
 
@@ -188,22 +175,19 @@ static bgpstream_patricia_node_t *bgpstream_patricia_node_create(bgpstream_patri
   assert(pfx->mask_len <= BGPSTREAM_PATRICIA_MAXBITS);
   assert(pfx->address.version != BGPSTREAM_ADDR_VERSION_UNKNOWN);
 
-  if((node = malloc_zero(sizeof(bgpstream_patricia_node_t))) == NULL)
-    {
-      return NULL;
-    }
+  if ((node = malloc_zero(sizeof(bgpstream_patricia_node_t))) == NULL) {
+    return NULL;
+  }
 
-  if(pfx->address.version == BGPSTREAM_ADDR_VERSION_IPV4)
-    {
-      pt->ipv4_active_nodes++;
-    }
-  else
-    {
-      pt->ipv6_active_nodes++;
-    }
+  if (pfx->address.version == BGPSTREAM_ADDR_VERSION_IPV4) {
+    pt->ipv4_active_nodes++;
+  } else {
+    pt->ipv6_active_nodes++;
+  }
 
   node->prefix.mask_len = pfx->mask_len;
-  bgpstream_addr_copy((bgpstream_ip_addr_t *) &node->prefix.address , (bgpstream_ip_addr_t *) &pfx->address);
+  bgpstream_addr_copy((bgpstream_ip_addr_t *)&node->prefix.address,
+                      (bgpstream_ip_addr_t *)&pfx->address);
 
   node->parent = NULL;
   node->bit = pfx->mask_len;
@@ -217,10 +201,9 @@ static bgpstream_patricia_node_t *bgpstream_patricia_gluenode_create()
 {
   bgpstream_patricia_node_t *node;
 
-  if((node = malloc_zero(sizeof(bgpstream_patricia_node_t))) == NULL)
-    {
-      return NULL;
-    }
+  if ((node = malloc_zero(sizeof(bgpstream_patricia_node_t))) == NULL) {
+    return NULL;
+  }
   node->prefix.address.version = BGPSTREAM_ADDR_VERSION_UNKNOWN;
   node->parent = NULL;
   node->bit = 0;
@@ -229,194 +212,170 @@ static bgpstream_patricia_node_t *bgpstream_patricia_gluenode_create()
   return node;
 }
 
-
 /* ======================= PATRICIA TREE FUNCTIONS ======================= */
 
-static bgpstream_patricia_node_t *bgpstream_patricia_get_head(bgpstream_patricia_tree_t *pt,
-                                                              bgpstream_addr_version_t v)
+static bgpstream_patricia_node_t *
+bgpstream_patricia_get_head(bgpstream_patricia_tree_t *pt,
+                            bgpstream_addr_version_t v)
 {
-  switch(v)
-    {
-    case BGPSTREAM_ADDR_VERSION_IPV4:
-      return pt->head4;
-    case BGPSTREAM_ADDR_VERSION_IPV6:
-      return pt->head6;
-    default:
-      assert(0);
-    }
+  switch (v) {
+  case BGPSTREAM_ADDR_VERSION_IPV4:
+    return pt->head4;
+  case BGPSTREAM_ADDR_VERSION_IPV6:
+    return pt->head6;
+  default:
+    assert(0);
+  }
   return NULL;
 }
 
-static void bgpstream_patricia_set_head(bgpstream_patricia_tree_t *pt, bgpstream_addr_version_t v,
+static void bgpstream_patricia_set_head(bgpstream_patricia_tree_t *pt,
+                                        bgpstream_addr_version_t v,
                                         bgpstream_patricia_node_t *n)
 {
-  switch(v)
-    {
-    case BGPSTREAM_ADDR_VERSION_IPV4:
-      pt->head4 = n;
-      break;
-    case BGPSTREAM_ADDR_VERSION_IPV6:
-      pt->head6 = n;
-      break;
-    default:
-      assert(0);
-    }
+  switch (v) {
+  case BGPSTREAM_ADDR_VERSION_IPV4:
+    pt->head4 = n;
+    break;
+  case BGPSTREAM_ADDR_VERSION_IPV6:
+    pt->head6 = n;
+    break;
+  default:
+    assert(0);
+  }
 }
 
-
-static uint64_t bgpstream_patricia_tree_count_subnets(bgpstream_patricia_node_t *node, uint64_t subnet_size)
+static uint64_t
+bgpstream_patricia_tree_count_subnets(bgpstream_patricia_node_t *node,
+                                      uint64_t subnet_size)
 {
-  if(node == NULL)
-    {
-      return 0;
-    }
-  /* if the node is a glue node, then the /subnet_size subnets are the sum of the
+  if (node == NULL) {
+    return 0;
+  }
+  /* if the node is a glue node, then the /subnet_size subnets are the sum of
+   * the
    * /24 subnets contained in its left and right subtrees */
-  if(node->prefix.address.version == BGPSTREAM_ADDR_VERSION_UNKNOWN)
-    {
-      /* if the glue node is already a /subnet_size, then just return 1 (even though
-       * the subnetworks below could be a non complete /subnet_size */
-      if(node->bit >= subnet_size)
-        {
-          return 1;
-        }
-      else
-        {
-          return bgpstream_patricia_tree_count_subnets(node->l, subnet_size) + \
-            bgpstream_patricia_tree_count_subnets(node->r, subnet_size);
-        }
+  if (node->prefix.address.version == BGPSTREAM_ADDR_VERSION_UNKNOWN) {
+    /* if the glue node is already a /subnet_size, then just return 1 (even
+     * though
+     * the subnetworks below could be a non complete /subnet_size */
+    if (node->bit >= subnet_size) {
+      return 1;
+    } else {
+      return bgpstream_patricia_tree_count_subnets(node->l, subnet_size) +
+             bgpstream_patricia_tree_count_subnets(node->r, subnet_size);
     }
-  else
-    {
-      /* otherwise we just count the subnet for the given network and return
-       * we don't need to go deeper in the tree (everything else beyond this
-       * point is covered */
+  } else {
+    /* otherwise we just count the subnet for the given network and return
+     * we don't need to go deeper in the tree (everything else beyond this
+     * point is covered */
 
-      /* compute how many /subnet_size are in this prefix */
-      if(node->prefix.mask_len >= subnet_size)
-        {
-          return 1;
-        }
-      else
-        {
-          uint8_t diff = subnet_size - node->prefix.mask_len;
-          if(diff == 64)
-            {
-              return UINT64_MAX;
-            }
-          else
-            {
-              return (uint64_t) 1 << diff;
-            }
-        }
+    /* compute how many /subnet_size are in this prefix */
+    if (node->prefix.mask_len >= subnet_size) {
+      return 1;
+    } else {
+      uint8_t diff = subnet_size - node->prefix.mask_len;
+      if (diff == 64) {
+        return UINT64_MAX;
+      } else {
+        return (uint64_t)1 << diff;
+      }
     }
+  }
 }
-
 
 /* depth pecifies how many "children" to explore for each node */
-static int bgpstream_patricia_tree_add_more_specifics(bgpstream_patricia_tree_result_set_t *set,
-                                                      bgpstream_patricia_node_t *node, const uint8_t depth)
+static int bgpstream_patricia_tree_add_more_specifics(
+  bgpstream_patricia_tree_result_set_t *set, bgpstream_patricia_node_t *node,
+  const uint8_t depth)
 {
-  if(node == NULL || depth == 0)
-    {
-      return 0;
-    }
+  if (node == NULL || depth == 0) {
+    return 0;
+  }
   uint8_t d = depth;
-  /* if it is a node containing a real prefix, then copy the address to a new result node */
-  if(node->prefix.address.version != BGPSTREAM_ADDR_VERSION_UNKNOWN)
-    {
-      if(bgpstream_patricia_tree_result_set_add_node(set, node) != 0)
-        {
-          return -1;
-        }
-      d--;
+  /* if it is a node containing a real prefix, then copy the address to a new
+   * result node */
+  if (node->prefix.address.version != BGPSTREAM_ADDR_VERSION_UNKNOWN) {
+    if (bgpstream_patricia_tree_result_set_add_node(set, node) != 0) {
+      return -1;
     }
+    d--;
+  }
 
   /* using pre-order R - Left - Right */
-  if(bgpstream_patricia_tree_add_more_specifics(set, node->l, d) != 0)
-    {
-      return -1;
-    }
-  if(bgpstream_patricia_tree_add_more_specifics(set, node->r, d) != 0)
-    {
-      return -1;
-    }
+  if (bgpstream_patricia_tree_add_more_specifics(set, node->l, d) != 0) {
+    return -1;
+  }
+  if (bgpstream_patricia_tree_add_more_specifics(set, node->r, d) != 0) {
+    return -1;
+  }
   return 0;
 }
 
 /* depth pecifies how many "children" to explore for each node */
-static int bgpstream_patricia_tree_add_less_specifics(bgpstream_patricia_tree_result_set_t *set,
-                                                      bgpstream_patricia_node_t *node, const uint8_t depth)
+static int bgpstream_patricia_tree_add_less_specifics(
+  bgpstream_patricia_tree_result_set_t *set, bgpstream_patricia_node_t *node,
+  const uint8_t depth)
 {
-  if(node == NULL)
-    {
-      return 0;
-    }
+  if (node == NULL) {
+    return 0;
+  }
   uint8_t d = depth;
-  while(node != NULL && d > 0)
-    {
-      /* if it is a node containing a real prefix, then copy the address to a new result node */
-      if(node->prefix.address.version != BGPSTREAM_ADDR_VERSION_UNKNOWN)
-        {
-          if(bgpstream_patricia_tree_result_set_add_node(set, node) != 0)
-            {
-              return -1;
-            }
-          d--;
-        }
-      node = node->parent;
+  while (node != NULL && d > 0) {
+    /* if it is a node containing a real prefix, then copy the address to a new
+     * result node */
+    if (node->prefix.address.version != BGPSTREAM_ADDR_VERSION_UNKNOWN) {
+      if (bgpstream_patricia_tree_result_set_add_node(set, node) != 0) {
+        return -1;
+      }
+      d--;
     }
+    node = node->parent;
+  }
   return 0;
 }
 
-
-static int bgpstream_patricia_tree_find_more_specific(bgpstream_patricia_node_t *node)
+static int
+bgpstream_patricia_tree_find_more_specific(bgpstream_patricia_node_t *node)
 {
-  if(node == NULL)
-    {
-      return 0;
+  if (node == NULL) {
+    return 0;
+  }
+  /* if it is a node containing a glue node, then we have to search for other
+   * cases */
+  if (node->prefix.address.version == BGPSTREAM_ADDR_VERSION_UNKNOWN) {
+    if (bgpstream_patricia_tree_find_more_specific(node->l) == 0) {
+      if (bgpstream_patricia_tree_find_more_specific(node->r) == 0) {
+        return 0;
+      }
     }
-  /* if it is a node containing a glue node, then we have to search for other cases */
-  if(node->prefix.address.version == BGPSTREAM_ADDR_VERSION_UNKNOWN)
-    {
-      if(bgpstream_patricia_tree_find_more_specific(node->l) == 0)
-        {
-          if(bgpstream_patricia_tree_find_more_specific(node->r) == 0)
-            {
-              return 0;
-            }
-        }
-    }
+  }
   /* if it is a node containing a real prefix, we are done */
   return 1;
-
 }
 
-static void bgpstream_patricia_tree_merge_tree(bgpstream_patricia_tree_t *dst, bgpstream_patricia_node_t *node)
+static void bgpstream_patricia_tree_merge_tree(bgpstream_patricia_tree_t *dst,
+                                               bgpstream_patricia_node_t *node)
 {
-  if(node == NULL)
-    {
-      return;
-    }
+  if (node == NULL) {
+    return;
+  }
   /* Add the current node, if it is not a glue node */
-  if(node->prefix.address.version != BGPSTREAM_ADDR_VERSION_UNKNOWN)
-    {
-      bgpstream_patricia_tree_insert(dst, (bgpstream_pfx_t *) &node->prefix);
-    }
+  if (node->prefix.address.version != BGPSTREAM_ADDR_VERSION_UNKNOWN) {
+    bgpstream_patricia_tree_insert(dst, (bgpstream_pfx_t *)&node->prefix);
+  }
   /* Recursively add left and right node */
   bgpstream_patricia_tree_merge_tree(dst, node->l);
   bgpstream_patricia_tree_merge_tree(dst, node->r);
 }
 
-static void bgpstream_patricia_tree_walk_tree(bgpstream_patricia_tree_t *pt,
-                                              bgpstream_patricia_node_t *node,
-                                              bgpstream_patricia_tree_process_node_t *fun,
-                                              void *data)
+static void bgpstream_patricia_tree_walk_tree(
+  bgpstream_patricia_tree_t *pt, bgpstream_patricia_node_t *node,
+  bgpstream_patricia_tree_process_node_t *fun, void *data)
 {
-  if(node == NULL)
-    {
-      return;
-    }
+  if (node == NULL) {
+    return;
+  }
 
   /* In order traversal: Left - Node - Right */
   bgpstream_patricia_node_t *l = node->l;
@@ -426,135 +385,131 @@ static void bgpstream_patricia_tree_walk_tree(bgpstream_patricia_tree_t *pt,
   bgpstream_patricia_tree_walk_tree(pt, l, fun, data);
 
   /* Node */
-  if(node->prefix.address.version != BGPSTREAM_ADDR_VERSION_UNKNOWN)
-    {
-      fun(pt, node, data);
-    }
+  if (node->prefix.address.version != BGPSTREAM_ADDR_VERSION_UNKNOWN) {
+    fun(pt, node, data);
+  }
 
   /* Right */
   bgpstream_patricia_tree_walk_tree(pt, r, fun, data);
-
 }
-
 
 static void bgpstream_patricia_tree_print_tree(bgpstream_patricia_node_t *node)
 {
-  if(node == NULL)
-    {
-      return;
-    }
+  if (node == NULL) {
+    return;
+  }
   bgpstream_patricia_tree_print_tree(node->l);
 
   char buffer[1024];
 
   /* if node is not a glue node, print the prefix */
-  if(node->prefix.address.version != BGPSTREAM_ADDR_VERSION_UNKNOWN)
-    {
-      memset(buffer, ' ', sizeof(char)*node->prefix.mask_len);
-      bgpstream_pfx_snprintf(buffer+node->prefix.mask_len, 1024, (bgpstream_pfx_t *) &node->prefix);
-      fprintf(stdout, "%s\n", buffer);
-    }
+  if (node->prefix.address.version != BGPSTREAM_ADDR_VERSION_UNKNOWN) {
+    memset(buffer, ' ', sizeof(char) * node->prefix.mask_len);
+    bgpstream_pfx_snprintf(buffer + node->prefix.mask_len, 1024,
+                           (bgpstream_pfx_t *)&node->prefix);
+    fprintf(stdout, "%s\n", buffer);
+  }
 
   bgpstream_patricia_tree_print_tree(node->r);
 }
 
-
-static void bgpstream_patricia_tree_destroy_tree(bgpstream_patricia_tree_t *pt, bgpstream_patricia_node_t *head)
+static void
+bgpstream_patricia_tree_destroy_tree(bgpstream_patricia_tree_t *pt,
+                                     bgpstream_patricia_node_t *head)
 {
-  if(head != NULL)
-    {
-      bgpstream_patricia_node_t *l = head->l;
-      bgpstream_patricia_node_t *r = head->r;
-      bgpstream_patricia_tree_destroy_tree(pt, l);
-      bgpstream_patricia_tree_destroy_tree(pt, r);
-      if(head->user != NULL && pt->node_user_destructor != NULL)
-        {
-          pt->node_user_destructor(head->user);
-        }
-      free(head);
+  if (head != NULL) {
+    bgpstream_patricia_node_t *l = head->l;
+    bgpstream_patricia_node_t *r = head->r;
+    bgpstream_patricia_tree_destroy_tree(pt, l);
+    bgpstream_patricia_tree_destroy_tree(pt, r);
+    if (head->user != NULL && pt->node_user_destructor != NULL) {
+      pt->node_user_destructor(head->user);
     }
+    free(head);
+  }
 }
 
 /* ======================= PUBLIC API FUNCTIONS ======================= */
 
-
-bgpstream_patricia_tree_result_set_t *bgpstream_patricia_tree_result_set_create()
+bgpstream_patricia_tree_result_set_t *
+bgpstream_patricia_tree_result_set_create()
 {
   bgpstream_patricia_tree_result_set_t *set;
 
-  if((set = malloc_zero(sizeof(bgpstream_patricia_tree_result_set_t))) == NULL)
-  {
-    fprintf(stderr, "Error: could not create bgpstream_patricia_tree_result_set\n");
+  if ((set = malloc_zero(sizeof(bgpstream_patricia_tree_result_set_t))) ==
+      NULL) {
+    fprintf(stderr,
+            "Error: could not create bgpstream_patricia_tree_result_set\n");
     return NULL;
   }
 
   /* always have space for a single node  */
-  if(bgpstream_patricia_tree_result_set_add_node(set, NULL) != 0)
-    {
-      free(set);
-      return NULL;
-    }
+  if (bgpstream_patricia_tree_result_set_add_node(set, NULL) != 0) {
+    free(set);
+    return NULL;
+  }
 
   bgpstream_patricia_tree_result_set_clear(set);
   return set;
 }
 
-void bgpstream_patricia_tree_result_set_destroy(bgpstream_patricia_tree_result_set_t **set_p)
+void bgpstream_patricia_tree_result_set_destroy(
+  bgpstream_patricia_tree_result_set_t **set_p)
 {
   assert(set_p);
   bgpstream_patricia_tree_result_set_t *set = *set_p;
-  if(set != NULL)
-    {
-      free(set->result_nodes);
-      set->result_nodes=NULL;
-      set->n_recs=0;
-      set->_cursor=0;
-      set->_alloc_size=0;
-      free(set);
-      *set_p=NULL;
-    }
+  if (set != NULL) {
+    free(set->result_nodes);
+    set->result_nodes = NULL;
+    set->n_recs = 0;
+    set->_cursor = 0;
+    set->_alloc_size = 0;
+    free(set);
+    *set_p = NULL;
+  }
 }
 
-void bgpstream_patricia_tree_result_set_rewind(bgpstream_patricia_tree_result_set_t *set)
+void bgpstream_patricia_tree_result_set_rewind(
+  bgpstream_patricia_tree_result_set_t *set)
 {
   set->_cursor = 0;
 }
 
-bgpstream_patricia_node_t *bgpstream_patricia_tree_result_set_next(bgpstream_patricia_tree_result_set_t *set)
+bgpstream_patricia_node_t *bgpstream_patricia_tree_result_set_next(
+  bgpstream_patricia_tree_result_set_t *set)
 {
-  if(set->n_recs <= set->_cursor)
-    {
-      /* No more nodes */
-      return NULL;
-    }
+  if (set->n_recs <= set->_cursor) {
+    /* No more nodes */
+    return NULL;
+  }
   return set->result_nodes[set->_cursor++]; /* Advance head */
 }
 
-int bgpstream_patricia_tree_result_set_count(bgpstream_patricia_tree_result_set_t *set)
+int bgpstream_patricia_tree_result_set_count(
+  bgpstream_patricia_tree_result_set_t *set)
 {
   return set->n_recs;
 }
 
-void bgpstream_patricia_tree_result_set_print(bgpstream_patricia_tree_result_set_t *set)
+void bgpstream_patricia_tree_result_set_print(
+  bgpstream_patricia_tree_result_set_t *set)
 {
   bgpstream_patricia_tree_result_set_rewind(set);
   bgpstream_patricia_node_t *next;
   char buffer[1024];
-  while((next = bgpstream_patricia_tree_result_set_next(set)) != NULL)
-    {
-      bgpstream_pfx_snprintf(buffer, 1024, (bgpstream_pfx_t *) &next->prefix);
-      fprintf(stdout, "%s\n", buffer);
-    }
+  while ((next = bgpstream_patricia_tree_result_set_next(set)) != NULL) {
+    bgpstream_pfx_snprintf(buffer, 1024, (bgpstream_pfx_t *)&next->prefix);
+    fprintf(stdout, "%s\n", buffer);
+  }
 }
 
-
-bgpstream_patricia_tree_t *bgpstream_patricia_tree_create(bgpstream_patricia_tree_destroy_user_t *bspt_user_destructor)
+bgpstream_patricia_tree_t *bgpstream_patricia_tree_create(
+  bgpstream_patricia_tree_destroy_user_t *bspt_user_destructor)
 {
   bgpstream_patricia_tree_t *pt = NULL;
-  if((pt = malloc_zero(sizeof(bgpstream_patricia_tree_t))) == NULL)
-    {
-      return NULL;
-    }
+  if ((pt = malloc_zero(sizeof(bgpstream_patricia_tree_t))) == NULL) {
+    return NULL;
+  }
   pt->head4 = NULL;
   pt->head6 = NULL;
   pt->ipv4_active_nodes = 0;
@@ -563,8 +518,9 @@ bgpstream_patricia_tree_t *bgpstream_patricia_tree_create(bgpstream_patricia_tre
   return pt;
 }
 
-
-bgpstream_patricia_node_t *bgpstream_patricia_tree_insert(bgpstream_patricia_tree_t *pt, bgpstream_pfx_t *pfx)
+bgpstream_patricia_node_t *
+bgpstream_patricia_tree_insert(bgpstream_patricia_tree_t *pt,
+                               bgpstream_pfx_t *pfx)
 {
   assert(pt);
   assert(pfx);
@@ -578,18 +534,16 @@ bgpstream_patricia_node_t *bgpstream_patricia_tree_insert(bgpstream_patricia_tre
   bgpstream_addr_version_t v = pfx->address.version;
 
   /* if Patricia Tree is empty, then insert new node */
-  if(bgpstream_patricia_get_head(pt,v) == NULL)
-    {
-      if((new_node = bgpstream_patricia_node_create(pt, pfx)) == NULL)
-        {
-          fprintf(stderr, "Error creating pt node\n");
-          return NULL;
-        }
-      /* attach first node in Tree */
-      bgpstream_patricia_set_head(pt, v, new_node);
-      /* DEBUG       fprintf(stderr, "Adding %s to HEAD\n", buffer); */
-      return new_node;
+  if (bgpstream_patricia_get_head(pt, v) == NULL) {
+    if ((new_node = bgpstream_patricia_node_create(pt, pfx)) == NULL) {
+      fprintf(stderr, "Error creating pt node\n");
+      return NULL;
     }
+    /* attach first node in Tree */
+    bgpstream_patricia_set_head(pt, v, new_node);
+    /* DEBUG       fprintf(stderr, "Adding %s to HEAD\n", buffer); */
+    return new_node;
+  }
 
   /* Prepare data for Patricia Tree navigation */
 
@@ -603,71 +557,60 @@ bgpstream_patricia_node_t *bgpstream_patricia_tree_insert(bgpstream_patricia_tre
    * - the current node has the same mask length (or greater) and
    *   it contains a valid prefix (i.e. it is not a glue node)
    * */
-  while (node_it->bit < bitlen || node_it->prefix.address.version == BGPSTREAM_ADDR_VERSION_UNKNOWN)
-    {
-      if (node_it->bit < BGPSTREAM_PATRICIA_MAXBITS &&
-          BIT_TEST (addr[node_it->bit >> 3], 0x80 >> (node_it->bit & 0x07)))
-        {
-          /* no more nodes on the right, exit from loop */
-          if (node_it->r == NULL)
-            {
-              break;
-            }
-          /* patricia_lookup: take right at node->bit */
-          node_it = node_it->r;
-        }
-      else
-        {
-          /* no more nodes on the left, exit from loop */
-          if (node_it->l == NULL)
-            {
-              break;
-            }
-          /* patricia_lookup: take left at node->bit */
-          node_it = node_it->l;
-        }
-      assert (node_it);
+  while (node_it->bit < bitlen ||
+         node_it->prefix.address.version == BGPSTREAM_ADDR_VERSION_UNKNOWN) {
+    if (node_it->bit < BGPSTREAM_PATRICIA_MAXBITS &&
+        BIT_TEST(addr[node_it->bit >> 3], 0x80 >> (node_it->bit & 0x07))) {
+      /* no more nodes on the right, exit from loop */
+      if (node_it->r == NULL) {
+        break;
+      }
+      /* patricia_lookup: take right at node->bit */
+      node_it = node_it->r;
+    } else {
+      /* no more nodes on the left, exit from loop */
+      if (node_it->l == NULL) {
+        break;
+      }
+      /* patricia_lookup: take left at node->bit */
+      node_it = node_it->l;
     }
+    assert(node_it);
+  }
 
   /*  node_it->prefix is the prefix we stopped at */
-  unsigned char *test_addr = bgpstream_pfx_get_first_byte((bgpstream_pfx_t *) &node_it->prefix);
-
+  unsigned char *test_addr =
+    bgpstream_pfx_get_first_byte((bgpstream_pfx_t *)&node_it->prefix);
 
   /* find the first bit different */
   uint8_t check_bit;
   uint8_t differ_bit;
   int i, j, r;
-  check_bit = (node_it->bit < bitlen) ? node_it->bit: bitlen;
+  check_bit = (node_it->bit < bitlen) ? node_it->bit : bitlen;
   differ_bit = 0;
-  for (i = 0; i*8 < check_bit; i++)
-    {
-      if ((r = (addr[i] ^ test_addr[i])) == 0)
-        {
-          differ_bit = (i + 1) * 8;
-          continue;
-	}
-      /* I know the better way, but for now */
-      for (j = 0; j < 8; j++)
-        {
-          if (BIT_TEST (r, (0x80 >> j)))
-            {
-              break;
-            }
-	}
-      /* must be found */
-      assert (j < 8);
-      differ_bit = i * 8 + j;
-      break;
+  for (i = 0; i * 8 < check_bit; i++) {
+    if ((r = (addr[i] ^ test_addr[i])) == 0) {
+      differ_bit = (i + 1) * 8;
+      continue;
     }
+    /* I know the better way, but for now */
+    for (j = 0; j < 8; j++) {
+      if (BIT_TEST(r, (0x80 >> j))) {
+        break;
+      }
+    }
+    /* must be found */
+    assert(j < 8);
+    differ_bit = i * 8 + j;
+    break;
+  }
 
-  if (differ_bit > check_bit)
-    {
-      differ_bit = check_bit;
-    }
+  if (differ_bit > check_bit) {
+    differ_bit = check_bit;
+  }
 
   bgpstream_patricia_node_t *parent;
-  bgpstream_patricia_node_t  *glue_node;
-
+  bgpstream_patricia_node_t *glue_node;
 
   /* go back up till we find the right parent **I.E.??** */
   parent = node_it->parent;
@@ -676,319 +619,265 @@ bgpstream_patricia_node_t *bgpstream_patricia_tree_insert(bgpstream_patricia_tre
     parent = node_it->parent;
   }
 
-
-  if (differ_bit == bitlen && node_it->bit == bitlen)
-    {
-      /* check the node contains a valid prefix,
-       * i.e. it is not a glue node */
-      if (node_it->prefix.address.version != BGPSTREAM_ADDR_VERSION_UNKNOWN)
-        {
-          /* Exact node found */
-          /* DEBUG  fprintf(stderr, "Prefix %s already in tree\n", buffer); */
-          return node_it;
-        }
-      /* otherwise replace the info in the glue node with proper
-       * prefix information and increment the right counter*/
-      node_it->prefix = *((bgpstream_pfx_storage_t *) pfx);
-      if(pfx->address.version == BGPSTREAM_ADDR_VERSION_IPV4)
-        {
-          pt->ipv4_active_nodes++;
-        }
-      else
-        {
-          pt->ipv6_active_nodes++;
-        }
-
-      /* patricia_lookup: new node #1 (glue mod) */
-      /* DEBUG fprintf(stderr, "Using %s to replace a GLUE node\n", buffer); */
+  if (differ_bit == bitlen && node_it->bit == bitlen) {
+    /* check the node contains a valid prefix,
+     * i.e. it is not a glue node */
+    if (node_it->prefix.address.version != BGPSTREAM_ADDR_VERSION_UNKNOWN) {
+      /* Exact node found */
+      /* DEBUG  fprintf(stderr, "Prefix %s already in tree\n", buffer); */
       return node_it;
     }
+    /* otherwise replace the info in the glue node with proper
+     * prefix information and increment the right counter*/
+    node_it->prefix = *((bgpstream_pfx_storage_t *)pfx);
+    if (pfx->address.version == BGPSTREAM_ADDR_VERSION_IPV4) {
+      pt->ipv4_active_nodes++;
+    } else {
+      pt->ipv6_active_nodes++;
+    }
+
+    /* patricia_lookup: new node #1 (glue mod) */
+    /* DEBUG fprintf(stderr, "Using %s to replace a GLUE node\n", buffer); */
+    return node_it;
+  }
 
   /* Create a new node */
-  if((new_node = bgpstream_patricia_node_create(pt, pfx)) == NULL)
-    {
-      fprintf(stderr, "Error creating pt node\n");
-      return NULL;
-    }
+  if ((new_node = bgpstream_patricia_node_create(pt, pfx)) == NULL) {
+    fprintf(stderr, "Error creating pt node\n");
+    return NULL;
+  }
 
   /* Insert the new node in the Patricia Tree: CHILD */
-  if (node_it->bit == differ_bit)
-    {
-      /* appending the new node as a child of node_it */
-      new_node->parent = node_it;
-      if (node_it->bit < BGPSTREAM_PATRICIA_MAXBITS &&
-          BIT_TEST (addr[node_it->bit >> 3], 0x80 >> (node_it->bit & 0x07)))
-        {
-          assert (node_it->r == NULL);
-          node_it->r = new_node;
-	}
-      else
-        {
-          assert(node_it->l == NULL);
-          node_it->l = new_node;
-	}
-      /* patricia_lookup: new_node #2 (child) */
-      /* DEBUG  fprintf(stderr, "Adding %s as a CHILD node\n", buffer); */
-      return new_node;
+  if (node_it->bit == differ_bit) {
+    /* appending the new node as a child of node_it */
+    new_node->parent = node_it;
+    if (node_it->bit < BGPSTREAM_PATRICIA_MAXBITS &&
+        BIT_TEST(addr[node_it->bit >> 3], 0x80 >> (node_it->bit & 0x07))) {
+      assert(node_it->r == NULL);
+      node_it->r = new_node;
+    } else {
+      assert(node_it->l == NULL);
+      node_it->l = new_node;
     }
-
+    /* patricia_lookup: new_node #2 (child) */
+    /* DEBUG  fprintf(stderr, "Adding %s as a CHILD node\n", buffer); */
+    return new_node;
+  }
 
   /* Insert the new node in the Patricia Tree: PARENT */
-  if (bitlen == differ_bit)
-    {
-      /* attaching the new node as a parent of node_it */
-      if (bitlen < BGPSTREAM_PATRICIA_MAXBITS &&
-          BIT_TEST (test_addr[bitlen >> 3], 0x80 >> (bitlen & 0x07)))
-        {
-          new_node->r = node_it;
-	}
-      else
-        {
-          new_node->l = node_it;
-	}
-      new_node->parent = node_it->parent;
-      if (node_it->parent == NULL)
-        {
-          assert(bgpstream_patricia_get_head(pt, v) == node_it);
-          bgpstream_patricia_set_head(pt, v, new_node);
-	}
-      else
-        {
-          if (node_it->parent->r == node_it)
-            {
-              node_it->parent->r = new_node;
-            }
-          else
-            {
-              node_it->parent->l = new_node;
-            }
-        }
-      node_it->parent = new_node;
-      /* patricia_lookup: new_node #3 (parent) */
-      /* DEBUG fprintf(stderr, "Adding %s as a PARENT node\n", buffer); */
-      return new_node;
+  if (bitlen == differ_bit) {
+    /* attaching the new node as a parent of node_it */
+    if (bitlen < BGPSTREAM_PATRICIA_MAXBITS &&
+        BIT_TEST(test_addr[bitlen >> 3], 0x80 >> (bitlen & 0x07))) {
+      new_node->r = node_it;
+    } else {
+      new_node->l = node_it;
     }
-  else
-    {
-      /* Insert the new node in the Patricia Tree: CREATE A GLUE NODE AND APPEND TO IT*/
-
-      glue_node = bgpstream_patricia_gluenode_create();
-
-      glue_node->bit = differ_bit;
-      glue_node->parent = node_it->parent;
-
-      if (differ_bit < BGPSTREAM_PATRICIA_MAXBITS &&
-          BIT_TEST (addr[differ_bit >> 3], 0x80 >> (differ_bit & 0x07)))
-        {
-          glue_node->r = new_node;
-          glue_node->l = node_it;
-	}
-      else
-        {
-          glue_node->r = node_it;
-          glue_node->l = new_node;
-        }
-      new_node->parent = glue_node;
-
-      if (node_it->parent == NULL)
-        {
-          assert(bgpstream_patricia_get_head(pt, v) == node_it);
-          bgpstream_patricia_set_head(pt, v, glue_node);
-	}
-      else
-        {
-          if (node_it->parent->r == node_it)
-            {
-              node_it->parent->r = glue_node;
-            }
-          else {
-	    node_it->parent->l = glue_node;
-          }
-        }
-      node_it->parent = glue_node;
-      /* "patricia_lookup: new_node #4 (glue+node) */
-      /* DEBUG fprintf(stderr, "Adding %s as a CHILD of a NEW GLUE node\n", buffer); */
-      return new_node;
+    new_node->parent = node_it->parent;
+    if (node_it->parent == NULL) {
+      assert(bgpstream_patricia_get_head(pt, v) == node_it);
+      bgpstream_patricia_set_head(pt, v, new_node);
+    } else {
+      if (node_it->parent->r == node_it) {
+        node_it->parent->r = new_node;
+      } else {
+        node_it->parent->l = new_node;
+      }
     }
+    node_it->parent = new_node;
+    /* patricia_lookup: new_node #3 (parent) */
+    /* DEBUG fprintf(stderr, "Adding %s as a PARENT node\n", buffer); */
+    return new_node;
+  } else {
+    /* Insert the new node in the Patricia Tree: CREATE A GLUE NODE AND APPEND
+     * TO IT*/
+
+    glue_node = bgpstream_patricia_gluenode_create();
+
+    glue_node->bit = differ_bit;
+    glue_node->parent = node_it->parent;
+
+    if (differ_bit < BGPSTREAM_PATRICIA_MAXBITS &&
+        BIT_TEST(addr[differ_bit >> 3], 0x80 >> (differ_bit & 0x07))) {
+      glue_node->r = new_node;
+      glue_node->l = node_it;
+    } else {
+      glue_node->r = node_it;
+      glue_node->l = new_node;
+    }
+    new_node->parent = glue_node;
+
+    if (node_it->parent == NULL) {
+      assert(bgpstream_patricia_get_head(pt, v) == node_it);
+      bgpstream_patricia_set_head(pt, v, glue_node);
+    } else {
+      if (node_it->parent->r == node_it) {
+        node_it->parent->r = glue_node;
+      } else {
+        node_it->parent->l = glue_node;
+      }
+    }
+    node_it->parent = glue_node;
+    /* "patricia_lookup: new_node #4 (glue+node) */
+    /* DEBUG fprintf(stderr, "Adding %s as a CHILD of a NEW GLUE node\n",
+     * buffer); */
+    return new_node;
+  }
 
   /* DEBUG   fprintf(stderr, "Adding %s as a ??\n", buffer); */
   return new_node;
 }
-
 
 void *bgpstream_patricia_tree_get_user(bgpstream_patricia_node_t *node)
 {
   return node->user;
 }
 
-
 int bgpstream_patricia_tree_set_user(bgpstream_patricia_tree_t *pt,
-                                     bgpstream_patricia_node_t *node, void *user)
+                                     bgpstream_patricia_node_t *node,
+                                     void *user)
 {
-  if(node->user == user)
-    {
-      return 0;
-    }
-  if(node->user != NULL && pt->node_user_destructor != NULL)
-    {
-      pt->node_user_destructor(node->user);
-    }
+  if (node->user == user) {
+    return 0;
+  }
+  if (node->user != NULL && pt->node_user_destructor != NULL) {
+    pt->node_user_destructor(node->user);
+  }
   node->user = user;
   return 1;
-
 }
 
-
-uint8_t bgpstream_patricia_tree_get_pfx_overlap_info(bgpstream_patricia_tree_t *pt,
-                                                     bgpstream_pfx_t *pfx)
+uint8_t
+bgpstream_patricia_tree_get_pfx_overlap_info(bgpstream_patricia_tree_t *pt,
+                                             bgpstream_pfx_t *pfx)
 {
 
   bgpstream_patricia_node_t *n = bgpstream_patricia_tree_search_exact(pt, pfx);
-  if(n != NULL)
-    {
-      return bgpstream_patricia_tree_get_node_overlap_info(pt, n) | BGPSTREAM_PATRICIA_EXACT_MATCH;
-    }
-  else
-    {
-      /* we basically simulate an insertion, to understand whether the prefix
-       * would overlap or not */
-      n = bgpstream_patricia_tree_insert(pt, pfx);
-      uint8_t mask = bgpstream_patricia_tree_get_node_overlap_info(pt, n);
-      bgpstream_patricia_tree_remove_node(pt, n);
-      return mask & (~BGPSTREAM_PATRICIA_EXACT_MATCH);
-    }
+  if (n != NULL) {
+    return bgpstream_patricia_tree_get_node_overlap_info(pt, n) |
+           BGPSTREAM_PATRICIA_EXACT_MATCH;
+  } else {
+    /* we basically simulate an insertion, to understand whether the prefix
+     * would overlap or not */
+    n = bgpstream_patricia_tree_insert(pt, pfx);
+    uint8_t mask = bgpstream_patricia_tree_get_node_overlap_info(pt, n);
+    bgpstream_patricia_tree_remove_node(pt, n);
+    return mask & (~BGPSTREAM_PATRICIA_EXACT_MATCH);
+  }
   return 0;
 }
 
-
-void bgpstream_patricia_tree_remove(bgpstream_patricia_tree_t *pt, bgpstream_pfx_t *pfx)
+void bgpstream_patricia_tree_remove(bgpstream_patricia_tree_t *pt,
+                                    bgpstream_pfx_t *pfx)
 {
-  bgpstream_patricia_tree_remove_node(pt, bgpstream_patricia_tree_search_exact(pt, pfx));
+  bgpstream_patricia_tree_remove_node(
+    pt, bgpstream_patricia_tree_search_exact(pt, pfx));
 }
 
-
-void bgpstream_patricia_tree_remove_node(bgpstream_patricia_tree_t *pt, bgpstream_patricia_node_t *node)
+void bgpstream_patricia_tree_remove_node(bgpstream_patricia_tree_t *pt,
+                                         bgpstream_patricia_node_t *node)
 {
   assert(pt);
-  if(node == NULL)
-    {
-      return;
-    }
+  if (node == NULL) {
+    return;
+  }
 
   bgpstream_addr_version_t v = node->prefix.address.version;
   bgpstream_patricia_node_t *parent;
   bgpstream_patricia_node_t *child;
 
-  uint64_t *num_active_node = &pt->ipv4_active_nodes;;
-  if(node->prefix.address.version == BGPSTREAM_ADDR_VERSION_IPV6)
-    {
-      num_active_node = &pt->ipv6_active_nodes;
-    }
+  uint64_t *num_active_node = &pt->ipv4_active_nodes;
+  ;
+  if (node->prefix.address.version == BGPSTREAM_ADDR_VERSION_IPV6) {
+    num_active_node = &pt->ipv6_active_nodes;
+  }
 
   /* we do not allow for explicit removal of glue nodes */
-  if(v == BGPSTREAM_ADDR_VERSION_UNKNOWN)
-    {
-      return;
-    }
+  if (v == BGPSTREAM_ADDR_VERSION_UNKNOWN) {
+    return;
+  }
 
-  if(node->user != NULL)
-    {
-      if(pt->node_user_destructor != NULL)
-        {
-          pt->node_user_destructor(node->user);
-        }
-      node->user = NULL;
+  if (node->user != NULL) {
+    if (pt->node_user_destructor != NULL) {
+      pt->node_user_destructor(node->user);
     }
+    node->user = NULL;
+  }
 
   /* if node has both children */
-  if(node->r != NULL && node->l != NULL)
-    {
-      /* if it is a glue node, there is nothing to remove,
-       * if it is node with a valid prefix, then it becomes a glue node
-       */
-      if(node->prefix.address.version != BGPSTREAM_ADDR_VERSION_UNKNOWN)
-        {
-          node->prefix.address.version = BGPSTREAM_ADDR_VERSION_UNKNOWN;
-        }
-      /* node data remains, unless we decide to pass a destroy function somewehere */
-      /* node->user = NULL; */
-      /* DEBUG fprintf(stderr, "Removing node with both children\n"); */
+  if (node->r != NULL && node->l != NULL) {
+    /* if it is a glue node, there is nothing to remove,
+     * if it is node with a valid prefix, then it becomes a glue node
+     */
+    if (node->prefix.address.version != BGPSTREAM_ADDR_VERSION_UNKNOWN) {
+      node->prefix.address.version = BGPSTREAM_ADDR_VERSION_UNKNOWN;
+    }
+    /* node data remains, unless we decide to pass a destroy function somewehere
+     */
+    /* node->user = NULL; */
+    /* DEBUG fprintf(stderr, "Removing node with both children\n"); */
+    return;
+  }
+
+  /* if node has no children */
+  if (node->r == NULL && node->l == NULL) {
+    parent = node->parent;
+    free(node);
+    (*num_active_node) = (*num_active_node) - 1;
+
+    /* removing head of tree */
+    if (parent == NULL) {
+      assert(node == bgpstream_patricia_get_head(pt, v));
+      bgpstream_patricia_set_head(pt, v, NULL);
+      /* DEBUG fprintf(stderr, "Removing head (that had no children)\n"); */
       return;
     }
 
-  /* if node has no children */
-  if (node->r == NULL && node->l == NULL)
-     {
-       parent = node->parent;
-       free(node);
-       (*num_active_node) = (*num_active_node) - 1;
-
-       /* removing head of tree */
-       if (parent == NULL)
-         {
-           assert(node == bgpstream_patricia_get_head(pt, v));
-           bgpstream_patricia_set_head(pt, v, NULL);
-           /* DEBUG fprintf(stderr, "Removing head (that had no children)\n"); */
-           return;
-         }
-
-       /* check if the node was the right or the left child */
-       if (parent->r == node)
-         {
-           parent->r = NULL;
-           child = parent->l;
-         }
-       else
-         {
-           assert (parent->l == node);
-           parent->l = NULL;
-           child = parent->r;
-         }
-
-       /* if the current parent was a valid prefix, return */
-	if (parent->prefix.address.version != BGPSTREAM_ADDR_VERSION_UNKNOWN)
-          {
-            /* DEBUG fprintf(stderr, "Removing node with no children\n"); */
-	    return;
-          }
-
-	/* otherwise it makes no sense to have a glue node
-         * with only one child, the parent has to be removed */
-
-	if (parent->parent == NULL)
-          { /* if the parent parent is the head, then attach
-             * the only child directly */
-            assert(parent == bgpstream_patricia_get_head(pt, v));
-            bgpstream_patricia_set_head(pt, v, child);
-          }
-	else
-          {
-            if (parent->parent->r == parent)
-              { /* if the parent is a right child */
-                parent->parent->r = child;
-              }
-            else
-              { /* if the parent is a left child */
-                assert (parent->parent->l == parent);
-                parent->parent->l = child;
-              }
-	}
-        /* the child parent, is now the grand-parent */
-	child->parent = parent->parent;
-        free(parent);
-	return;
+    /* check if the node was the right or the left child */
+    if (parent->r == node) {
+      parent->r = NULL;
+      child = parent->l;
+    } else {
+      assert(parent->l == node);
+      parent->l = NULL;
+      child = parent->r;
     }
+
+    /* if the current parent was a valid prefix, return */
+    if (parent->prefix.address.version != BGPSTREAM_ADDR_VERSION_UNKNOWN) {
+      /* DEBUG fprintf(stderr, "Removing node with no children\n"); */
+      return;
+    }
+
+    /* otherwise it makes no sense to have a glue node
+     * with only one child, the parent has to be removed */
+
+    if (parent->parent ==
+        NULL) { /* if the parent parent is the head, then attach
+                 * the only child directly */
+      assert(parent == bgpstream_patricia_get_head(pt, v));
+      bgpstream_patricia_set_head(pt, v, child);
+    } else {
+      if (parent->parent->r == parent) { /* if the parent is a right child */
+        parent->parent->r = child;
+      } else { /* if the parent is a left child */
+        assert(parent->parent->l == parent);
+        parent->parent->l = child;
+      }
+    }
+    /* the child parent, is now the grand-parent */
+    child->parent = parent->parent;
+    free(parent);
+    return;
+  }
 
   /* if node has only one child */
-  if (node->r)
-    {
-      child = node->r;
-    }
-  else
-    {
-      assert (node->l);
-      child = node->l;
-    }
+  if (node->r) {
+    child = node->r;
+  } else {
+    assert(node->l);
+    child = node->l;
+  }
   /* the child parent, is now the grand-parent */
   parent = node->parent;
   child->parent = parent;
@@ -996,32 +885,25 @@ void bgpstream_patricia_tree_remove_node(bgpstream_patricia_tree_t *pt, bgpstrea
   free(node);
   (*num_active_node) = (*num_active_node) - 1;
 
-  if (parent == NULL)
-    { /* if the parent is the head, then attach
-       * the only child directly */
-      assert(node == bgpstream_patricia_get_head(pt, v));
-      bgpstream_patricia_set_head(pt, v, child);
-      return;
+  if (parent == NULL) { /* if the parent is the head, then attach
+                         * the only child directly */
+    assert(node == bgpstream_patricia_get_head(pt, v));
+    bgpstream_patricia_set_head(pt, v, child);
+    return;
+  } else {
+    /* attach child node to the correct parent child pointer */
+    if (parent->r == node) { /* if node was a right child */
+      parent->r = child;
+    } else { /* if node was a left child */
+      assert(parent->l == node);
+      parent->l = child;
     }
-  else
-    {
-      /* attach child node to the correct parent child pointer */
-      if(parent->r == node)
-        { /* if node was a right child */
-          parent->r = child;
-        }
-      else
-        { /* if node was a left child */
-          assert(parent->l == node);
-          parent->l = child;
-        }
-    }
-
+  }
 }
 
-
-bgpstream_patricia_node_t *bgpstream_patricia_tree_search_exact(bgpstream_patricia_tree_t *pt,
-                                                                bgpstream_pfx_t *pfx)
+bgpstream_patricia_node_t *
+bgpstream_patricia_tree_search_exact(bgpstream_patricia_tree_t *pt,
+                                     bgpstream_pfx_t *pfx)
 {
   assert(pt);
   assert(pfx);
@@ -1031,193 +913,168 @@ bgpstream_patricia_node_t *bgpstream_patricia_tree_search_exact(bgpstream_patric
   bgpstream_addr_version_t v = pfx->address.version;
 
   /* if Patricia Tree is empty*/
-  if(bgpstream_patricia_get_head(pt,v) == NULL)
-    {
-      return NULL;
-    }
+  if (bgpstream_patricia_get_head(pt, v) == NULL) {
+    return NULL;
+  }
 
   bgpstream_patricia_node_t *node_it = bgpstream_patricia_get_head(pt, v);
   uint8_t bitlen = pfx->mask_len;
   unsigned char *addr = bgpstream_pfx_get_first_byte(pfx);
 
-  while (node_it->bit < bitlen)
-    {
-      if( BIT_TEST (addr[node_it->bit >> 3], 0x80 >> (node_it->bit & 0x07)))
-        {
-          /* patricia_lookup: take right at node->bit */
-          node_it = node_it->r;
-        }
-      else
-        {
-          /* patricia_lookup: take left at node->bit */
-          node_it = node_it->l;
-        }
-      	if (node_it == NULL)
-          {
-            return NULL;
-          }
+  while (node_it->bit < bitlen) {
+    if (BIT_TEST(addr[node_it->bit >> 3], 0x80 >> (node_it->bit & 0x07))) {
+      /* patricia_lookup: take right at node->bit */
+      node_it = node_it->r;
+    } else {
+      /* patricia_lookup: take left at node->bit */
+      node_it = node_it->l;
     }
+    if (node_it == NULL) {
+      return NULL;
+    }
+  }
 
   /* if we passed the right mask, or if we stopped at a glue node, then
    * no exact match found */
-  if (node_it->bit > bitlen || node_it->prefix.address.version == BGPSTREAM_ADDR_VERSION_UNKNOWN)
-    {
-      return NULL;
-    }
+  if (node_it->bit > bitlen ||
+      node_it->prefix.address.version == BGPSTREAM_ADDR_VERSION_UNKNOWN) {
+    return NULL;
+  }
 
-  assert (node_it->bit == bitlen);
+  assert(node_it->bit == bitlen);
   /* compare the prefixes bit by bit
    * TODO: consider replacing with bgpstream_pfx_storage_equal */
-  if (comp_with_mask(bgpstream_pfx_get_first_byte((bgpstream_pfx_t *) &node_it->prefix),
-                     bgpstream_pfx_get_first_byte(pfx), bitlen))
-    {
-      /* exact match found */
-      return node_it;
-    }
+  if (comp_with_mask(
+        bgpstream_pfx_get_first_byte((bgpstream_pfx_t *)&node_it->prefix),
+        bgpstream_pfx_get_first_byte(pfx), bitlen)) {
+    /* exact match found */
+    return node_it;
+  }
   return NULL;
 }
-
 
 uint64_t bgpstream_patricia_prefix_count(bgpstream_patricia_tree_t *pt,
                                          bgpstream_addr_version_t v)
 {
-  switch(v)
-    {
-    case BGPSTREAM_ADDR_VERSION_IPV4:
-      return pt->ipv4_active_nodes;
-    case BGPSTREAM_ADDR_VERSION_IPV6:
-      return pt->ipv6_active_nodes;
-    default:
-      return 0;
-    }
+  switch (v) {
+  case BGPSTREAM_ADDR_VERSION_IPV4:
+    return pt->ipv4_active_nodes;
+  case BGPSTREAM_ADDR_VERSION_IPV6:
+    return pt->ipv6_active_nodes;
+  default:
+    return 0;
+  }
   return 0;
 }
-
 
 uint64_t bgpstream_patricia_tree_count_24subnets(bgpstream_patricia_tree_t *pt)
 {
   return bgpstream_patricia_tree_count_subnets(pt->head4, 24);
 }
 
-
 uint64_t bgpstream_patricia_tree_count_64subnets(bgpstream_patricia_tree_t *pt)
 {
   return bgpstream_patricia_tree_count_subnets(pt->head6, 64);
 }
 
-
-int bgpstream_patricia_tree_get_more_specifics(bgpstream_patricia_tree_t *pt,
-                                               bgpstream_patricia_node_t *node,
-                                               bgpstream_patricia_tree_result_set_t *results)
+int bgpstream_patricia_tree_get_more_specifics(
+  bgpstream_patricia_tree_t *pt, bgpstream_patricia_node_t *node,
+  bgpstream_patricia_tree_result_set_t *results)
 {
   bgpstream_patricia_tree_result_set_clear(results);
 
-  if(node != NULL)
-    { /* we do not return the node itself */
-      if(bgpstream_patricia_tree_add_more_specifics(results, node->l, BGPSTREAM_PATRICIA_MAXBITS+1) != 0)
-        {
-          return -1;
-        }
-      if(bgpstream_patricia_tree_add_more_specifics(results, node->r, BGPSTREAM_PATRICIA_MAXBITS+1) != 0)
-        {
-          return -1;
-        }
+  if (node != NULL) { /* we do not return the node itself */
+    if (bgpstream_patricia_tree_add_more_specifics(
+          results, node->l, BGPSTREAM_PATRICIA_MAXBITS + 1) != 0) {
+      return -1;
     }
+    if (bgpstream_patricia_tree_add_more_specifics(
+          results, node->r, BGPSTREAM_PATRICIA_MAXBITS + 1) != 0) {
+      return -1;
+    }
+  }
   return 0;
 }
 
-
-int bgpstream_patricia_tree_get_mincovering_prefix(bgpstream_patricia_tree_t *pt,
-                                                   bgpstream_patricia_node_t *node,
-                                                   bgpstream_patricia_tree_result_set_t *results)
+int bgpstream_patricia_tree_get_mincovering_prefix(
+  bgpstream_patricia_tree_t *pt, bgpstream_patricia_node_t *node,
+  bgpstream_patricia_tree_result_set_t *results)
 {
   bgpstream_patricia_tree_result_set_clear(results);
 
-  if(node == NULL)
-    {
-      return 0;
-    }
+  if (node == NULL) {
+    return 0;
+  }
   /* we do not return the node itself (that's why we pass the parent node) */
   return bgpstream_patricia_tree_add_less_specifics(results, node->parent, 1);
 }
 
-int bgpstream_patricia_tree_get_less_specifics(bgpstream_patricia_tree_t *pt,
-                                               bgpstream_patricia_node_t *node,
-                                               bgpstream_patricia_tree_result_set_t *results)
+int bgpstream_patricia_tree_get_less_specifics(
+  bgpstream_patricia_tree_t *pt, bgpstream_patricia_node_t *node,
+  bgpstream_patricia_tree_result_set_t *results)
 {
   bgpstream_patricia_tree_result_set_clear(results);
 
-  if(node == NULL)
-    {
-      return 0;
-    }
+  if (node == NULL) {
+    return 0;
+  }
   /* we do not return the node itself (that's why we pass the parent node) */
-  return bgpstream_patricia_tree_add_less_specifics(results, node->parent, BGPSTREAM_PATRICIA_MAXBITS+1);
+  return bgpstream_patricia_tree_add_less_specifics(
+    results, node->parent, BGPSTREAM_PATRICIA_MAXBITS + 1);
 }
 
-
-int bgpstream_patricia_tree_get_minimum_coverage(bgpstream_patricia_tree_t *pt,
-                                                 bgpstream_addr_version_t v,
-                                                 bgpstream_patricia_tree_result_set_t *results)
+int bgpstream_patricia_tree_get_minimum_coverage(
+  bgpstream_patricia_tree_t *pt, bgpstream_addr_version_t v,
+  bgpstream_patricia_tree_result_set_t *results)
 {
   bgpstream_patricia_tree_result_set_clear(results);
-  bgpstream_patricia_node_t *head = bgpstream_patricia_get_head(pt,v);
+  bgpstream_patricia_node_t *head = bgpstream_patricia_get_head(pt, v);
   /* we stop at the first layer, hence depth = 1 */
   return bgpstream_patricia_tree_add_more_specifics(results, head, 1);
 }
 
-
-uint8_t bgpstream_patricia_tree_get_node_overlap_info(bgpstream_patricia_tree_t *pt,
-                                                      bgpstream_patricia_node_t *node)
+uint8_t
+bgpstream_patricia_tree_get_node_overlap_info(bgpstream_patricia_tree_t *pt,
+                                              bgpstream_patricia_node_t *node)
 {
   uint8_t mask = BGPSTREAM_PATRICIA_EXACT_MATCH;
 
   bgpstream_patricia_node_t *node_it = node->parent;
-  while(node_it != NULL)
-    {
-      if(node_it->prefix.address.version != BGPSTREAM_ADDR_VERSION_UNKNOWN)
-        {
-          /* one more specific found */
-          mask = mask | BGPSTREAM_PATRICIA_LESS_SPECIFICS;
-          break;
-        }
-      node_it = node_it->parent;
+  while (node_it != NULL) {
+    if (node_it->prefix.address.version != BGPSTREAM_ADDR_VERSION_UNKNOWN) {
+      /* one more specific found */
+      mask = mask | BGPSTREAM_PATRICIA_LESS_SPECIFICS;
+      break;
     }
+    node_it = node_it->parent;
+  }
 
   node_it = node;
-  if(node_it != NULL)
-    { /* we do not consider the node itself */
-      /* if one of the subtree return 1 we can avoid the other */
-      if(bgpstream_patricia_tree_find_more_specific(node->l) == 1)
-        {
-          mask = mask | BGPSTREAM_PATRICIA_MORE_SPECIFICS;
-        }
-      else
-        {
-          if(bgpstream_patricia_tree_find_more_specific(node->r) == 1)
-            {
-              mask = mask | BGPSTREAM_PATRICIA_MORE_SPECIFICS;
-            }
-        }
+  if (node_it != NULL) { /* we do not consider the node itself */
+    /* if one of the subtree return 1 we can avoid the other */
+    if (bgpstream_patricia_tree_find_more_specific(node->l) == 1) {
+      mask = mask | BGPSTREAM_PATRICIA_MORE_SPECIFICS;
+    } else {
+      if (bgpstream_patricia_tree_find_more_specific(node->r) == 1) {
+        mask = mask | BGPSTREAM_PATRICIA_MORE_SPECIFICS;
+      }
     }
+  }
   return mask;
 }
 
-
-void bgpstream_patricia_tree_merge(bgpstream_patricia_tree_t *dst, const bgpstream_patricia_tree_t *src)
+void bgpstream_patricia_tree_merge(bgpstream_patricia_tree_t *dst,
+                                   const bgpstream_patricia_tree_t *src)
 {
   assert(dst);
-  if(src == NULL)
-    {
-      return;
-    }
+  if (src == NULL) {
+    return;
+  }
   /* Merge IPv4 */
   bgpstream_patricia_tree_merge_tree(dst, src->head4);
   /* Merge IPv6 */
   bgpstream_patricia_tree_merge_tree(dst, src->head6);
 }
-
-
 
 void bgpstream_patricia_tree_walk(bgpstream_patricia_tree_t *pt,
                                   bgpstream_patricia_tree_process_node_t *fun,
@@ -1227,25 +1084,21 @@ void bgpstream_patricia_tree_walk(bgpstream_patricia_tree_t *pt,
   bgpstream_patricia_tree_walk_tree(pt, pt->head6, fun, data);
 }
 
-
 void bgpstream_patricia_tree_print(bgpstream_patricia_tree_t *pt)
 {
   bgpstream_patricia_tree_print_tree(pt->head4);
   bgpstream_patricia_tree_print_tree(pt->head6);
 }
 
-
-bgpstream_pfx_t *bgpstream_patricia_tree_get_pfx(bgpstream_patricia_node_t *node)
+bgpstream_pfx_t *
+bgpstream_patricia_tree_get_pfx(bgpstream_patricia_node_t *node)
 {
   assert(node);
-  if(node->prefix.address.version != BGPSTREAM_ADDR_VERSION_UNKNOWN)
-    {
-      return (bgpstream_pfx_t *) &node->prefix;
-    }
+  if (node->prefix.address.version != BGPSTREAM_ADDR_VERSION_UNKNOWN) {
+    return (bgpstream_pfx_t *)&node->prefix;
+  }
   return NULL;
 }
-
-
 
 void bgpstream_patricia_tree_clear(bgpstream_patricia_tree_t *pt)
 {
@@ -1260,12 +1113,10 @@ void bgpstream_patricia_tree_clear(bgpstream_patricia_tree_t *pt)
   pt->head6 = NULL;
 }
 
-
 void bgpstream_patricia_tree_destroy(bgpstream_patricia_tree_t *pt)
 {
-  if(pt != NULL)
-    {
-      bgpstream_patricia_tree_clear(pt);
-      free(pt);
-    }
+  if (pt != NULL) {
+    bgpstream_patricia_tree_clear(pt);
+    free(pt);
+  }
 }

--- a/lib/utils/bgpstream_utils_patricia.h
+++ b/lib/utils/bgpstream_utils_patricia.h
@@ -35,35 +35,30 @@
  * "demo.c" so that it could be used as a standalone API.
  */
 
-
-
 #ifndef __BGPSTREAM_UTILS_PATRICIA_H
 #define __BGPSTREAM_UTILS_PATRICIA_H
 
-#include <limits.h>
-#include <stdlib.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
 #include <arpa/inet.h>
+#include <limits.h>
+#include <netinet/in.h>
+#include <stdlib.h>
+#include <sys/socket.h>
 
 #include "bgpstream_utils_pfx.h"
 
-
 /** @file
  *
- * @brief Header file that exposes the public interface of BGP Stream Patricia Tree
+ * @brief Header file that exposes the public interface of BGP Stream Patricia
+ * Tree
  * objects
  *
  * @author Chiara Orsini
  *
  */
 
-
 #define BGPSTREAM_PATRICIA_LESS_SPECIFICS 0b0100
-#define BGPSTREAM_PATRICIA_EXACT_MATCH    0b0010
+#define BGPSTREAM_PATRICIA_EXACT_MATCH 0b0010
 #define BGPSTREAM_PATRICIA_MORE_SPECIFICS 0b0001
-
-
 
 /**
  * @name Opaque Data Structures
@@ -77,10 +72,10 @@ typedef struct bgpstream_patricia_node bgpstream_patricia_node_t;
 typedef struct bgpstream_patricia_tree bgpstream_patricia_tree_t;
 
 /** Opaque structure containing a Patricia Tree results set */
-typedef struct bgpstream_patricia_tree_result_set bgpstream_patricia_tree_result_set_t;
+typedef struct bgpstream_patricia_tree_result_set
+  bgpstream_patricia_tree_result_set_t;
 
 /** @} */
-
 
 /**
  * @name Public Data Structures
@@ -91,7 +86,7 @@ typedef struct bgpstream_patricia_tree_result_set bgpstream_patricia_tree_result
  *  patricia tree node
  * @param user    user pointer to destroy
  */
-typedef void (bgpstream_patricia_tree_destroy_user_t) (void* user);
+typedef void(bgpstream_patricia_tree_destroy_user_t)(void *user);
 
 /** Callback for custom processing of the bgpstream_patricia_node structures
  *  when traversing a patricia tree
@@ -100,9 +95,8 @@ typedef void (bgpstream_patricia_tree_destroy_user_t) (void* user);
  * @param data    user pointer to a data structure that can be used by the
  *                user to store a state
  */
-typedef void (bgpstream_patricia_tree_process_node_t) (bgpstream_patricia_tree_t *pt,
-                                                       bgpstream_patricia_node_t * node,
-                                                       void* data);
+typedef void(bgpstream_patricia_tree_process_node_t)(
+  bgpstream_patricia_tree_t *pt, bgpstream_patricia_node_t *node, void *data);
 
 /** @} */
 
@@ -111,68 +105,71 @@ typedef void (bgpstream_patricia_tree_process_node_t) (bgpstream_patricia_tree_t
  *
  * @{ */
 
-
 /** Initialize a new result set instance
  *
  * @return the result set instance created, NULL if an error occurs
  */
-bgpstream_patricia_tree_result_set_t *bgpstream_patricia_tree_result_set_create();
-
+bgpstream_patricia_tree_result_set_t *
+bgpstream_patricia_tree_result_set_create();
 
 /** Free a result set instance
  *
  * @param this_p        The pointer to the result set instance to free
  */
-void bgpstream_patricia_tree_result_set_destroy(bgpstream_patricia_tree_result_set_t **set_p);
-
+void bgpstream_patricia_tree_result_set_destroy(
+  bgpstream_patricia_tree_result_set_t **set_p);
 
 /** Move the result set iterator pointer to the the beginning
  *  (so that next returns the first element)
  *
  * @param this          The result set instance
  */
-void bgpstream_patricia_tree_result_set_rewind(bgpstream_patricia_tree_result_set_t *set);
-
+void bgpstream_patricia_tree_result_set_rewind(
+  bgpstream_patricia_tree_result_set_t *set);
 
 /** Get the next result in the result set iterator
  *
  * @param this          The result set instance
  * @return a pointer to the result
  */
-bgpstream_patricia_node_t *bgpstream_patricia_tree_result_set_next(bgpstream_patricia_tree_result_set_t *set);
+bgpstream_patricia_node_t *bgpstream_patricia_tree_result_set_next(
+  bgpstream_patricia_tree_result_set_t *set);
 
 /** Count the number of results in the list
  *
  * @param result      pointer to the patricia tree result list to print
  * @return the number of nodes in the result set
  */
-int bgpstream_patricia_tree_result_set_count(bgpstream_patricia_tree_result_set_t *set);
-
+int bgpstream_patricia_tree_result_set_count(
+  bgpstream_patricia_tree_result_set_t *set);
 
 /** Print the result list
  *
  * @param result      pointer to the patricia tree result list to print
  */
-void bgpstream_patricia_tree_result_set_print(bgpstream_patricia_tree_result_set_t *set);
-
+void bgpstream_patricia_tree_result_set_print(
+  bgpstream_patricia_tree_result_set_t *set);
 
 /** Create a new Patricia Tree instance
  *
- * @param bspt_user_destructor          a function that destroys the user structure
+ * @param bspt_user_destructor          a function that destroys the user
+ * structure
  *                                      in the Patricia Tree Node structure
  * @return a pointer to the structure, or NULL if an error occurred
  */
-bgpstream_patricia_tree_t *bgpstream_patricia_tree_create(bgpstream_patricia_tree_destroy_user_t *bspt_user_destructor);
-
+bgpstream_patricia_tree_t *bgpstream_patricia_tree_create(
+  bgpstream_patricia_tree_destroy_user_t *bspt_user_destructor);
 
 /** Insert a new prefix, if it does not exist
  *
  * @param pt           pointer to the patricia tree to lookup in
  * @param pfx          pointer to the prefix to insert
- * @return a pointer to the prefix in the Patricia Tree, or NULL if an error occurred
+ * @return a pointer to the prefix in the Patricia Tree, or NULL if an error
+ * occurred
  */
-bgpstream_patricia_node_t *bgpstream_patricia_tree_insert(bgpstream_patricia_tree_t *pt, bgpstream_pfx_t *pfx);
-
+bgpstream_patricia_node_t *
+bgpstream_patricia_tree_insert(bgpstream_patricia_tree_t *pt,
+                               bgpstream_pfx_t *pfx);
 
 /** Get the user pointer associated with the node
  *
@@ -180,7 +177,6 @@ bgpstream_patricia_node_t *bgpstream_patricia_tree_insert(bgpstream_patricia_tre
  * @return the user pointer associated with the node
  */
 void *bgpstream_patricia_tree_get_user(bgpstream_patricia_node_t *node);
-
 
 /** Set the user pointer associated with the node
  *
@@ -190,41 +186,44 @@ void *bgpstream_patricia_tree_get_user(bgpstream_patricia_node_t *node);
  * @return 1 if a new user pointer is set, 0 if the user pointer was already
  *         set to the address provided.
  */
-int bgpstream_patricia_tree_set_user(bgpstream_patricia_tree_t *pt, bgpstream_patricia_node_t *node, void *user);
-
+int bgpstream_patricia_tree_set_user(bgpstream_patricia_tree_t *pt,
+                                     bgpstream_patricia_node_t *node,
+                                     void *user);
 
 /** Merge the information of two Patricia Trees
  *
  * @param dst        pointer to the patricia tree to modify
  * @param src        pointer to the patricia tree to merge into dest
  */
-void bgpstream_patricia_tree_merge(bgpstream_patricia_tree_t *dst, const bgpstream_patricia_tree_t *src);
-
+void bgpstream_patricia_tree_merge(bgpstream_patricia_tree_t *dst,
+                                   const bgpstream_patricia_tree_t *src);
 
 /** Remove a prefix from the Patricia Tree (if it exists)
  *
  * @param pt           pointer to the patricia tree to lookup in
  * @param pfx          pointer to the prefix to remove
  */
-void bgpstream_patricia_tree_remove(bgpstream_patricia_tree_t *pt, bgpstream_pfx_t *pfx);
-
+void bgpstream_patricia_tree_remove(bgpstream_patricia_tree_t *pt,
+                                    bgpstream_pfx_t *pfx);
 
 /** Remove a node from the Patricia Tree
  *
  * @param pt           pointer to the patricia tree to lookup in
  * @param node         pointer to the node to remove
  */
-void bgpstream_patricia_tree_remove_node(bgpstream_patricia_tree_t *pt, bgpstream_patricia_node_t *node);
-
+void bgpstream_patricia_tree_remove_node(bgpstream_patricia_tree_t *pt,
+                                         bgpstream_patricia_node_t *node);
 
 /** Search exact prefix in Patricia Tree
  *
  * @param pt           pointer to the patricia tree to lookup in
  * @param pfx          pointer to the prefix to search
- * @return a pointer to the prefix in the Patricia Tree, or NULL if an error occurred
+ * @return a pointer to the prefix in the Patricia Tree, or NULL if an error
+ * occurred
  */
-bgpstream_patricia_node_t *bgpstream_patricia_tree_search_exact(bgpstream_patricia_tree_t *pt, bgpstream_pfx_t *pfx);
-
+bgpstream_patricia_node_t *
+bgpstream_patricia_tree_search_exact(bgpstream_patricia_tree_t *pt,
+                                     bgpstream_pfx_t *pfx);
 
 /** Count the number of prefixes in the Patricia Tree
  *
@@ -232,8 +231,8 @@ bgpstream_patricia_node_t *bgpstream_patricia_tree_search_exact(bgpstream_patric
  * @param v          IP version
  * @return the number of prefixes
  */
-uint64_t bgpstream_patricia_prefix_count(bgpstream_patricia_tree_t *pt, bgpstream_addr_version_t v);
-
+uint64_t bgpstream_patricia_prefix_count(bgpstream_patricia_tree_t *pt,
+                                         bgpstream_addr_version_t v);
 
 /** Count the number of unique /24 IPv4 prefixes in the Patricia Tree
  *
@@ -241,13 +240,11 @@ uint64_t bgpstream_patricia_prefix_count(bgpstream_patricia_tree_t *pt, bgpstrea
  */
 uint64_t bgpstream_patricia_tree_count_24subnets(bgpstream_patricia_tree_t *pt);
 
-
 /** Count the number of unique /64 IPv6 prefixes in the Patricia Tree
  *
  * @param pt           pointer to the patricia tree
  */
 uint64_t bgpstream_patricia_tree_count_64subnets(bgpstream_patricia_tree_t *pt);
-
 
 /** Return more specific prefixes
  *
@@ -256,10 +253,9 @@ uint64_t bgpstream_patricia_tree_count_64subnets(bgpstream_patricia_tree_t *pt);
  * @param results      pointer to the results structure to fill
  * @return 0 if the computation finished correctly, -1 if an error occurred
  */
-int bgpstream_patricia_tree_get_more_specifics(bgpstream_patricia_tree_t *pt,
-                                               bgpstream_patricia_node_t *node,
-                                               bgpstream_patricia_tree_result_set_t *results);
-
+int bgpstream_patricia_tree_get_more_specifics(
+  bgpstream_patricia_tree_t *pt, bgpstream_patricia_node_t *node,
+  bgpstream_patricia_tree_result_set_t *results);
 
 /** Return the smallest less specific prefix
  *
@@ -268,9 +264,9 @@ int bgpstream_patricia_tree_get_more_specifics(bgpstream_patricia_tree_t *pt,
  * @param results      pointer to the results structure to fill
  * @return 0 if the computation finished correctly, -1 if an error occurred
  */
-int bgpstream_patricia_tree_get_mincovering_prefix(bgpstream_patricia_tree_t *pt,
-                                                   bgpstream_patricia_node_t *node,
-                                                   bgpstream_patricia_tree_result_set_t *results);
+int bgpstream_patricia_tree_get_mincovering_prefix(
+  bgpstream_patricia_tree_t *pt, bgpstream_patricia_node_t *node,
+  bgpstream_patricia_tree_result_set_t *results);
 
 /** Return less specific prefixes
  *
@@ -279,12 +275,12 @@ int bgpstream_patricia_tree_get_mincovering_prefix(bgpstream_patricia_tree_t *pt
  * @param results      pointer to the results structure to fill
  * @return 0 if the computation finished correctly, -1 if an error occurred
  */
-int bgpstream_patricia_tree_get_less_specifics(bgpstream_patricia_tree_t *pt,
-                                               bgpstream_patricia_node_t *node,
-                                               bgpstream_patricia_tree_result_set_t *results);
+int bgpstream_patricia_tree_get_less_specifics(
+  bgpstream_patricia_tree_t *pt, bgpstream_patricia_node_t *node,
+  bgpstream_patricia_tree_result_set_t *results);
 
-
-/** Return minimum coverage (the minimum list of prefixes in the Patricia Tree that
+/** Return minimum coverage (the minimum list of prefixes in the Patricia Tree
+ * that
  *  cover the entire IP space)
  *
  * @param pt           pointer to the patricia tree
@@ -292,52 +288,54 @@ int bgpstream_patricia_tree_get_less_specifics(bgpstream_patricia_tree_t *pt,
  * @param results      pointer to the results structure to fill
  * @return 0 if the computation finished correctly, -1 if an error occurred
  */
-int bgpstream_patricia_tree_get_minimum_coverage(bgpstream_patricia_tree_t *pt,
-                                                 bgpstream_addr_version_t v,
-                                                 bgpstream_patricia_tree_result_set_t *results);
-
+int bgpstream_patricia_tree_get_minimum_coverage(
+  bgpstream_patricia_tree_t *pt, bgpstream_addr_version_t v,
+  bgpstream_patricia_tree_result_set_t *results);
 
 /** Check whether a node overlaps with other prefixes in the tree
  *
  * @param pt           pointer to the patricia tree
  * @param node         pointer to the node in the tree
- * @return a mask: all zeroes if no overlap, 1 on first bit if more specifics are present
+ * @return a mask: all zeroes if no overlap, 1 on first bit if more specifics
+ * are present
  *                 1 on the second bit if less specifics are present
  */
-uint8_t bgpstream_patricia_tree_get_node_overlap_info(bgpstream_patricia_tree_t *pt,
-                                                      bgpstream_patricia_node_t *node);
-
+uint8_t
+bgpstream_patricia_tree_get_node_overlap_info(bgpstream_patricia_tree_t *pt,
+                                              bgpstream_patricia_node_t *node);
 
 /** Check whether a prefix would overlap with the prefixes already in the tree
  *
  * @param pt           pointer to the patricia tree
  * @param node         pointer to the prefix to check
- * @return a mask: all zeroes if no overlap, 1 on first bit if more specifics are present
+ * @return a mask: all zeroes if no overlap, 1 on first bit if more specifics
+ * are present
  *                 1 on the second bit if less specifics are present
  */
-uint8_t bgpstream_patricia_tree_get_pfx_overlap_info(bgpstream_patricia_tree_t *pt,
-                                                     bgpstream_pfx_t *pfx);
-
+uint8_t
+bgpstream_patricia_tree_get_pfx_overlap_info(bgpstream_patricia_tree_t *pt,
+                                             bgpstream_pfx_t *pfx);
 
 /** Get node's prefix
  *
  * @param node         pointer to the node
  * @return a pointer to the node's prefix , or NULL if an error occurred
  */
-bgpstream_pfx_t *bgpstream_patricia_tree_get_pfx(bgpstream_patricia_node_t *node);
-
+bgpstream_pfx_t *
+bgpstream_patricia_tree_get_pfx(bgpstream_patricia_node_t *node);
 
 /** Process the nodes while walking the Patricia Tree in order
  *
  * @param pt           pointer to the patricia tree
- * @param fun          pointer to a function to process the nodes in the patricia tree
- * @param data         pointer to a custom structure that can be used to update a state
+ * @param fun          pointer to a function to process the nodes in the
+ * patricia tree
+ * @param data         pointer to a custom structure that can be used to update
+ * a state
  *                     during the fun call
  */
 void bgpstream_patricia_tree_walk(bgpstream_patricia_tree_t *pt,
                                   bgpstream_patricia_tree_process_node_t *fun,
                                   void *data);
-
 
 /** Print the prefixes in the Patricia Tree
  *
@@ -345,13 +343,11 @@ void bgpstream_patricia_tree_walk(bgpstream_patricia_tree_t *pt,
  */
 void bgpstream_patricia_tree_print(bgpstream_patricia_tree_t *pt);
 
-
 /** Clear the given Patricia Tree (i.e. remove all prefixes)
  *
  * @param pt           pointer to the patricia tree to clear
  */
 void bgpstream_patricia_tree_clear(bgpstream_patricia_tree_t *pt);
-
 
 /** Destroy the given Patricia Tree
  *
@@ -359,9 +355,6 @@ void bgpstream_patricia_tree_clear(bgpstream_patricia_tree_t *pt);
  */
 void bgpstream_patricia_tree_destroy(bgpstream_patricia_tree_t *pt);
 
-
 /** @} */
-
-
 
 #endif /* __BGPSTREAM_UTILS_PATRICIA_H */

--- a/lib/utils/bgpstream_utils_peer_sig_map.h
+++ b/lib/utils/bgpstream_utils_peer_sig_map.h
@@ -21,11 +21,10 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #ifndef __BGPSTREAM_UTILS_PEER_SIG_MAP_H
 #define __BGPSTREAM_UTILS_PEER_SIG_MAP_H
 
-#include "bgpstream_utils.h"      /** < for COLLECTOR_NAME_LEN */
+#include "bgpstream_utils.h" /** < for COLLECTOR_NAME_LEN */
 #include "bgpstream_utils_addr.h"
 
 /** @file
@@ -50,7 +49,6 @@ typedef struct bgpstream_peer_sig_map bgpstream_peer_sig_map_t;
 
 /** @} */
 
-
 /**
  * @name Public Data Structures
  *
@@ -72,13 +70,10 @@ typedef struct struct_bgpstream_peer_sig_t {
 
 /** @} */
 
-
-
 /**
  * @name Public API Functions
  *
  * @{ */
-
 
 /** Create a new peer signature map
  *
@@ -96,10 +91,8 @@ bgpstream_peer_sig_map_t *bgpstream_peer_sig_map_create();
  *
  */
 bgpstream_peer_id_t bgpstream_peer_sig_map_get_id(
-                                        bgpstream_peer_sig_map_t *map,
-                                        char *collector_str,
-					bgpstream_ip_addr_t *peer_ip_addr,
-                                        uint32_t peer_asnumber);
+  bgpstream_peer_sig_map_t *map, char *collector_str,
+  bgpstream_ip_addr_t *peer_ip_addr, uint32_t peer_asnumber);
 
 /** Get the peer signature for the given peer ID
  *
@@ -108,9 +101,9 @@ bgpstream_peer_id_t bgpstream_peer_sig_map_get_id(
  * @return pointer to the peer signature for the given peer ID, NULL if it was
  * not found
  */
-bgpstream_peer_sig_t *bgpstream_peer_sig_map_get_sig(
-                                                  bgpstream_peer_sig_map_t *map,
-                                                  bgpstream_peer_id_t peer_id);
+bgpstream_peer_sig_t *
+bgpstream_peer_sig_map_get_sig(bgpstream_peer_sig_map_t *map,
+                               bgpstream_peer_id_t peer_id);
 
 /** Get the number of peer signatures in the given map
  *
@@ -134,4 +127,3 @@ void bgpstream_peer_sig_map_clear(bgpstream_peer_sig_map_t *map);
 /** @} */
 
 #endif /* __BGPSTREAM_UTILS_PEER_SIG_MAP_H */
-

--- a/lib/utils/bgpstream_utils_pfx.c
+++ b/lib/utils/bgpstream_utils_pfx.c
@@ -21,10 +21,10 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <errno.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <errno.h>
 
 #include "khash.h"
 
@@ -35,23 +35,20 @@ char *bgpstream_pfx_snprintf(char *buf, size_t len, bgpstream_pfx_t *pfx)
   char *p = buf;
 
   /* print the address */
-  if(bgpstream_addr_ntop(buf, len, &(pfx->address)) == NULL)
-    {
-      return NULL;
-    }
+  if (bgpstream_addr_ntop(buf, len, &(pfx->address)) == NULL) {
+    return NULL;
+  }
 
-  while(*p != '\0')
-    {
-      p++;
-      len--;
-    }
+  while (*p != '\0') {
+    p++;
+    len--;
+  }
 
   /* print the mask */
-  snprintf(p, len, "/%"PRIu8, pfx->mask_len);
+  snprintf(p, len, "/%" PRIu8, pfx->mask_len);
 
   return buf;
 }
-
 
 #if UINT_MAX == 0xffffffffu
 unsigned int
@@ -64,7 +61,6 @@ bgpstream_ipv4_pfx_hash(bgpstream_ipv4_pfx_t *pfx)
   return __ac_Wang_hash(pfx->address.ipv4.s_addr | (uint32_t)pfx->mask_len);
 }
 
-
 #if ULONG_MAX == ULLONG_MAX
 unsigned long
 #else
@@ -73,12 +69,11 @@ unsigned long long
 bgpstream_ipv6_pfx_hash(bgpstream_ipv6_pfx_t *pfx)
 {
   // ipv6 number - we take most significant 64 bits only
-  unsigned char *s6 =  &(pfx->address.ipv6.s6_addr[0]);
-  uint64_t address = *((uint64_t *) s6);
+  unsigned char *s6 = &(pfx->address.ipv6.s6_addr[0]);
+  uint64_t address = *((uint64_t *)s6);
   // embed the network mask length in the 64 bits
   return __ac_Wang_hash(address | (uint64_t)pfx->mask_len);
 }
-
 
 #if ULONG_MAX == ULLONG_MAX
 unsigned long
@@ -87,33 +82,28 @@ unsigned long long
 #endif
 bgpstream_pfx_storage_hash(bgpstream_pfx_storage_t *pfx)
 {
-  if(pfx->address.version == BGPSTREAM_ADDR_VERSION_IPV4)
-    {
-      return bgpstream_ipv4_pfx_hash((bgpstream_ipv4_pfx_t *)pfx);
-    }
-  if(pfx->address.version == BGPSTREAM_ADDR_VERSION_IPV6)
-    {
-      return bgpstream_ipv6_pfx_hash((bgpstream_ipv6_pfx_t *)pfx);
-    }
+  if (pfx->address.version == BGPSTREAM_ADDR_VERSION_IPV4) {
+    return bgpstream_ipv4_pfx_hash((bgpstream_ipv4_pfx_t *)pfx);
+  }
+  if (pfx->address.version == BGPSTREAM_ADDR_VERSION_IPV6) {
+    return bgpstream_ipv6_pfx_hash((bgpstream_ipv6_pfx_t *)pfx);
+  }
   return 0;
 }
 
 int bgpstream_pfx_equal(bgpstream_pfx_t *pfx1, bgpstream_pfx_t *pfx2)
 {
-  if(pfx1->address.version != pfx2->address.version)
-    {
-      return 0;
-    }
-  if(pfx1->address.version == BGPSTREAM_ADDR_VERSION_IPV4)
-    {
-      return bgpstream_ipv4_pfx_equal((bgpstream_ipv4_pfx_t *)pfx1,
-                                      (bgpstream_ipv4_pfx_t *)pfx2);
-    }
-  if(pfx1->address.version == BGPSTREAM_ADDR_VERSION_IPV6)
-    {
-      return bgpstream_ipv6_pfx_equal((bgpstream_ipv6_pfx_t *)pfx1,
-                                      (bgpstream_ipv6_pfx_t *)pfx2);
-    }
+  if (pfx1->address.version != pfx2->address.version) {
+    return 0;
+  }
+  if (pfx1->address.version == BGPSTREAM_ADDR_VERSION_IPV4) {
+    return bgpstream_ipv4_pfx_equal((bgpstream_ipv4_pfx_t *)pfx1,
+                                    (bgpstream_ipv4_pfx_t *)pfx2);
+  }
+  if (pfx1->address.version == BGPSTREAM_ADDR_VERSION_IPV6) {
+    return bgpstream_ipv6_pfx_equal((bgpstream_ipv6_pfx_t *)pfx1,
+                                    (bgpstream_ipv6_pfx_t *)pfx2);
+  }
   return 0;
 }
 
@@ -124,7 +114,6 @@ int bgpstream_ipv4_pfx_equal(bgpstream_ipv4_pfx_t *pfx1,
           bgpstream_ipv4_addr_equal(&pfx1->address, &pfx2->address));
 }
 
-
 int bgpstream_ipv6_pfx_equal(bgpstream_ipv6_pfx_t *pfx1,
                              bgpstream_ipv6_pfx_t *pfx2)
 {
@@ -134,14 +123,12 @@ int bgpstream_ipv6_pfx_equal(bgpstream_ipv6_pfx_t *pfx1,
           bgpstream_ipv6_addr_equal(&pfx1->address, &pfx2->address));
 }
 
-
 int bgpstream_pfx_storage_equal(bgpstream_pfx_storage_t *pfx1,
                                 bgpstream_pfx_storage_t *pfx2)
 {
-  if(pfx1->mask_len == pfx2->mask_len)
-    {
-      return bgpstream_addr_storage_equal(&pfx1->address, &pfx2->address);
-    }
+  if (pfx1->mask_len == pfx2->mask_len) {
+    return bgpstream_addr_storage_equal(&pfx1->address, &pfx2->address);
+  }
   return 0;
 }
 
@@ -149,66 +136,59 @@ int bgpstream_pfx_contains(bgpstream_pfx_t *outer, bgpstream_pfx_t *inner)
 {
   bgpstream_addr_storage_t tmp;
 
-  if(outer->address.version != inner->address.version ||
-     outer->mask_len > inner->mask_len)
-    {
-      return 0;
-    }
+  if (outer->address.version != inner->address.version ||
+      outer->mask_len > inner->mask_len) {
+    return 0;
+  }
 
-  bgpstream_addr_copy((bgpstream_ip_addr_t*)&tmp, &inner->address);
-  bgpstream_addr_mask((bgpstream_ip_addr_t*)&tmp, outer->mask_len);
-  return bgpstream_addr_equal((bgpstream_ip_addr_t*)&tmp, &outer->address);
+  bgpstream_addr_copy((bgpstream_ip_addr_t *)&tmp, &inner->address);
+  bgpstream_addr_mask((bgpstream_ip_addr_t *)&tmp, outer->mask_len);
+  return bgpstream_addr_equal((bgpstream_ip_addr_t *)&tmp, &outer->address);
 }
 
-bgpstream_pfx_storage_t *
-bgpstream_str2pfx(const char *pfx_str, bgpstream_pfx_storage_t *pfx)
+bgpstream_pfx_storage_t *bgpstream_str2pfx(const char *pfx_str,
+                                           bgpstream_pfx_storage_t *pfx)
 {
-  if(pfx_str == NULL || pfx == NULL)
-    {
-      return NULL;
-    }
+  if (pfx_str == NULL || pfx == NULL) {
+    return NULL;
+  }
 
-  char pfx_copy[INET6_ADDRSTRLEN+3];
+  char pfx_copy[INET6_ADDRSTRLEN + 3];
   char *endptr = NULL;
 
   /* strncpy() functions copy at most len characters from src into
    * dst.  If src is less than len characters long, the remainder of
    * dst is filled with `\0' characters.  Otherwise, dst is not
    * terminated. */
-  strncpy(pfx_copy, pfx_str, INET6_ADDRSTRLEN+3);
-  if(pfx_copy[INET6_ADDRSTRLEN+3-1] != '\0')
-    {
-      return NULL;
-    }
+  strncpy(pfx_copy, pfx_str, INET6_ADDRSTRLEN + 3);
+  if (pfx_copy[INET6_ADDRSTRLEN + 3 - 1] != '\0') {
+    return NULL;
+  }
 
   /* get pointer to ip/mask divisor */
   char *found = strchr(pfx_copy, '/');
-  if(found == NULL)
-    {
-      return NULL;
-    }
+  if (found == NULL) {
+    return NULL;
+  }
 
   *found = '\0';
   /* get the ip address */
-  if(bgpstream_str2addr(pfx_copy, &pfx->address) == NULL)
-    {
-      return NULL;
-    }
+  if (bgpstream_str2addr(pfx_copy, &pfx->address) == NULL) {
+    return NULL;
+  }
 
   /* get the mask len */
   errno = 0;
-  unsigned long int r = strtoul(found+1, &endptr, 10);
+  unsigned long int r = strtoul(found + 1, &endptr, 10);
   int ret = errno;
-  if(!(endptr != NULL  && *endptr == '\0') ||
-     ret != 0 ||
-     (pfx->address.version == BGPSTREAM_ADDR_VERSION_IPV4 && r > 32) ||
-     (pfx->address.version == BGPSTREAM_ADDR_VERSION_IPV6 && r > 128) )
-    {
-      return NULL;
-    }
-  pfx->mask_len = (uint8_t) r;
+  if (!(endptr != NULL && *endptr == '\0') || ret != 0 ||
+      (pfx->address.version == BGPSTREAM_ADDR_VERSION_IPV4 && r > 32) ||
+      (pfx->address.version == BGPSTREAM_ADDR_VERSION_IPV6 && r > 128)) {
+    return NULL;
+  }
+  pfx->mask_len = (uint8_t)r;
 
-  bgpstream_addr_mask((bgpstream_ip_addr_t*)&pfx->address, pfx->mask_len);
+  bgpstream_addr_mask((bgpstream_ip_addr_t *)&pfx->address, pfx->mask_len);
 
   return pfx;
 }

--- a/lib/utils/bgpstream_utils_pfx.h
+++ b/lib/utils/bgpstream_utils_pfx.h
@@ -21,7 +21,6 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #ifndef __BGPSTREAM_UTILS_PFX_H
 #define __BGPSTREAM_UTILS_PFX_H
 
@@ -91,13 +90,10 @@ typedef struct struct_bgpstream_pfx_storage_t {
 
 /** @} */
 
-
-
 /**
  * @name Public API Functions
  *
  * @{ */
-
 
 /** Write the string representation of the given prefix into the given
  * character buffer.
@@ -112,7 +108,6 @@ typedef struct struct_bgpstream_pfx_storage_t {
  */
 char *bgpstream_pfx_snprintf(char *buf, size_t len, bgpstream_pfx_t *pfx);
 
-
 /** Hash the given IPv4 Prefix into a 32bit number
  *
  * @param pfx          pointer to the IPv4 prefix to hash
@@ -124,7 +119,6 @@ unsigned int
 unsigned long
 #endif
 bgpstream_ipv4_pfx_hash(bgpstream_ipv4_pfx_t *pfx);
-
 
 /** Hash the given IPv6 prefix into a 64bit number
  *
@@ -150,7 +144,6 @@ unsigned long long
 #endif
 bgpstream_pfx_storage_hash(bgpstream_pfx_storage_t *pfx);
 
-
 /** Compare two prefixes for equality
  *
  * @param pfx1          pointer to the first prefix to compare
@@ -168,7 +161,6 @@ int bgpstream_pfx_equal(bgpstream_pfx_t *pfx1, bgpstream_pfx_t *pfx2);
 int bgpstream_ipv4_pfx_equal(bgpstream_ipv4_pfx_t *pfx1,
                              bgpstream_ipv4_pfx_t *pfx2);
 
-
 /** Compare two IPv6 prefixes for equality
  *
  * @param pfx1         pointer to the first prefix to compare
@@ -177,7 +169,6 @@ int bgpstream_ipv4_pfx_equal(bgpstream_ipv4_pfx_t *pfx1,
  */
 int bgpstream_ipv6_pfx_equal(bgpstream_ipv6_pfx_t *pfx1,
                              bgpstream_ipv6_pfx_t *pfx2);
-
 
 /** Compare two generic prefixes for equality
  *
@@ -196,25 +187,20 @@ int bgpstream_pfx_storage_equal(bgpstream_pfx_storage_t *pfx1,
  */
 int bgpstream_pfx_contains(bgpstream_pfx_t *outer, bgpstream_pfx_t *inner);
 
-
 /** Utility macros used to pass khashes objects by reference
  *  instead of copying them */
 
-#define bgpstream_pfx_storage_hash_val(arg) \
-        bgpstream_pfx_storage_hash(&(arg))
-#define bgpstream_pfx_storage_equal_val(arg1, arg2) \
-        bgpstream_pfx_storage_equal(&(arg1), &(arg2))
+#define bgpstream_pfx_storage_hash_val(arg) bgpstream_pfx_storage_hash(&(arg))
+#define bgpstream_pfx_storage_equal_val(arg1, arg2)                            \
+  bgpstream_pfx_storage_equal(&(arg1), &(arg2))
 
-#define bgpstream_ipv4_pfx_storage_hash_val(arg) \
-        bgpstream_ipv4_pfx_hash(&(arg))
-#define bgpstream_ipv4_pfx_storage_equal_val(arg1, arg2) \
-        bgpstream_ipv4_pfx_equal(&(arg1), &(arg2))
+#define bgpstream_ipv4_pfx_storage_hash_val(arg) bgpstream_ipv4_pfx_hash(&(arg))
+#define bgpstream_ipv4_pfx_storage_equal_val(arg1, arg2)                       \
+  bgpstream_ipv4_pfx_equal(&(arg1), &(arg2))
 
-#define bgpstream_ipv6_pfx_storage_hash_val(arg) \
-        bgpstream_ipv6_pfx_hash(&(arg))
-#define bgpstream_ipv6_pfx_storage_equal_val(arg1, arg2) \
-        bgpstream_ipv6_pfx_equal(&(arg1), &(arg2))
-
+#define bgpstream_ipv6_pfx_storage_hash_val(arg) bgpstream_ipv6_pfx_hash(&(arg))
+#define bgpstream_ipv6_pfx_storage_equal_val(arg1, arg2)                       \
+  bgpstream_ipv6_pfx_equal(&(arg1), &(arg2))
 
 /** Convert a string into a prefix storage
  *
@@ -223,10 +209,9 @@ int bgpstream_pfx_contains(bgpstream_pfx_t *outer, bgpstream_pfx_t *inner);
  * @return the pointer to an initialized pfx storage, NULL if the
  *         prefix is not valid
  */
-bgpstream_pfx_storage_t *
-bgpstream_str2pfx(const char *pfx_str, bgpstream_pfx_storage_t *pfx);
+bgpstream_pfx_storage_t *bgpstream_str2pfx(const char *pfx_str,
+                                           bgpstream_pfx_storage_t *pfx);
 
 /** @} */
 
 #endif /* __BGPSTREAM_UTILS_PFX_H */
-

--- a/lib/utils/bgpstream_utils_pfx_set.c
+++ b/lib/utils/bgpstream_utils_pfx_set.c
@@ -21,14 +21,13 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <stdio.h>
 #include <assert.h>
+#include <stdio.h>
 
 #include "khash.h"
 #include "utils.h"
 
 #include "bgpstream_utils_pfx_set.h"
-
 
 /** set of unique IP prefixes
  *  this structure maintains a set of unique
@@ -36,15 +35,12 @@
  *  using a int64 type)
  */
 KHASH_INIT(bgpstream_pfx_storage_set /* name */,
-	   bgpstream_pfx_storage_t /* khkey_t */,
-	   char /* khval_t */,
-	   0  /* kh_is_set */,
-	   bgpstream_pfx_storage_hash_val /*__hash_func */,
-	   bgpstream_pfx_storage_equal_val /* __hash_equal */);
-
+           bgpstream_pfx_storage_t /* khkey_t */, char /* khval_t */,
+           0 /* kh_is_set */, bgpstream_pfx_storage_hash_val /*__hash_func */,
+           bgpstream_pfx_storage_equal_val /* __hash_equal */);
 
 struct bgpstream_pfx_storage_set {
-  khash_t(bgpstream_pfx_storage_set) *hash;
+  khash_t(bgpstream_pfx_storage_set) * hash;
   uint64_t ipv4_size;
   uint64_t ipv6_size;
 };
@@ -52,32 +48,26 @@ struct bgpstream_pfx_storage_set {
 /* ipv4 specific set */
 
 KHASH_INIT(bgpstream_ipv4_pfx_set /* name */,
-	   bgpstream_ipv4_pfx_t /* khkey_t */,
-	   char /* khval_t */,
-	   0  /* kh_is_set */,
-	   bgpstream_ipv4_pfx_storage_hash_val /*__hash_func */,
-	   bgpstream_ipv4_pfx_storage_equal_val /* __hash_equal */);
-
+           bgpstream_ipv4_pfx_t /* khkey_t */, char /* khval_t */,
+           0 /* kh_is_set */,
+           bgpstream_ipv4_pfx_storage_hash_val /*__hash_func */,
+           bgpstream_ipv4_pfx_storage_equal_val /* __hash_equal */);
 
 struct bgpstream_ipv4_pfx_set {
-  khash_t(bgpstream_ipv4_pfx_set) *hash;
+  khash_t(bgpstream_ipv4_pfx_set) * hash;
 };
 
 /* ipv6 specific set */
 
 KHASH_INIT(bgpstream_ipv6_pfx_set /* name */,
-	   bgpstream_ipv6_pfx_t /* khkey_t */,
-	   char /* khval_t */,
-	   0  /* kh_is_set */,
-	   bgpstream_ipv6_pfx_storage_hash_val /*__hash_func */,
-	   bgpstream_ipv6_pfx_storage_equal_val /* __hash_equal */);
-
+           bgpstream_ipv6_pfx_t /* khkey_t */, char /* khval_t */,
+           0 /* kh_is_set */,
+           bgpstream_ipv6_pfx_storage_hash_val /*__hash_func */,
+           bgpstream_ipv6_pfx_storage_equal_val /* __hash_equal */);
 
 struct bgpstream_ipv6_pfx_set {
-  khash_t(bgpstream_ipv6_pfx_set) *hash;
+  khash_t(bgpstream_ipv6_pfx_set) * hash;
 };
-
-
 
 /* STORAGE */
 
@@ -85,42 +75,35 @@ bgpstream_pfx_storage_set_t *bgpstream_pfx_storage_set_create()
 {
   bgpstream_pfx_storage_set_t *set;
 
-  if((set =
-      (bgpstream_pfx_storage_set_t*)
-      malloc(sizeof(bgpstream_pfx_storage_set_t))) == NULL)
-    {
-      return NULL;
-    }
+  if ((set = (bgpstream_pfx_storage_set_t *)malloc(
+         sizeof(bgpstream_pfx_storage_set_t))) == NULL) {
+    return NULL;
+  }
 
-  if((set->hash = kh_init(bgpstream_pfx_storage_set)) == NULL)
-    {
-      bgpstream_pfx_storage_set_destroy(set);
-      return NULL;
-    }
+  if ((set->hash = kh_init(bgpstream_pfx_storage_set)) == NULL) {
+    bgpstream_pfx_storage_set_destroy(set);
+    return NULL;
+  }
   set->ipv4_size = 0;
   set->ipv6_size = 0;
   return set;
 }
 
 int bgpstream_pfx_storage_set_insert(bgpstream_pfx_storage_set_t *set,
-                                      bgpstream_pfx_storage_t *pfx)
+                                     bgpstream_pfx_storage_t *pfx)
 {
   int khret;
   khiter_t k;
-  if((k = kh_get(bgpstream_pfx_storage_set, set->hash, *pfx)) ==
-     kh_end(set->hash))
-    {
-      k = kh_put(bgpstream_pfx_storage_set, set->hash, *pfx, &khret);
-      if(pfx->address.version == BGPSTREAM_ADDR_VERSION_IPV4)
-        {
-          set->ipv4_size++;
-        }
-      else
-        {
-          set->ipv6_size++;
-        }
-      return 1;
+  if ((k = kh_get(bgpstream_pfx_storage_set, set->hash, *pfx)) ==
+      kh_end(set->hash)) {
+    k = kh_put(bgpstream_pfx_storage_set, set->hash, *pfx, &khret);
+    if (pfx->address.version == BGPSTREAM_ADDR_VERSION_IPV4) {
+      set->ipv4_size++;
+    } else {
+      set->ipv6_size++;
     }
+    return 1;
+  }
   return 0;
 }
 
@@ -128,11 +111,10 @@ int bgpstream_pfx_storage_set_exists(bgpstream_pfx_storage_set_t *set,
                                      bgpstream_pfx_storage_t *pfx)
 {
   khiter_t k;
-  if((k = kh_get(bgpstream_pfx_storage_set, set->hash, *pfx)) ==
-     kh_end(set->hash))
-    {
-      return 0;
-    }
+  if ((k = kh_get(bgpstream_pfx_storage_set, set->hash, *pfx)) ==
+      kh_end(set->hash)) {
+    return 0;
+  }
   return 1;
 }
 
@@ -141,35 +123,31 @@ int bgpstream_pfx_storage_set_size(bgpstream_pfx_storage_set_t *set)
   return kh_size(set->hash);
 }
 
-int bgpstream_pfx_storage_set_version_size(bgpstream_pfx_storage_set_t *set, bgpstream_addr_version_t v)
+int bgpstream_pfx_storage_set_version_size(bgpstream_pfx_storage_set_t *set,
+                                           bgpstream_addr_version_t v)
 {
-  switch(v)
-    {
-    case BGPSTREAM_ADDR_VERSION_IPV4:
-      return set->ipv4_size;
-    case BGPSTREAM_ADDR_VERSION_IPV6:
-      return set->ipv6_size;
-    default:
-      return -1;
-    }
+  switch (v) {
+  case BGPSTREAM_ADDR_VERSION_IPV4:
+    return set->ipv4_size;
+  case BGPSTREAM_ADDR_VERSION_IPV6:
+    return set->ipv6_size;
+  default:
+    return -1;
+  }
 }
 
-
 int bgpstream_pfx_storage_set_merge(bgpstream_pfx_storage_set_t *dst_set,
-                                     bgpstream_pfx_storage_set_t *src_set)
+                                    bgpstream_pfx_storage_set_t *src_set)
 {
   khiter_t k;
-  for(k = kh_begin(src_set->hash); k != kh_end(src_set->hash); ++k)
-    {
-      if(kh_exist(src_set->hash, k))
-	{
-	  if(bgpstream_pfx_storage_set_insert(dst_set,
-                                               &(kh_key(src_set->hash, k))) <0)
-            {
-              return -1;
-            }
-	}
+  for (k = kh_begin(src_set->hash); k != kh_end(src_set->hash); ++k) {
+    if (kh_exist(src_set->hash, k)) {
+      if (bgpstream_pfx_storage_set_insert(dst_set,
+                                           &(kh_key(src_set->hash, k))) < 0) {
+        return -1;
+      }
     }
+  }
   return 0;
 }
 
@@ -186,41 +164,35 @@ void bgpstream_pfx_storage_set_clear(bgpstream_pfx_storage_set_t *set)
   set->ipv6_size = 0;
 }
 
-
-
 /* IPv4 */
 
 bgpstream_ipv4_pfx_set_t *bgpstream_ipv4_pfx_set_create()
 {
   bgpstream_ipv4_pfx_set_t *set;
 
-  if((set =
-      (bgpstream_ipv4_pfx_set_t*)
-      malloc(sizeof(bgpstream_ipv4_pfx_set_t))) == NULL)
-    {
-      return NULL;
-    }
+  if ((set = (bgpstream_ipv4_pfx_set_t *)malloc(
+         sizeof(bgpstream_ipv4_pfx_set_t))) == NULL) {
+    return NULL;
+  }
 
-  if((set->hash = kh_init(bgpstream_ipv4_pfx_set)) == NULL)
-    {
-      bgpstream_ipv4_pfx_set_destroy(set);
-      return NULL;
-    }
+  if ((set->hash = kh_init(bgpstream_ipv4_pfx_set)) == NULL) {
+    bgpstream_ipv4_pfx_set_destroy(set);
+    return NULL;
+  }
 
   return set;
 }
 
 int bgpstream_ipv4_pfx_set_insert(bgpstream_ipv4_pfx_set_t *set,
-                                      bgpstream_ipv4_pfx_t *pfx)
+                                  bgpstream_ipv4_pfx_t *pfx)
 {
   int khret;
   khiter_t k;
-  if((k = kh_get(bgpstream_ipv4_pfx_set, set->hash, *pfx)) ==
-     kh_end(set->hash))
-    {
-      k = kh_put(bgpstream_ipv4_pfx_set, set->hash, *pfx, &khret);
-      return 1;
-    }
+  if ((k = kh_get(bgpstream_ipv4_pfx_set, set->hash, *pfx)) ==
+      kh_end(set->hash)) {
+    k = kh_put(bgpstream_ipv4_pfx_set, set->hash, *pfx, &khret);
+    return 1;
+  }
   return 0;
 }
 
@@ -228,14 +200,12 @@ int bgpstream_ipv4_pfx_set_exists(bgpstream_ipv4_pfx_set_t *set,
                                   bgpstream_ipv4_pfx_t *pfx)
 {
   khiter_t k;
-  if((k = kh_get(bgpstream_ipv4_pfx_set, set->hash, *pfx)) ==
-     kh_end(set->hash))
-    {
-      return 0;
-    }
+  if ((k = kh_get(bgpstream_ipv4_pfx_set, set->hash, *pfx)) ==
+      kh_end(set->hash)) {
+    return 0;
+  }
   return 1;
 }
-
 
 int bgpstream_ipv4_pfx_set_size(bgpstream_ipv4_pfx_set_t *set)
 {
@@ -243,20 +213,17 @@ int bgpstream_ipv4_pfx_set_size(bgpstream_ipv4_pfx_set_t *set)
 }
 
 int bgpstream_ipv4_pfx_set_merge(bgpstream_ipv4_pfx_set_t *dst_set,
-                                     bgpstream_ipv4_pfx_set_t *src_set)
+                                 bgpstream_ipv4_pfx_set_t *src_set)
 {
   khiter_t k;
-  for(k = kh_begin(src_set->hash); k != kh_end(src_set->hash); ++k)
-    {
-      if(kh_exist(src_set->hash, k))
-	{
-	  if(bgpstream_ipv4_pfx_set_insert(dst_set,
-                                               &(kh_key(src_set->hash, k))) <0)
-            {
-              return -1;
-            }
-	}
+  for (k = kh_begin(src_set->hash); k != kh_end(src_set->hash); ++k) {
+    if (kh_exist(src_set->hash, k)) {
+      if (bgpstream_ipv4_pfx_set_insert(dst_set, &(kh_key(src_set->hash, k))) <
+          0) {
+        return -1;
+      }
     }
+  }
   return 0;
 }
 
@@ -271,26 +238,21 @@ void bgpstream_ipv4_pfx_set_clear(bgpstream_ipv4_pfx_set_t *set)
   kh_clear(bgpstream_ipv4_pfx_set, set->hash);
 }
 
-
-
 /* IPv6 */
 
 bgpstream_ipv6_pfx_set_t *bgpstream_ipv6_pfx_set_create()
 {
   bgpstream_ipv6_pfx_set_t *set;
 
-  if((set =
-      (bgpstream_ipv6_pfx_set_t*)
-      malloc(sizeof(bgpstream_ipv6_pfx_set_t))) == NULL)
-    {
-      return NULL;
-    }
+  if ((set = (bgpstream_ipv6_pfx_set_t *)malloc(
+         sizeof(bgpstream_ipv6_pfx_set_t))) == NULL) {
+    return NULL;
+  }
 
-  if((set->hash = kh_init(bgpstream_ipv6_pfx_set)) == NULL)
-    {
-      bgpstream_ipv6_pfx_set_destroy(set);
-      return NULL;
-    }
+  if ((set->hash = kh_init(bgpstream_ipv6_pfx_set)) == NULL) {
+    bgpstream_ipv6_pfx_set_destroy(set);
+    return NULL;
+  }
 
   return set;
 }
@@ -300,12 +262,11 @@ int bgpstream_ipv6_pfx_set_insert(bgpstream_ipv6_pfx_set_t *set,
 {
   int khret;
   khiter_t k;
-  if((k = kh_get(bgpstream_ipv6_pfx_set, set->hash, *pfx)) ==
-     kh_end(set->hash))
-    {
-      k = kh_put(bgpstream_ipv6_pfx_set, set->hash, *pfx, &khret);
-      return 1;
-    }
+  if ((k = kh_get(bgpstream_ipv6_pfx_set, set->hash, *pfx)) ==
+      kh_end(set->hash)) {
+    k = kh_put(bgpstream_ipv6_pfx_set, set->hash, *pfx, &khret);
+    return 1;
+  }
   return 0;
 }
 
@@ -313,11 +274,10 @@ int bgpstream_ipv6_pfx_set_exists(bgpstream_ipv6_pfx_set_t *set,
                                   bgpstream_ipv6_pfx_t *pfx)
 {
   khiter_t k;
-  if((k = kh_get(bgpstream_ipv6_pfx_set, set->hash, *pfx)) ==
-     kh_end(set->hash))
-    {
-      return 0;
-    }
+  if ((k = kh_get(bgpstream_ipv6_pfx_set, set->hash, *pfx)) ==
+      kh_end(set->hash)) {
+    return 0;
+  }
   return 1;
 }
 
@@ -327,20 +287,17 @@ int bgpstream_ipv6_pfx_set_size(bgpstream_ipv6_pfx_set_t *set)
 }
 
 int bgpstream_ipv6_pfx_set_merge(bgpstream_ipv6_pfx_set_t *dst_set,
-                                     bgpstream_ipv6_pfx_set_t *src_set)
+                                 bgpstream_ipv6_pfx_set_t *src_set)
 {
   khiter_t k;
-  for(k = kh_begin(src_set->hash); k != kh_end(src_set->hash); ++k)
-    {
-      if(kh_exist(src_set->hash, k))
-	{
-	  if(bgpstream_ipv6_pfx_set_insert(dst_set,
-                                               &(kh_key(src_set->hash, k))) <0)
-            {
-              return -1;
-            }
-	}
+  for (k = kh_begin(src_set->hash); k != kh_end(src_set->hash); ++k) {
+    if (kh_exist(src_set->hash, k)) {
+      if (bgpstream_ipv6_pfx_set_insert(dst_set, &(kh_key(src_set->hash, k))) <
+          0) {
+        return -1;
+      }
     }
+  }
   return 0;
 }
 

--- a/lib/utils/bgpstream_utils_pfx_set.h
+++ b/lib/utils/bgpstream_utils_pfx_set.h
@@ -21,7 +21,6 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #ifndef __BGPSTREAM_UTILS_PFX_SET_H
 #define __BGPSTREAM_UTILS_PFX_SET_H
 
@@ -98,7 +97,8 @@ int bgpstream_pfx_storage_set_size(bgpstream_pfx_storage_set_t *set);
  * @param v          IP version
  * @return the size of the prefix set
  */
-int bgpstream_pfx_storage_set_version_size(bgpstream_pfx_storage_set_t *set, bgpstream_addr_version_t v);
+int bgpstream_pfx_storage_set_version_size(bgpstream_pfx_storage_set_t *set,
+                                           bgpstream_addr_version_t v);
 
 /** Merge two prefix sets
  *
@@ -120,9 +120,6 @@ void bgpstream_pfx_storage_set_destroy(bgpstream_pfx_storage_set_t *set);
  * @param set           pointer to the prefix set to clear
  */
 void bgpstream_pfx_storage_set_clear(bgpstream_pfx_storage_set_t *set);
-
-
-
 
 /* IPv4 */
 
@@ -151,7 +148,7 @@ int bgpstream_ipv4_pfx_set_insert(bgpstream_ipv4_pfx_set_t *set,
  * @return 0 if the prefix is not in the set, 1 if it is in the set
  */
 int bgpstream_ipv4_pfx_set_exists(bgpstream_ipv4_pfx_set_t *set,
-                                     bgpstream_ipv4_pfx_t *pfx);
+                                  bgpstream_ipv4_pfx_t *pfx);
 
 /** Get the number of prefixes in the given set
  *
@@ -167,7 +164,7 @@ int bgpstream_ipv4_pfx_set_size(bgpstream_ipv4_pfx_set_t *set);
  * @return 0 if the sets were merged succsessfully, -1 otherwise
  */
 int bgpstream_ipv4_pfx_set_merge(bgpstream_ipv4_pfx_set_t *dst_set,
-                                  bgpstream_ipv4_pfx_set_t *src_set);
+                                 bgpstream_ipv4_pfx_set_t *src_set);
 
 /** Destroy the given prefix set
  *
@@ -180,8 +177,6 @@ void bgpstream_ipv4_pfx_set_destroy(bgpstream_ipv4_pfx_set_t *set);
  * @param set           pointer to the prefix set to clear
  */
 void bgpstream_ipv4_pfx_set_clear(bgpstream_ipv4_pfx_set_t *set);
-
-
 
 /** Create a new IPv6 Prefix set instance
  *
@@ -222,7 +217,7 @@ int bgpstream_ipv6_pfx_set_size(bgpstream_ipv6_pfx_set_t *set);
  * @return 0 if the sets were merged succsessfully, -1 otherwise
  */
 int bgpstream_ipv6_pfx_set_merge(bgpstream_ipv6_pfx_set_t *dst_set,
-                                  bgpstream_ipv6_pfx_set_t *src_set);
+                                 bgpstream_ipv6_pfx_set_t *src_set);
 
 /** Destroy the given prefix set
  *
@@ -237,5 +232,3 @@ void bgpstream_ipv6_pfx_set_destroy(bgpstream_ipv6_pfx_set_t *set);
 void bgpstream_ipv6_pfx_set_clear(bgpstream_ipv6_pfx_set_t *set);
 
 #endif /* __BGPSTREAM_UTILS_PFX_SET_H */
-
-

--- a/lib/utils/bgpstream_utils_str_set.c
+++ b/lib/utils/bgpstream_utils_str_set.c
@@ -31,15 +31,13 @@
 
 /* PRIVATE */
 
-KHASH_INIT(bgpstream_str_set, char*, char, 0,
-	   kh_str_hash_func, kh_str_hash_equal);
-
+KHASH_INIT(bgpstream_str_set, char *, char, 0, kh_str_hash_func,
+           kh_str_hash_equal);
 
 struct bgpstream_str_set_t {
   khiter_t k;
-  khash_t(bgpstream_str_set) *hash;
+  khash_t(bgpstream_str_set) * hash;
 };
-
 
 /* PUBLIC FUNCTIONS */
 
@@ -47,68 +45,58 @@ bgpstream_str_set_t *bgpstream_str_set_create()
 {
   bgpstream_str_set_t *set;
 
-  if((set = (bgpstream_str_set_t*)malloc(sizeof(bgpstream_str_set_t))) == NULL)
-    {
-      return NULL;
-    }
+  if ((set = (bgpstream_str_set_t *)malloc(sizeof(bgpstream_str_set_t))) ==
+      NULL) {
+    return NULL;
+  }
 
-  if((set->hash = kh_init(bgpstream_str_set)) == NULL)
-    {
-      bgpstream_str_set_destroy(set);
-      return NULL;
-    }
+  if ((set->hash = kh_init(bgpstream_str_set)) == NULL) {
+    bgpstream_str_set_destroy(set);
+    return NULL;
+  }
 
   bgpstream_str_set_rewind(set);
   return set;
 }
 
-
-int bgpstream_str_set_insert(bgpstream_str_set_t *set,
-                             const char *val)
+int bgpstream_str_set_insert(bgpstream_str_set_t *set, const char *val)
 {
   int khret;
   khiter_t k;
   char *cpy;
-  if((cpy = strdup(val)) == NULL)
-    {
-      return -1;
-    }
+  if ((cpy = strdup(val)) == NULL) {
+    return -1;
+  }
 
-  if((k = kh_get(bgpstream_str_set, set->hash, cpy)) == kh_end(set->hash))
-    {
-      k = kh_put(bgpstream_str_set, set->hash, cpy, &khret);
-      return 1;
-    }
-  else
-    {
-      free(cpy);
-    }
+  if ((k = kh_get(bgpstream_str_set, set->hash, cpy)) == kh_end(set->hash)) {
+    k = kh_put(bgpstream_str_set, set->hash, cpy, &khret);
+    return 1;
+  } else {
+    free(cpy);
+  }
   return 0;
 }
-
 
 int bgpstream_str_set_remove(bgpstream_str_set_t *set, char *val)
 {
   khiter_t k;
   bgpstream_str_set_rewind(set);
-  if((k = kh_get(bgpstream_str_set, set->hash, val)) != kh_end(set->hash))
-    {
-      // free memory allocated for the key (string)
-      free(kh_key(set->hash,k));
-      // delete entry
-      kh_del(bgpstream_str_set, set->hash, k);
-      return 1;
-    }
+  if ((k = kh_get(bgpstream_str_set, set->hash, val)) != kh_end(set->hash)) {
+    // free memory allocated for the key (string)
+    free(kh_key(set->hash, k));
+    // delete entry
+    kh_del(bgpstream_str_set, set->hash, k);
+    return 1;
+  }
   return 0;
 }
 
 int bgpstream_str_set_exists(bgpstream_str_set_t *set, char *val)
 {
   khiter_t k;
-  if((k = kh_get(bgpstream_str_set, set->hash, val)) == kh_end(set->hash))
-    {
-      return 0;
-    }
+  if ((k = kh_get(bgpstream_str_set, set->hash, val)) == kh_end(set->hash)) {
+    return 0;
+  }
   return 1;
 }
 
@@ -118,76 +106,63 @@ int bgpstream_str_set_size(bgpstream_str_set_t *set)
 }
 
 int bgpstream_str_set_merge(bgpstream_str_set_t *dst_set,
-                             bgpstream_str_set_t *src_set)
+                            bgpstream_str_set_t *src_set)
 {
   khiter_t k;
 
-  for(k = kh_begin(src_set->hash); k != kh_end(src_set->hash); ++k)
-    {
-      if(kh_exist(src_set->hash, k))
-	{
-          if(bgpstream_str_set_insert(dst_set, kh_key(src_set->hash, k)) < 0)
-            {
-              return -1;
-            }
-	}
+  for (k = kh_begin(src_set->hash); k != kh_end(src_set->hash); ++k) {
+    if (kh_exist(src_set->hash, k)) {
+      if (bgpstream_str_set_insert(dst_set, kh_key(src_set->hash, k)) < 0) {
+        return -1;
+      }
     }
+  }
   bgpstream_str_set_rewind(dst_set);
   bgpstream_str_set_rewind(src_set);
   return 0;
 }
-
 
 void bgpstream_str_set_rewind(bgpstream_str_set_t *set)
 {
   set->k = kh_begin(set->hash);
 }
 
-char* bgpstream_str_set_next(bgpstream_str_set_t *set)
+char *bgpstream_str_set_next(bgpstream_str_set_t *set)
 {
   char *v = NULL;
-  for( ; set->k != kh_end(set->hash); ++set->k)
-    {
-      if(kh_exist(set->hash, set->k))
-	{
-          v = kh_key(set->hash, set->k);
-          set->k++;
-          return v;
-        }
+  for (; set->k != kh_end(set->hash); ++set->k) {
+    if (kh_exist(set->hash, set->k)) {
+      v = kh_key(set->hash, set->k);
+      set->k++;
+      return v;
     }
+  }
   return v;
 }
-
 
 void bgpstream_str_set_clear(bgpstream_str_set_t *set)
 {
   khiter_t k;
   bgpstream_str_set_rewind(set);
-  for(k = kh_begin(set->hash); k != kh_end(set->hash); ++k)
-    {
-      if(kh_exist(set->hash, k))
-	{
-	  free(kh_key(set->hash,k));
-	}
+  for (k = kh_begin(set->hash); k != kh_end(set->hash); ++k) {
+    if (kh_exist(set->hash, k)) {
+      free(kh_key(set->hash, k));
     }
+  }
   kh_clear(bgpstream_str_set, set->hash);
 }
 
 void bgpstream_str_set_destroy(bgpstream_str_set_t *set)
 {
   khiter_t k;
-  if(set->hash != NULL)
-    {
-      for(k = kh_begin(set->hash); k != kh_end(set->hash); ++k)
-        {
-          if(kh_exist(set->hash, k))
-            {
-              free(kh_key(set->hash,k));
-            }
-        }
-      kh_destroy(bgpstream_str_set, set->hash);
-      set->hash = NULL;
+  if (set->hash != NULL) {
+    for (k = kh_begin(set->hash); k != kh_end(set->hash); ++k) {
+      if (kh_exist(set->hash, k)) {
+        free(kh_key(set->hash, k));
+      }
     }
+    kh_destroy(bgpstream_str_set, set->hash);
+    set->hash = NULL;
+  }
   free(set);
 }
-

--- a/lib/utils/bgpstream_utils_str_set.h
+++ b/lib/utils/bgpstream_utils_str_set.h
@@ -21,7 +21,6 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #ifndef __BGPSTREAM_UTILS_STR_SET_H
 #define __BGPSTREAM_UTILS_STR_SET_H
 
@@ -49,7 +48,6 @@ typedef struct bgpstream_str_set_t bgpstream_str_set_t;
  *
  * @{ */
 
-
 /** Create a new string set instance
  *
  * @return a pointer to the structure, or NULL if an error occurred
@@ -65,7 +63,7 @@ bgpstream_str_set_t *bgpstream_str_set_create();
  *
  * @note this function copies the provided string
  */
-int bgpstream_str_set_insert(bgpstream_str_set_t *set, const char * val);
+int bgpstream_str_set_insert(bgpstream_str_set_t *set, const char *val);
 
 /** Remove a string from the set
  *
@@ -112,7 +110,7 @@ void bgpstream_str_set_rewind(bgpstream_str_set_t *set);
  *         (borrowed pointer), NULL if the end of the set
  *         has been reached
  */
-char* bgpstream_str_set_next(bgpstream_str_set_t *set);
+char *bgpstream_str_set_next(bgpstream_str_set_t *set);
 
 /** Empty the string set.
  *

--- a/pybgpstream/src/_pybgpstream_bgpelem.c
+++ b/pybgpstream/src/_pybgpstream_bgpelem.c
@@ -21,8 +21,8 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Python.h>
 #include "pyutils.h"
+#include <Python.h>
 
 #include <bgpstream.h>
 
@@ -30,97 +30,91 @@
 
 #define BGPElemDocstring "BGPElem object"
 
-static PyObject *
-get_ip_pystr(bgpstream_ip_addr_t *ip) {
+static PyObject *get_ip_pystr(bgpstream_ip_addr_t *ip)
+{
   char ip_str[INET6_ADDRSTRLEN] = "";
   bgpstream_addr_ntop(ip_str, INET6_ADDRSTRLEN, ip);
   return PYSTR_FROMSTR(ip_str);
 }
 
-static PyObject *
-get_pfx_pystr(bgpstream_pfx_t *pfx) {
-  char pfx_str[INET6_ADDRSTRLEN+3] = "";
-  if(bgpstream_pfx_snprintf(pfx_str, INET6_ADDRSTRLEN+3, pfx) == NULL)
+static PyObject *get_pfx_pystr(bgpstream_pfx_t *pfx)
+{
+  char pfx_str[INET6_ADDRSTRLEN + 3] = "";
+  if (bgpstream_pfx_snprintf(pfx_str, INET6_ADDRSTRLEN + 3, pfx) == NULL)
     return NULL;
   return PYSTR_FROMSTR(pfx_str);
 }
 
-static PyObject *
-get_aspath_pystr(bgpstream_as_path_t *aspath) {
+static PyObject *get_aspath_pystr(bgpstream_as_path_t *aspath)
+{
   // assuming 10 char per ASN, then this will hold >400 hops
   char buf[4096] = "";
-  if(bgpstream_as_path_snprintf(buf, 4096, aspath) >= 4096)
+  if (bgpstream_as_path_snprintf(buf, 4096, aspath) >= 4096)
     return NULL;
   return PYSTR_FROMSTR(buf);
 }
 
-static PyObject *
-get_communities_pylist(bgpstream_community_set_t *communities) {
+static PyObject *get_communities_pylist(bgpstream_community_set_t *communities)
+{
 
   PyObject *list;
   bgpstream_community_t *c;
   Py_ssize_t len = bgpstream_community_set_size(communities);
   int i;
   /* create the dictionary */
-  if((list = PyList_New(len)) == NULL)
+  if ((list = PyList_New(len)) == NULL)
     return NULL;
-  
+
   PyObject *dict;
 
-  for(i = 0; i< len; i++)
-    {
-      c = bgpstream_community_set_get(communities, i);
+  for (i = 0; i < len; i++) {
+    c = bgpstream_community_set_get(communities, i);
 
-      /* create the dictionary */
-      if((dict = PyDict_New()) == NULL)
-        return NULL;
-      /* add pair to dictionary */
-      if (add_to_dict(dict, "asn", Py_BuildValue("k", c->asn)) ||
-          add_to_dict(dict, "value", Py_BuildValue("k", c->value))) {
-        return NULL;
-      }
-
-      /* add dictionary to list*/
-      PyList_SetItem(list, (Py_ssize_t)i, dict);
+    /* create the dictionary */
+    if ((dict = PyDict_New()) == NULL)
+      return NULL;
+    /* add pair to dictionary */
+    if (add_to_dict(dict, "asn", Py_BuildValue("k", c->asn)) ||
+        add_to_dict(dict, "value", Py_BuildValue("k", c->value))) {
+      return NULL;
     }
+
+    /* add dictionary to list*/
+    PyList_SetItem(list, (Py_ssize_t)i, dict);
+  }
   return list;
 }
 
-static PyObject *
-get_peerstate_pystr(bgpstream_elem_peerstate_t state) {
+static PyObject *get_peerstate_pystr(bgpstream_elem_peerstate_t state)
+{
   char buf[128] = "";
-  if(bgpstream_elem_peerstate_snprintf(buf, 128, state) >= 128)
+  if (bgpstream_elem_peerstate_snprintf(buf, 128, state) >= 128)
     return NULL;
   return PYSTR_FROMSTR(buf);
 }
 
-static void
-BGPElem_dealloc(BGPElemObject *self)
+static void BGPElem_dealloc(BGPElemObject *self)
 {
   bgpstream_elem_destroy(self->elem);
-  Py_TYPE(self)->tp_free((PyObject*)self);
+  Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
-static int
-BGPElem_init(BGPElemObject *self,
-	       PyObject *args, PyObject *kwds)
+static int BGPElem_init(BGPElemObject *self, PyObject *args, PyObject *kwds)
 {
   return 0;
 }
 
 /* type */
-static PyObject *
-BGPElem_get_type(BGPElemObject *self, void *closure)
+static PyObject *BGPElem_get_type(BGPElemObject *self, void *closure)
 {
   char buf[128] = "";
-  if(bgpstream_elem_type_snprintf(buf, 128, self->elem->type) >= 128)
+  if (bgpstream_elem_type_snprintf(buf, 128, self->elem->type) >= 128)
     return NULL;
   return PYSTR_FROMSTR(buf);
 }
 
 /* timestamp */
-static PyObject *
-BGPElem_get_time(BGPElemObject *self, void *closure)
+static PyObject *BGPElem_get_time(BGPElemObject *self, void *closure)
 {
   return Py_BuildValue("k", self->elem->timestamp);
 }
@@ -128,151 +122,127 @@ BGPElem_get_time(BGPElemObject *self, void *closure)
 /* peer address */
 /** @todo consider using something like netaddr
     (http://pythonhosted.org/netaddr/) */
-static PyObject *
-BGPElem_get_peer_address(BGPElemObject *self, void *closure)
+static PyObject *BGPElem_get_peer_address(BGPElemObject *self, void *closure)
 {
   return get_ip_pystr((bgpstream_ip_addr_t *)&self->elem->peer_address);
 }
 
 /* peer as number */
-static PyObject *
-BGPElem_get_peer_asn(BGPElemObject *self, void *closure)
+static PyObject *BGPElem_get_peer_asn(BGPElemObject *self, void *closure)
 {
   return Py_BuildValue("k", self->elem->peer_asnumber);
 }
 
-
 /** Type-dependent field dict */
-static PyObject *
-BGPElem_get_fields(BGPElemObject *self, void *closure)
+static PyObject *BGPElem_get_fields(BGPElemObject *self, void *closure)
 {
   PyObject *dict;
 
   /* create the dictionary */
-  if((dict = PyDict_New()) == NULL)
+  if ((dict = PyDict_New()) == NULL)
     return NULL;
 
-  switch(self->elem->type)
-    {
-    case BGPSTREAM_ELEM_TYPE_RIB:
-    case BGPSTREAM_ELEM_TYPE_ANNOUNCEMENT:
-      if (add_to_dict(dict, "next-hop", get_ip_pystr((bgpstream_ip_addr_t *)&self->elem->nexthop)) ||
-          add_to_dict(dict, "as-path", get_aspath_pystr(self->elem->aspath)) ||
-          add_to_dict(dict, "communities", get_communities_pylist(self->elem->communities))) {
-        return NULL;
-      }
-
-      /* FALLTHROUGH */
-
-    case BGPSTREAM_ELEM_TYPE_WITHDRAWAL:
-      if (add_to_dict(dict, "prefix", get_pfx_pystr((bgpstream_pfx_t *)&self->elem->prefix))) {
-        return NULL;
-      }
-      break;
-
-    case BGPSTREAM_ELEM_TYPE_PEERSTATE:
-      if (add_to_dict(dict, "old-state", get_peerstate_pystr(self->elem->old_state)) ||
-          add_to_dict(dict, "new-state", get_peerstate_pystr(self->elem->new_state))) {
-        return NULL;
-      }
-      break;
-
-    case BGPSTREAM_ELEM_TYPE_UNKNOWN:
-    default:
-      break;
+  switch (self->elem->type) {
+  case BGPSTREAM_ELEM_TYPE_RIB:
+  case BGPSTREAM_ELEM_TYPE_ANNOUNCEMENT:
+    if (add_to_dict(
+          dict, "next-hop",
+          get_ip_pystr((bgpstream_ip_addr_t *)&self->elem->nexthop)) ||
+        add_to_dict(dict, "as-path", get_aspath_pystr(self->elem->aspath)) ||
+        add_to_dict(dict, "communities",
+                    get_communities_pylist(self->elem->communities))) {
+      return NULL;
     }
+
+  /* FALLTHROUGH */
+
+  case BGPSTREAM_ELEM_TYPE_WITHDRAWAL:
+    if (add_to_dict(dict, "prefix",
+                    get_pfx_pystr((bgpstream_pfx_t *)&self->elem->prefix))) {
+      return NULL;
+    }
+    break;
+
+  case BGPSTREAM_ELEM_TYPE_PEERSTATE:
+    if (add_to_dict(dict, "old-state",
+                    get_peerstate_pystr(self->elem->old_state)) ||
+        add_to_dict(dict, "new-state",
+                    get_peerstate_pystr(self->elem->new_state))) {
+      return NULL;
+    }
+    break;
+
+  case BGPSTREAM_ELEM_TYPE_UNKNOWN:
+  default:
+    break;
+  }
 
   return Py_BuildValue("N", dict);
 }
 
 static PyMethodDef BGPElem_methods[] = {
-  {NULL}  /* Sentinel */
+  {NULL} /* Sentinel */
 };
 
 static PyGetSetDef BGPElem_getsetters[] = {
 
   /* type */
-  {
-    "type",
-    (getter)BGPElem_get_type, NULL,
-    "Type",
-    NULL
-  },
+  {"type", (getter)BGPElem_get_type, NULL, "Type", NULL},
 
   /* timestamp */
-  {
-    "time",
-    (getter)BGPElem_get_time, NULL,
-    "Time",
-    NULL
-  },
+  {"time", (getter)BGPElem_get_time, NULL, "Time", NULL},
 
   /* Peer Address */
-  {
-    "peer_address",
-    (getter)BGPElem_get_peer_address, NULL,
-    "Peer IP Address",
-    NULL
-  },
+  {"peer_address", (getter)BGPElem_get_peer_address, NULL, "Peer IP Address",
+   NULL},
 
   /* peer ASN */
-  {
-    "peer_asn",
-    (getter)BGPElem_get_peer_asn, NULL,
-    "Peer ASN",
-    NULL
-  },
+  {"peer_asn", (getter)BGPElem_get_peer_asn, NULL, "Peer ASN", NULL},
 
   /* Type-Specific Fields */
-  {
-    "fields",
-    (getter)BGPElem_get_fields, NULL,
-    "Type-Specific Fields",
-    NULL
-  },
+  {"fields", (getter)BGPElem_get_fields, NULL, "Type-Specific Fields", NULL},
 
   {NULL} /* Sentinel */
 };
 
 static PyTypeObject BGPElemType = {
-  PyVarObject_HEAD_INIT(NULL, 0)
-  "_pybgpstream.BGPElem",             /* tp_name */
-  sizeof(BGPElemObject), /* tp_basicsize */
-  0,                                    /* tp_itemsize */
-  (destructor)BGPElem_dealloc,        /* tp_dealloc */
-  0,                                    /* tp_print */
-  0,                                    /* tp_getattr */
-  0,                                    /* tp_setattr */
-  0,                                    /* tp_compare */
-  0,                                    /* tp_repr */
-  0,                                    /* tp_as_number */
-  0,                                    /* tp_as_sequence */
-  0,                                    /* tp_as_mapping */
-  0,                                    /* tp_hash */
-  0,                                    /* tp_call */
-  0,                                    /* tp_str */
-  0,                                    /* tp_getattro */
-  0,                                    /* tp_setattro */
-  0,                                    /* tp_as_buffer */
-  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
-  BGPElemDocstring,      /* tp_doc */
-  0,		               /* tp_traverse */
-  0,		               /* tp_clear */
-  0,		               /* tp_richcompare */
-  0,		               /* tp_weaklistoffset */
-  0,		               /* tp_iter */
-  0,		               /* tp_iternext */
-  BGPElem_methods,             /* tp_methods */
-  0,             /* tp_members */
-  BGPElem_getsetters,                 /* tp_getset */
-  0,                         /* tp_base */
-  0,                         /* tp_dict */
-  0,                         /* tp_descr_get */
-  0,                         /* tp_descr_set */
-  0,                         /* tp_dictoffset */
-  (initproc)BGPElem_init,  /* tp_init */
-  0,                         /* tp_alloc */
-  0,             /* tp_new */
+  PyVarObject_HEAD_INIT(NULL, 0) "_pybgpstream.BGPElem", /* tp_name */
+  sizeof(BGPElemObject),                                 /* tp_basicsize */
+  0,                                                     /* tp_itemsize */
+  (destructor)BGPElem_dealloc,                           /* tp_dealloc */
+  0,                                                     /* tp_print */
+  0,                                                     /* tp_getattr */
+  0,                                                     /* tp_setattr */
+  0,                                                     /* tp_compare */
+  0,                                                     /* tp_repr */
+  0,                                                     /* tp_as_number */
+  0,                                                     /* tp_as_sequence */
+  0,                                                     /* tp_as_mapping */
+  0,                                                     /* tp_hash */
+  0,                                                     /* tp_call */
+  0,                                                     /* tp_str */
+  0,                                                     /* tp_getattro */
+  0,                                                     /* tp_setattro */
+  0,                                                     /* tp_as_buffer */
+  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,              /* tp_flags */
+  BGPElemDocstring,                                      /* tp_doc */
+  0,                                                     /* tp_traverse */
+  0,                                                     /* tp_clear */
+  0,                                                     /* tp_richcompare */
+  0,                                                     /* tp_weaklistoffset */
+  0,                                                     /* tp_iter */
+  0,                                                     /* tp_iternext */
+  BGPElem_methods,                                       /* tp_methods */
+  0,                                                     /* tp_members */
+  BGPElem_getsetters,                                    /* tp_getset */
+  0,                                                     /* tp_base */
+  0,                                                     /* tp_dict */
+  0,                                                     /* tp_descr_get */
+  0,                                                     /* tp_descr_set */
+  0,                                                     /* tp_dictoffset */
+  (initproc)BGPElem_init,                                /* tp_init */
+  0,                                                     /* tp_alloc */
+  0,                                                     /* tp_new */
 };
 
 PyTypeObject *_pybgpstream_bgpstream_get_BGPElemType()
@@ -286,7 +256,7 @@ PyObject *BGPElem_new(bgpstream_elem_t *elem)
   BGPElemObject *self;
 
   self = (BGPElemObject *)(BGPElemType.tp_alloc(&BGPElemType, 0));
-  if(self == NULL) {
+  if (self == NULL) {
     return NULL;
   }
 
@@ -294,7 +264,7 @@ PyObject *BGPElem_new(bgpstream_elem_t *elem)
     return NULL;
   }
 
-  if(bgpstream_elem_copy(self->elem, elem) == NULL) {
+  if (bgpstream_elem_copy(self->elem, elem) == NULL) {
     Py_DECREF(self);
     return NULL;
   }

--- a/pybgpstream/src/_pybgpstream_bgpelem.h
+++ b/pybgpstream/src/_pybgpstream_bgpelem.h
@@ -31,7 +31,7 @@
 typedef struct {
   PyObject_HEAD
 
-  bgpstream_elem_t *elem;
+    bgpstream_elem_t *elem;
 
 } BGPElemObject;
 

--- a/pybgpstream/src/_pybgpstream_bgprecord.c
+++ b/pybgpstream/src/_pybgpstream_bgprecord.c
@@ -21,37 +21,35 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Python.h>
 #include "pyutils.h"
+#include <Python.h>
 
 #include <bgpstream.h>
 
-#include "_pybgpstream_bgprecord.h"
 #include "_pybgpstream_bgpelem.h"
+#include "_pybgpstream_bgprecord.h"
 
 #define BGPRecordDocstring "BGPRecord object"
 
-static void
-BGPRecord_dealloc(BGPRecordObject *self)
+static void BGPRecord_dealloc(BGPRecordObject *self)
 {
-  if(self->rec != NULL)
-    {
-      bgpstream_record_destroy(self->rec);
-    }
-  Py_TYPE(self)->tp_free((PyObject*)self);
+  if (self->rec != NULL) {
+    bgpstream_record_destroy(self->rec);
+  }
+  Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
-static PyObject *
-BGPRecord_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+static PyObject *BGPRecord_new(PyTypeObject *type, PyObject *args,
+                               PyObject *kwds)
 {
   BGPRecordObject *self;
 
   self = (BGPRecordObject *)type->tp_alloc(type, 0);
-  if(self == NULL) {
+  if (self == NULL) {
     return NULL;
   }
 
-  if((self->rec = bgpstream_record_create()) == NULL) {
+  if ((self->rec = bgpstream_record_create()) == NULL) {
     Py_DECREF(self);
     return NULL;
   }
@@ -59,9 +57,7 @@ BGPRecord_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
   return (PyObject *)self;
 }
 
-static int
-BGPRecord_init(BGPRecordObject *self,
-	       PyObject *args, PyObject *kwds)
+static int BGPRecord_init(BGPRecordObject *self, PyObject *args, PyObject *kwds)
 {
   return 0;
 }
@@ -69,126 +65,115 @@ BGPRecord_init(BGPRecordObject *self,
 /* attributes */
 
 /* project */
-static PyObject *
-BGPRecord_get_project(BGPRecordObject *self, void *closure)
+static PyObject *BGPRecord_get_project(BGPRecordObject *self, void *closure)
 {
   return Py_BuildValue("s", self->rec->attributes.dump_project);
 }
 
 /* collector */
-static PyObject *
-BGPRecord_get_collector(BGPRecordObject *self, void *closure)
+static PyObject *BGPRecord_get_collector(BGPRecordObject *self, void *closure)
 {
   return Py_BuildValue("s", self->rec->attributes.dump_collector);
 }
 
 /* type */
-static PyObject *
-BGPRecord_get_type(BGPRecordObject *self, void *closure)
+static PyObject *BGPRecord_get_type(BGPRecordObject *self, void *closure)
 {
-  switch(self->rec->attributes.dump_type)
-    {
-    case BGPSTREAM_UPDATE:
-      return Py_BuildValue("s", "update");
-      break;
+  switch (self->rec->attributes.dump_type) {
+  case BGPSTREAM_UPDATE:
+    return Py_BuildValue("s", "update");
+    break;
 
-    case BGPSTREAM_RIB:
-      return Py_BuildValue("s", "rib");
-      break;
+  case BGPSTREAM_RIB:
+    return Py_BuildValue("s", "rib");
+    break;
 
-    default:
-      return Py_BuildValue("s", "unknown");
-    }
+  default:
+    return Py_BuildValue("s", "unknown");
+  }
 
   return NULL;
 }
 
 /* dump_time */
-static PyObject *
-BGPRecord_get_dump_time(BGPRecordObject *self, void *closure)
+static PyObject *BGPRecord_get_dump_time(BGPRecordObject *self, void *closure)
 {
   return Py_BuildValue("l", self->rec->attributes.dump_time);
 }
 
 /* record_time */
-static PyObject *
-BGPRecord_get_record_time(BGPRecordObject *self, void *closure)
+static PyObject *BGPRecord_get_record_time(BGPRecordObject *self, void *closure)
 {
   return Py_BuildValue("l", self->rec->attributes.record_time);
 }
 
 /* get status */
-static PyObject *
-BGPRecord_get_status(BGPRecordObject *self, void *closure)
+static PyObject *BGPRecord_get_status(BGPRecordObject *self, void *closure)
 {
-  switch(self->rec->status)
-    {
-    case BGPSTREAM_RECORD_STATUS_VALID_RECORD:
-      return Py_BuildValue("s", "valid");
-      break;
+  switch (self->rec->status) {
+  case BGPSTREAM_RECORD_STATUS_VALID_RECORD:
+    return Py_BuildValue("s", "valid");
+    break;
 
-    case BGPSTREAM_RECORD_STATUS_FILTERED_SOURCE:
-      return Py_BuildValue("s", "filtered-source");
-      break;
+  case BGPSTREAM_RECORD_STATUS_FILTERED_SOURCE:
+    return Py_BuildValue("s", "filtered-source");
+    break;
 
-    case BGPSTREAM_RECORD_STATUS_EMPTY_SOURCE:
-      return Py_BuildValue("s", "empty-source");
-      break;
+  case BGPSTREAM_RECORD_STATUS_EMPTY_SOURCE:
+    return Py_BuildValue("s", "empty-source");
+    break;
 
-    case BGPSTREAM_RECORD_STATUS_CORRUPTED_SOURCE:
-      return Py_BuildValue("s", "corrupted-source");
-      break;
+  case BGPSTREAM_RECORD_STATUS_CORRUPTED_SOURCE:
+    return Py_BuildValue("s", "corrupted-source");
+    break;
 
-    case BGPSTREAM_RECORD_STATUS_CORRUPTED_RECORD:
-      return Py_BuildValue("s", "corrupted-record");
-      break;
+  case BGPSTREAM_RECORD_STATUS_CORRUPTED_RECORD:
+    return Py_BuildValue("s", "corrupted-record");
+    break;
 
-    default:
-      return Py_BuildValue("s", "unknown");
-    }
+  default:
+    return Py_BuildValue("s", "unknown");
+  }
 
   return NULL;
 }
 
 /* get dump position */
-static PyObject *
-BGPRecord_get_dump_position(BGPRecordObject *self, void *closure)
+static PyObject *BGPRecord_get_dump_position(BGPRecordObject *self,
+                                             void *closure)
 {
-  switch(self->rec->dump_pos)
-    {
-    case BGPSTREAM_DUMP_START:
-      return Py_BuildValue("s", "start");
-      break;
+  switch (self->rec->dump_pos) {
+  case BGPSTREAM_DUMP_START:
+    return Py_BuildValue("s", "start");
+    break;
 
-    case BGPSTREAM_DUMP_MIDDLE:
-      return Py_BuildValue("s", "middle");
-      break;
+  case BGPSTREAM_DUMP_MIDDLE:
+    return Py_BuildValue("s", "middle");
+    break;
 
-    case BGPSTREAM_DUMP_END:
-      return Py_BuildValue("s", "end");
-      break;
+  case BGPSTREAM_DUMP_END:
+    return Py_BuildValue("s", "end");
+    break;
 
-    default:
-      return Py_BuildValue("s", "unknown");
-    }
+  default:
+    return Py_BuildValue("s", "unknown");
+  }
 
   return NULL;
 }
 
 /* get next elem */
-static PyObject *
-BGPRecord_get_next_elem(BGPRecordObject *self)
+static PyObject *BGPRecord_get_next_elem(BGPRecordObject *self)
 {
   bgpstream_elem_t *elem;
 
   PyObject *pyelem;
 
-  if((elem = bgpstream_record_get_next_elem(self->rec)) == NULL)
+  if ((elem = bgpstream_record_get_next_elem(self->rec)) == NULL)
     Py_RETURN_NONE;
 
-  if((pyelem = BGPElem_new(elem)) == NULL) {
-    PyErr_SetString(PyExc_RuntimeError,
-                    "Could not create BGPElem object");
+  if ((pyelem = BGPElem_new(elem)) == NULL) {
+    PyErr_SetString(PyExc_RuntimeError, "Could not create BGPElem object");
     return NULL;
   }
 
@@ -197,116 +182,77 @@ BGPRecord_get_next_elem(BGPRecordObject *self)
 
 static PyMethodDef BGPRecord_methods[] = {
 
-  {
-    "get_next_elem",
-    (PyCFunction)BGPRecord_get_next_elem,
-    METH_NOARGS,
-    "Get next BGP Elem from the Record"
-  },
+  {"get_next_elem", (PyCFunction)BGPRecord_get_next_elem, METH_NOARGS,
+   "Get next BGP Elem from the Record"},
 
-  {NULL}  /* Sentinel */
+  {NULL} /* Sentinel */
 };
 
 static PyGetSetDef BGPRecord_getsetters[] = {
 
   /* attributes.dump_project */
-  {
-    "project",
-    (getter)BGPRecord_get_project, NULL,
-    "Dump Project",
-    NULL
-  },
+  {"project", (getter)BGPRecord_get_project, NULL, "Dump Project", NULL},
 
   /* attributes.dump_collector */
-  {
-    "collector",
-    (getter)BGPRecord_get_collector, NULL,
-    "Dump Collector",
-    NULL
-  },
+  {"collector", (getter)BGPRecord_get_collector, NULL, "Dump Collector", NULL},
 
   /* attributes.dump_type */
-  {
-    "type",
-    (getter)BGPRecord_get_type, NULL,
-    "Dump Type",
-    NULL
-  },
+  {"type", (getter)BGPRecord_get_type, NULL, "Dump Type", NULL},
 
   /* attributes.dump_time */
-  {
-    "dump_time",
-    (getter)BGPRecord_get_dump_time, NULL,
-    "Dump Time",
-    NULL
-  },
+  {"dump_time", (getter)BGPRecord_get_dump_time, NULL, "Dump Time", NULL},
 
   /* attributes.record_time */
-  {
-    "time",
-    (getter)BGPRecord_get_record_time, NULL,
-    "Record Time",
-    NULL
-  },
+  {"time", (getter)BGPRecord_get_record_time, NULL, "Record Time", NULL},
 
   /* status */
-  {
-    "status",
-    (getter)BGPRecord_get_status, NULL,
-    "Status",
-    NULL
-  },
+  {"status", (getter)BGPRecord_get_status, NULL, "Status", NULL},
 
   /* attributes.dump_position */
-  {
-    "dump_position",
-    (getter)BGPRecord_get_dump_position, NULL,
-    "Dump Position",
-    NULL
-  },
+  {"dump_position", (getter)BGPRecord_get_dump_position, NULL, "Dump Position",
+   NULL},
 
   {NULL} /* Sentinel */
 };
 
 static PyTypeObject BGPRecordType = {
-  PyVarObject_HEAD_INIT(NULL, 0)
-  "_pybgpstream.BGPRecord",             /* tp_name */
-  sizeof(BGPRecordObject), /* tp_basicsize */
-  0,                                    /* tp_itemsize */
-  (destructor)BGPRecord_dealloc,        /* tp_dealloc */
-  0,                                    /* tp_print */
-  0,                                    /* tp_getattr */
-  0,                                    /* tp_setattr */
-  0,                                    /* tp_compare */
-  0,                                    /* tp_repr */
-  0,                                    /* tp_as_number */
-  0,                                    /* tp_as_sequence */
-  0,                                    /* tp_as_mapping */
-  0,                                    /* tp_hash */
-  0,                                    /* tp_call */
-  0,                                    /* tp_str */
-  0,                                    /* tp_getattro */
-  0,                                    /* tp_setattro */
-  0,                                    /* tp_as_buffer */
-  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
-  BGPRecordDocstring,      /* tp_doc */
-  0,		               /* tp_traverse */
-  0,		               /* tp_clear */
-  0,		               /* tp_richcompare */
-  0,		               /* tp_weaklistoffset */
-  0,		               /* tp_iter */
-  0,		               /* tp_iternext */
-  BGPRecord_methods,             /* tp_methods */
-  0,             /* tp_members */
-  BGPRecord_getsetters,                 /* tp_getset */
-  0,                         /* tp_base */
-  0,                         /* tp_dict */
-  0,                         /* tp_descr_get */
-  0,                         /* tp_descr_set */
-  0,                         /* tp_dictoffset */
-  (initproc)BGPRecord_init,  /* tp_init */
-  0,                         /* tp_alloc */
-  BGPRecord_new,             /* tp_new */
+  PyVarObject_HEAD_INIT(NULL, 0) "_pybgpstream.BGPRecord", /* tp_name */
+  sizeof(BGPRecordObject),                                 /* tp_basicsize */
+  0,                                                       /* tp_itemsize */
+  (destructor)BGPRecord_dealloc,                           /* tp_dealloc */
+  0,                                                       /* tp_print */
+  0,                                                       /* tp_getattr */
+  0,                                                       /* tp_setattr */
+  0,                                                       /* tp_compare */
+  0,                                                       /* tp_repr */
+  0,                                                       /* tp_as_number */
+  0,                                                       /* tp_as_sequence */
+  0,                                                       /* tp_as_mapping */
+  0,                                                       /* tp_hash */
+  0,                                                       /* tp_call */
+  0,                                                       /* tp_str */
+  0,                                                       /* tp_getattro */
+  0,                                                       /* tp_setattro */
+  0,                                                       /* tp_as_buffer */
+  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,                /* tp_flags */
+  BGPRecordDocstring,                                      /* tp_doc */
+  0,                                                       /* tp_traverse */
+  0,                                                       /* tp_clear */
+  0,                                                       /* tp_richcompare */
+  0,                        /* tp_weaklistoffset */
+  0,                        /* tp_iter */
+  0,                        /* tp_iternext */
+  BGPRecord_methods,        /* tp_methods */
+  0,                        /* tp_members */
+  BGPRecord_getsetters,     /* tp_getset */
+  0,                        /* tp_base */
+  0,                        /* tp_dict */
+  0,                        /* tp_descr_get */
+  0,                        /* tp_descr_set */
+  0,                        /* tp_dictoffset */
+  (initproc)BGPRecord_init, /* tp_init */
+  0,                        /* tp_alloc */
+  BGPRecord_new,            /* tp_new */
 };
 
 PyTypeObject *_pybgpstream_bgpstream_get_BGPRecordType()

--- a/pybgpstream/src/_pybgpstream_bgprecord.h
+++ b/pybgpstream/src/_pybgpstream_bgprecord.h
@@ -31,8 +31,8 @@
 typedef struct {
   PyObject_HEAD
 
-  /* BGP Stream Record instance Handle */
-  bgpstream_record_t *rec;
+    /* BGP Stream Record instance Handle */
+    bgpstream_record_t *rec;
 
 } BGPRecordObject;
 

--- a/pybgpstream/src/_pybgpstream_bgpstream.c
+++ b/pybgpstream/src/_pybgpstream_bgpstream.c
@@ -20,8 +20,8 @@
  * You should have received a copy of the GNU General Public License along with
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <Python.h>
 #include "pyutils.h"
+#include <Python.h>
 
 #include <bgpstream.h>
 
@@ -30,64 +30,51 @@
 typedef struct {
   PyObject_HEAD
 
-  /* BGP Stream Instance Handle */
-  bgpstream_t *bs;
+    /* BGP Stream Instance Handle */
+    bgpstream_t *bs;
 } BGPStreamObject;
 
 #define BGPStreamDocstring "BGPStream object"
 
-
-static void
-BGPStream_dealloc(BGPStreamObject *self)
+static void BGPStream_dealloc(BGPStreamObject *self)
 {
-  if(self->bs != NULL)
-    {
-      bgpstream_stop(self->bs);
-      bgpstream_destroy(self->bs);
-    }
-  Py_TYPE(self)->tp_free((PyObject*)self);
+  if (self->bs != NULL) {
+    bgpstream_stop(self->bs);
+    bgpstream_destroy(self->bs);
+  }
+  Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
-static PyObject *
-BGPStream_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+static PyObject *BGPStream_new(PyTypeObject *type, PyObject *args,
+                               PyObject *kwds)
 {
   BGPStreamObject *self;
 
   self = (BGPStreamObject *)type->tp_alloc(type, 0);
-  if(self == NULL) {
+  if (self == NULL) {
     return NULL;
   }
 
-  if ((self->bs = bgpstream_create()) == NULL)
-    {
-      Py_DECREF(self);
-      return NULL;
-    }
+  if ((self->bs = bgpstream_create()) == NULL) {
+    Py_DECREF(self);
+    return NULL;
+  }
 
   return (PyObject *)self;
 }
 
-static int
-BGPStream_init(BGPStreamObject *self,
-	       PyObject *args, PyObject *kwds)
+static int BGPStream_init(BGPStreamObject *self, PyObject *args, PyObject *kwds)
 {
   return 0;
 }
 
 /** Add a filter to the bgpstream. */
-static PyObject *
-BGPStream_add_filter(BGPStreamObject *self, PyObject *args)
+static PyObject *BGPStream_add_filter(BGPStreamObject *self, PyObject *args)
 {
   /* args: FILTER_TYPE (string), FILTER_VALUE (string) */
-  static char *filtertype_strs[] = {
-    "project",
-    "collector",
-    "record-type",
-    "peer-asn",
-    "prefix",
-    "community",
-    NULL
-  };
+  static char *filtertype_strs[] = {"project",  "collector", "record-type",
+                                    "peer-asn", "prefix",    "community",
+                                    NULL};
   static int filtertype_vals[] = {
     BGPSTREAM_FILTER_TYPE_PROJECT,
     BGPSTREAM_FILTER_TYPE_COLLECTOR,
@@ -106,15 +93,15 @@ BGPStream_add_filter(BGPStreamObject *self, PyObject *args)
 
   int i;
   int filter_val = -1;
-  for (i=0; filtertype_strs[i] != NULL; i++) {
+  for (i = 0; filtertype_strs[i] != NULL; i++) {
     if (strcmp(filtertype_strs[i], filter_type) == 0) {
       filter_val = filtertype_vals[i];
       break;
     }
   }
   if (filter_val == -1) {
-    return PyErr_Format(PyExc_ValueError,
-			"Invalid filter type: %s", filter_type);
+    return PyErr_Format(PyExc_ValueError, "Invalid filter type: %s",
+                        filter_type);
   }
 
   bgpstream_add_filter(self->bs, filter_val, value);
@@ -122,10 +109,9 @@ BGPStream_add_filter(BGPStreamObject *self, PyObject *args)
   Py_RETURN_NONE;
 }
 
-
 /** Add a rib period filter to the bgpstream. */
-static PyObject *
-BGPStream_add_rib_period_filter(BGPStreamObject *self, PyObject *args)
+static PyObject *BGPStream_add_rib_period_filter(BGPStreamObject *self,
+                                                 PyObject *args)
 {
   /* args: period (int) */
 
@@ -140,8 +126,8 @@ BGPStream_add_rib_period_filter(BGPStreamObject *self, PyObject *args)
 }
 
 /** Add a time filter to the bgpstream. */
-static PyObject *
-BGPStream_add_interval_filter(BGPStreamObject *self, PyObject *args)
+static PyObject *BGPStream_add_interval_filter(BGPStreamObject *self,
+                                               PyObject *args)
 {
   /* args: from (int), until (int) */
 
@@ -156,8 +142,7 @@ BGPStream_add_interval_filter(BGPStreamObject *self, PyObject *args)
 }
 
 /** Get information about available data interfaces */
-static PyObject *
-BGPStream_get_data_interfaces(BGPStreamObject *self)
+static PyObject *BGPStream_get_data_interfaces(BGPStreamObject *self)
 {
   PyObject *list;
   PyObject *dict;
@@ -170,16 +155,16 @@ BGPStream_get_data_interfaces(BGPStreamObject *self)
   id_cnt = bgpstream_get_data_interfaces(self->bs, &ids);
 
   /* create the list */
-  if((list = PyList_New(0)) == NULL)
+  if ((list = PyList_New(0)) == NULL)
     return NULL;
 
-  for(i=0; i<id_cnt; i++) {
+  for (i = 0; i < id_cnt; i++) {
     /* create the dictionary */
-    if((dict = PyDict_New()) == NULL)
+    if ((dict = PyDict_New()) == NULL)
       return NULL;
 
     info = bgpstream_get_data_interface_info(self->bs, ids[i]);
-    if(info == NULL) {
+    if (info == NULL) {
       /* this data interface is not available */
       continue;
     }
@@ -189,11 +174,11 @@ BGPStream_get_data_interfaces(BGPStreamObject *self)
     if (add_to_dict(dict, "id", PYNUM_FROMLONG(ids[i])) ||
         add_to_dict(dict, "name", PYSTR_FROMSTR(info->name)) ||
         add_to_dict(dict, "description", PYSTR_FROMSTR(info->description))) {
-        return NULL;
+      return NULL;
     }
 
     /* add dict to list */
-    if(PyList_Append(list, dict) == -1)
+    if (PyList_Append(list, dict) == -1)
       return NULL;
     Py_DECREF(dict);
   }
@@ -202,8 +187,8 @@ BGPStream_get_data_interfaces(BGPStreamObject *self)
 }
 
 /** Set the data interface */
-static PyObject *
-BGPStream_set_data_interface(BGPStreamObject *self, PyObject *args)
+static PyObject *BGPStream_set_data_interface(BGPStreamObject *self,
+                                              PyObject *args)
 {
   const char *name;
   if (!PyArg_ParseTuple(args, "s", &name)) {
@@ -211,9 +196,8 @@ BGPStream_set_data_interface(BGPStreamObject *self, PyObject *args)
   }
 
   int id;
-  if((id = bgpstream_get_data_interface_id_by_name(self->bs, name)) == 0) {
-    return PyErr_Format(PyExc_ValueError,
-			"Invalid data interface: %s", name);
+  if ((id = bgpstream_get_data_interface_id_by_name(self->bs, name)) == 0) {
+    return PyErr_Format(PyExc_ValueError, "Invalid data interface: %s", name);
   }
   bgpstream_set_data_interface(self->bs, id);
 
@@ -222,8 +206,8 @@ BGPStream_set_data_interface(BGPStreamObject *self, PyObject *args)
 
 /** Get the list of interface options that are available for the given
     interface */
-static PyObject *
-BGPStream_get_data_interface_options(BGPStreamObject *self, PyObject *args)
+static PyObject *BGPStream_get_data_interface_options(BGPStreamObject *self,
+                                                      PyObject *args)
 {
   const char *name;
   if (!PyArg_ParseTuple(args, "s", &name)) {
@@ -231,9 +215,8 @@ BGPStream_get_data_interface_options(BGPStreamObject *self, PyObject *args)
   }
 
   int id;
-  if((id = bgpstream_get_data_interface_id_by_name(self->bs, name)) == 0) {
-    return PyErr_Format(PyExc_ValueError,
-			"Invalid data interface: %s", name);
+  if ((id = bgpstream_get_data_interface_id_by_name(self->bs, name)) == 0) {
+    return PyErr_Format(PyExc_ValueError, "Invalid data interface: %s", name);
   }
 
   int opt_cnt = 0;
@@ -242,23 +225,24 @@ BGPStream_get_data_interface_options(BGPStreamObject *self, PyObject *args)
 
   /* create the list */
   PyObject *list;
-  if((list = PyList_New(0)) == NULL)
+  if ((list = PyList_New(0)) == NULL)
     return NULL;
 
   int i;
   PyObject *dict;
-  for(i=0; i<opt_cnt; i++) {
+  for (i = 0; i < opt_cnt; i++) {
     /* create the dictionary */
-    if((dict = PyDict_New()) == NULL)
+    if ((dict = PyDict_New()) == NULL)
       return NULL;
 
-    if (add_to_dict(dict, "name", PYSTR_FROMSTR(options[i].name)) || 
-        add_to_dict(dict, "description", PYSTR_FROMSTR(options[i].description))) {
-        return NULL;
+    if (add_to_dict(dict, "name", PYSTR_FROMSTR(options[i].name)) ||
+        add_to_dict(dict, "description",
+                    PYSTR_FROMSTR(options[i].description))) {
+      return NULL;
     }
 
     /* add dict to list */
-    if(PyList_Append(list, dict) == -1)
+    if (PyList_Append(list, dict) == -1)
       return NULL;
     Py_DECREF(dict);
   }
@@ -267,31 +251,29 @@ BGPStream_get_data_interface_options(BGPStreamObject *self, PyObject *args)
 }
 
 /** Set a data interface option (takes interface, opt-name, opt-val) */
-static PyObject *
-BGPStream_set_data_interface_option(BGPStreamObject *self, PyObject *args)
+static PyObject *BGPStream_set_data_interface_option(BGPStreamObject *self,
+                                                     PyObject *args)
 {
   const char *interface_name;
   const char *opt_name;
   const char *opt_value;
 
-  if(!PyArg_ParseTuple(args, "sss", &interface_name, &opt_name, &opt_value)) {
+  if (!PyArg_ParseTuple(args, "sss", &interface_name, &opt_name, &opt_value)) {
     return NULL;
   }
 
   int id;
-  if((id =
-      bgpstream_get_data_interface_id_by_name(self->bs, interface_name)) == 0) {
-    return PyErr_Format(PyExc_ValueError,
-			"Invalid data interface: %s", interface_name);
+  if ((id = bgpstream_get_data_interface_id_by_name(self->bs,
+                                                    interface_name)) == 0) {
+    return PyErr_Format(PyExc_ValueError, "Invalid data interface: %s",
+                        interface_name);
   }
 
   bgpstream_data_interface_option_t *opt;
-  if((opt =
-      bgpstream_get_data_interface_option_by_name(self->bs,
-                                                  id,
-                                                  opt_name)) == NULL) {
-    return PyErr_Format(PyExc_ValueError,
-			"Invalid data interface option: %s", opt_name);
+  if ((opt = bgpstream_get_data_interface_option_by_name(self->bs, id,
+                                                         opt_name)) == NULL) {
+    return PyErr_Format(PyExc_ValueError, "Invalid data interface option: %s",
+                        opt_name);
   }
 
   bgpstream_set_data_interface_option(self->bs, opt, opt_value);
@@ -300,8 +282,7 @@ BGPStream_set_data_interface_option(BGPStreamObject *self, PyObject *args)
 }
 
 /** Enable blocking mode */
-static PyObject *
-BGPStream_set_live_mode(BGPStreamObject *self)
+static PyObject *BGPStream_set_live_mode(BGPStreamObject *self)
 {
   bgpstream_set_live_mode(self->bs);
   Py_RETURN_NONE;
@@ -312,8 +293,7 @@ BGPStream_set_live_mode(BGPStreamObject *self)
  * Corresponds to bgpstream_init (so as not to be confused with Python's
  * __init__ method)
  */
-static PyObject *
-BGPStream_start(BGPStreamObject *self)
+static PyObject *BGPStream_start(BGPStreamObject *self)
 {
   if (bgpstream_start(self->bs) < 0) {
     PyErr_SetString(PyExc_RuntimeError, "Could not start stream");
@@ -322,17 +302,15 @@ BGPStream_start(BGPStreamObject *self)
   Py_RETURN_NONE;
 }
 
-
 /** Corresponds to bgpstream_get_next_record */
-static PyObject *
-BGPStream_get_next_record(BGPStreamObject *self, PyObject *args)
+static PyObject *BGPStream_get_next_record(BGPStreamObject *self,
+                                           PyObject *args)
 {
   BGPRecordObject *pyrec = NULL;
   int ret;
 
   /* get the BGPRecord argument */
-  if (!PyArg_ParseTuple(args, "O!",
-                        _pybgpstream_bgpstream_get_BGPRecordType(),
+  if (!PyArg_ParseTuple(args, "O!", _pybgpstream_bgpstream_get_BGPRecordType(),
                         &pyrec)) {
     return NULL;
   }
@@ -346,7 +324,7 @@ BGPStream_get_next_record(BGPStreamObject *self, PyObject *args)
 
   if (ret < 0) {
     PyErr_SetString(PyExc_RuntimeError,
-		    "Could not get next record (is the stream started?)");
+                    "Could not get next record (is the stream started?)");
     return NULL;
   } else if (ret == 0) {
     /* end of stream */
@@ -357,114 +335,76 @@ BGPStream_get_next_record(BGPStreamObject *self, PyObject *args)
 }
 
 static PyMethodDef BGPStream_methods[] = {
-  {
-    "add_filter",
-    (PyCFunction)BGPStream_add_filter,
-    METH_VARARGS,
-    "Add a filter to an un-started stream."
-  },
+  {"add_filter", (PyCFunction)BGPStream_add_filter, METH_VARARGS,
+   "Add a filter to an un-started stream."},
 
-  {
-    "add_rib_period_filter",
-    (PyCFunction)BGPStream_add_rib_period_filter,
-    METH_VARARGS,
-    "Set the RIB period filter for the current stream."
-  },
+  {"add_rib_period_filter", (PyCFunction)BGPStream_add_rib_period_filter,
+   METH_VARARGS, "Set the RIB period filter for the current stream."},
 
+  {"add_interval_filter", (PyCFunction)BGPStream_add_interval_filter,
+   METH_VARARGS, "Add an interval filter to an un-started stream."},
   {
-    "add_interval_filter",
-    (PyCFunction)BGPStream_add_interval_filter,
-    METH_VARARGS,
-   "Add an interval filter to an un-started stream."
+    "get_data_interfaces", (PyCFunction)BGPStream_get_data_interfaces,
+    METH_NOARGS, "Get a list of data interfaces available",
   },
-  {
-    "get_data_interfaces",
-    (PyCFunction)BGPStream_get_data_interfaces,
-    METH_NOARGS,
-    "Get a list of data interfaces available",
-  },
-  {
-    "set_data_interface",
-    (PyCFunction)BGPStream_set_data_interface,
-    METH_VARARGS,
-    "Set the data interface used to discover dump files"
-  },
-  {
-    "get_data_interface_options",
-    (PyCFunction)BGPStream_get_data_interface_options,
-    METH_VARARGS,
-    "Get a list of options available for the given data interface"
-  },
-  {
-    "set_data_interface_option",
-    (PyCFunction)BGPStream_set_data_interface_option,
-    METH_VARARGS,
-    "Set a data interface option"
-  },
-  {
-    "set_live_mode",
-    (PyCFunction)BGPStream_set_live_mode,
-    METH_NOARGS,
-    "Enable live mode"
-  },
+  {"set_data_interface", (PyCFunction)BGPStream_set_data_interface,
+   METH_VARARGS, "Set the data interface used to discover dump files"},
+  {"get_data_interface_options",
+   (PyCFunction)BGPStream_get_data_interface_options, METH_VARARGS,
+   "Get a list of options available for the given data interface"},
+  {"set_data_interface_option",
+   (PyCFunction)BGPStream_set_data_interface_option, METH_VARARGS,
+   "Set a data interface option"},
+  {"set_live_mode", (PyCFunction)BGPStream_set_live_mode, METH_NOARGS,
+   "Enable live mode"},
 
-  {
-    "start",
-   (PyCFunction)BGPStream_start,
-   METH_NOARGS,
-   "Start the BGPStream."
-  },
+  {"start", (PyCFunction)BGPStream_start, METH_NOARGS, "Start the BGPStream."},
 
-  {
-    "get_next_record",
-    (PyCFunction)BGPStream_get_next_record,
-    METH_VARARGS,
-    "Get the next BGPStreamRecord from the stream, or None if end-of-stream "
-    "has been reached"
-  },
+  {"get_next_record", (PyCFunction)BGPStream_get_next_record, METH_VARARGS,
+   "Get the next BGPStreamRecord from the stream, or None if end-of-stream "
+   "has been reached"},
 
-  {NULL}  /* Sentinel */
+  {NULL} /* Sentinel */
 };
 
 static PyTypeObject BGPStreamType = {
-  PyVarObject_HEAD_INIT(NULL, 0)
-  "_pybgpstream.BGPStream",             /* tp_name */
-  sizeof(BGPStreamObject), /* tp_basicsize */
-  0,                                    /* tp_itemsize */
-  (destructor)BGPStream_dealloc,        /* tp_dealloc */
-  0,                                    /* tp_print */
-  0,                                    /* tp_getattr */
-  0,                                    /* tp_setattr */
-  0,                                    /* tp_compare */
-  0,                                    /* tp_repr */
-  0,                                    /* tp_as_number */
-  0,                                    /* tp_as_sequence */
-  0,                                    /* tp_as_mapping */
-  0,                                    /* tp_hash */
-  0,                                    /* tp_call */
-  0,                                    /* tp_str */
-  0,                                    /* tp_getattro */
-  0,                                    /* tp_setattro */
-  0,                                    /* tp_as_buffer */
-  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
-  BGPStreamDocstring,      /* tp_doc */
-  0,		               /* tp_traverse */
-  0,		               /* tp_clear */
-  0,		               /* tp_richcompare */
-  0,		               /* tp_weaklistoffset */
-  0,		               /* tp_iter */
-  0,		               /* tp_iternext */
-  BGPStream_methods,             /* tp_methods */
-  0,             /* tp_members */
-  0,                         /* tp_getset */
-  0,                         /* tp_base */
-  0,                         /* tp_dict */
-  0,                         /* tp_descr_get */
-  0,                         /* tp_descr_set */
-  0,                         /* tp_dictoffset */
-  (initproc)BGPStream_init,  /* tp_init */
-  0,                         /* tp_alloc */
-  BGPStream_new,             /* tp_new */
+  PyVarObject_HEAD_INIT(NULL, 0) "_pybgpstream.BGPStream", /* tp_name */
+  sizeof(BGPStreamObject),                                 /* tp_basicsize */
+  0,                                                       /* tp_itemsize */
+  (destructor)BGPStream_dealloc,                           /* tp_dealloc */
+  0,                                                       /* tp_print */
+  0,                                                       /* tp_getattr */
+  0,                                                       /* tp_setattr */
+  0,                                                       /* tp_compare */
+  0,                                                       /* tp_repr */
+  0,                                                       /* tp_as_number */
+  0,                                                       /* tp_as_sequence */
+  0,                                                       /* tp_as_mapping */
+  0,                                                       /* tp_hash */
+  0,                                                       /* tp_call */
+  0,                                                       /* tp_str */
+  0,                                                       /* tp_getattro */
+  0,                                                       /* tp_setattro */
+  0,                                                       /* tp_as_buffer */
+  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,                /* tp_flags */
+  BGPStreamDocstring,                                      /* tp_doc */
+  0,                                                       /* tp_traverse */
+  0,                                                       /* tp_clear */
+  0,                                                       /* tp_richcompare */
+  0,                        /* tp_weaklistoffset */
+  0,                        /* tp_iter */
+  0,                        /* tp_iternext */
+  BGPStream_methods,        /* tp_methods */
+  0,                        /* tp_members */
+  0,                        /* tp_getset */
+  0,                        /* tp_base */
+  0,                        /* tp_dict */
+  0,                        /* tp_descr_get */
+  0,                        /* tp_descr_set */
+  0,                        /* tp_dictoffset */
+  (initproc)BGPStream_init, /* tp_init */
+  0,                        /* tp_alloc */
+  BGPStream_new,            /* tp_new */
 };
 
 PyTypeObject *_pybgpstream_bgpstream_get_BGPStreamType()

--- a/pybgpstream/src/_pybgpstream_module.c
+++ b/pybgpstream/src/_pybgpstream_module.c
@@ -23,41 +23,42 @@
 
 #include <Python.h>
 
-#include "_pybgpstream_bgpstream.h"
-#include "_pybgpstream_bgprecord.h"
 #include "_pybgpstream_bgpelem.h"
+#include "_pybgpstream_bgprecord.h"
+#include "_pybgpstream_bgpstream.h"
 
 static PyMethodDef module_methods[] = {
-    {NULL}  /* Sentinel */
+  {NULL} /* Sentinel */
 };
 
-#define ADD_OBJECT(objname)                                             \
-  do {                                                                  \
-    if ((obj = _pybgpstream_bgpstream_get_##objname##Type()) == NULL)   \
-      return NULL;                                                      \
-    if (PyType_Ready(obj) < 0)                                          \
-      return NULL;                                                      \
-    Py_INCREF(obj);                                                     \
-    PyModule_AddObject(m, #objname, (PyObject*)obj);         \
-  } while(0)
+#define ADD_OBJECT(objname)                                                    \
+  do {                                                                         \
+    if ((obj = _pybgpstream_bgpstream_get_##objname##Type()) == NULL)          \
+      return NULL;                                                             \
+    if (PyType_Ready(obj) < 0)                                                 \
+      return NULL;                                                             \
+    Py_INCREF(obj);                                                            \
+    PyModule_AddObject(m, #objname, (PyObject *)obj);                          \
+  } while (0)
 
-#define MODULE_DOCSTRING "Module that provides a low-level interface to libbgpstream"
+#define MODULE_DOCSTRING                                                       \
+  "Module that provides a low-level interface to libbgpstream"
 
 #if PY_MAJOR_VERSION > 2
 static struct PyModuleDef module_def = {
-	PyModuleDef_HEAD_INIT,
-	"_pybgpstream",
-	MODULE_DOCSTRING,
-	-1,
-	module_methods,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
+  PyModuleDef_HEAD_INIT,
+  "_pybgpstream",
+  MODULE_DOCSTRING,
+  -1,
+  module_methods,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
 };
 #endif
 
-#ifndef PyMODINIT_FUNC	/* declarations for DLL import/export */
+#ifndef PyMODINIT_FUNC /* declarations for DLL import/export */
 #define PyMODINIT_FUNC void
 #endif
 
@@ -69,9 +70,7 @@ static PyObject *moduleinit(void)
 #if PY_MAJOR_VERSION > 2
   m = PyModule_Create(&module_def);
 #else
-  m = Py_InitModule3("_pybgpstream",
-					 module_methods,
-					 MODULE_DOCSTRING);
+  m = Py_InitModule3("_pybgpstream", module_methods, MODULE_DOCSTRING);
 #endif
 
   if (m == NULL)
@@ -90,14 +89,12 @@ static PyObject *moduleinit(void)
 }
 
 #if PY_MAJOR_VERSION > 2
-PyMODINIT_FUNC
-PyInit__pybgpstream(void)
+PyMODINIT_FUNC PyInit__pybgpstream(void)
 {
   return moduleinit();
 }
 #else
-PyMODINIT_FUNC
-init_pybgpstream(void)
+PyMODINIT_FUNC init_pybgpstream(void)
 {
   moduleinit();
 }

--- a/pybgpstream/src/pyutils.h
+++ b/pybgpstream/src/pyutils.h
@@ -2,8 +2,7 @@
 #define ___PYUTILS_H
 
 #ifndef PyVarObject_HEAD_INIT
-#define PyVarObject_HEAD_INIT(type, size) \
-	PyObject_HEAD_INIT(type) size,
+#define PyVarObject_HEAD_INIT(type, size) PyObject_HEAD_INIT(type) size,
 #endif
 
 #if PY_MAJOR_VERSION > 2
@@ -13,7 +12,7 @@
 #endif
 
 #ifndef Py_TYPE
-#define Py_TYPE(ob) (((PyObject*)(ob))->ob_type)
+#define Py_TYPE(ob) (((PyObject *)(ob))->ob_type)
 #endif
 
 #if PY_MAJOR_VERSION > 2
@@ -24,14 +23,14 @@
 #define PYNUM_FROMLONG(num) PyInt_FromLong(num)
 #endif
 
-static inline int
-add_to_dict(PyObject* dict, const char* key_str, PyObject* value)
+static inline int add_to_dict(PyObject *dict, const char *key_str,
+                              PyObject *value)
 {
-    PyObject *key = PYSTR_FROMSTR(key_str);
-    int err = PyDict_SetItem(dict, key, value);
-    Py_DECREF(key);
-    Py_DECREF(value);
-    return err;
+  PyObject *key = PYSTR_FROMSTR(key_str);
+  int err = PyDict_SetItem(dict, key, value);
+  Py_DECREF(key);
+  Py_DECREF(value);
+  return err;
 }
 
 #endif

--- a/test/bgpstream-test-filters.c
+++ b/test/bgpstream-test-filters.c
@@ -28,7 +28,6 @@
 #include <string.h>
 #include <wandio.h>
 
-
 bgpstream_t *bs;
 bgpstream_record_t *rec;
 bgpstream_elem_t *elem;
@@ -37,39 +36,46 @@ bgpstream_data_interface_id_t datasource_id = 0;
 bgpstream_data_interface_option_t *option;
 
 static char elem_buf[65536];
-static char * expected_results[7] = {
-  "U|A|1427846850|ris|rrc06|25152|202.249.2.185|202.70.88.0/21|202.249.2.185|25152 2914 15412 9304 23752|23752|2914:410 2914:1408 2914:2401 2914:3400||",
-  "U|A|1427846860|ris|rrc06|25152|202.249.2.185|202.70.88.0/21|202.249.2.185|25152 2914 15412 9304 23752|23752|2914:410 2914:1408 2914:2401 2914:3400||",
-  "U|A|1427846871|ris|rrc06|25152|2001:200:0:fe00::6249:0|2620:110:9004::/48|2001:200:0:fe00::6249:0|25152 2914 3356 13620|13620|2914:420 2914:1001 2914:2000 2914:3000||",
-  "U|A|1427846874|routeviews|route-views.jinx|37105|196.223.14.46|154.73.136.0/24|196.223.14.84|37105 37549|37549|37105:300||",
-  "U|A|1427846874|routeviews|route-views.jinx|37105|196.223.14.46|154.73.137.0/24|196.223.14.84|37105 37549|37549|37105:300||",
-  "U|A|1427846874|routeviews|route-views.jinx|37105|196.223.14.46|154.73.138.0/24|196.223.14.84|37105 37549|37549|37105:300||",
-  "U|A|1427846874|routeviews|route-views.jinx|37105|196.223.14.46|154.73.139.0/24|196.223.14.84|37105 37549|37549|37105:300||"};
+static char *expected_results[7] = {
+  "U|A|1427846850|ris|rrc06|25152|202.249.2.185|202.70.88.0/"
+  "21|202.249.2.185|25152 2914 15412 9304 23752|23752|2914:410 2914:1408 "
+  "2914:2401 2914:3400||",
+  "U|A|1427846860|ris|rrc06|25152|202.249.2.185|202.70.88.0/"
+  "21|202.249.2.185|25152 2914 15412 9304 23752|23752|2914:410 2914:1408 "
+  "2914:2401 2914:3400||",
+  "U|A|1427846871|ris|rrc06|25152|2001:200:0:fe00::6249:0|2620:110:9004::/"
+  "48|2001:200:0:fe00::6249:0|25152 2914 3356 13620|13620|2914:420 2914:1001 "
+  "2914:2000 2914:3000||",
+  "U|A|1427846874|routeviews|route-views.jinx|37105|196.223.14.46|154.73.136.0/"
+  "24|196.223.14.84|37105 37549|37549|37105:300||",
+  "U|A|1427846874|routeviews|route-views.jinx|37105|196.223.14.46|154.73.137.0/"
+  "24|196.223.14.84|37105 37549|37549|37105:300||",
+  "U|A|1427846874|routeviews|route-views.jinx|37105|196.223.14.46|154.73.138.0/"
+  "24|196.223.14.84|37105 37549|37549|37105:300||",
+  "U|A|1427846874|routeviews|route-views.jinx|37105|196.223.14.46|154.73.139.0/"
+  "24|196.223.14.84|37105 37549|37549|37105:300||"};
 
+#define SETUP                                                                  \
+  do {                                                                         \
+    bs = bgpstream_create();                                                   \
+    rec = bgpstream_record_create();                                           \
+  } while (0)
 
-#define SETUP                                   \
-  do {                                          \
-    bs = bgpstream_create();                    \
-    rec = bgpstream_record_create();            \
-  } while(0)
+#define TEARDOWN                                                               \
+  do {                                                                         \
+    bgpstream_record_destroy(rec);                                             \
+    rec = NULL;                                                                \
+    bgpstream_destroy(bs);                                                     \
+    bs = NULL;                                                                 \
+  } while (0)
 
-#define TEARDOWN                                \
-  do {                                          \
-    bgpstream_record_destroy(rec);              \
-    rec = NULL;                                 \
-    bgpstream_destroy(bs);                      \
-    bs = NULL;                                  \
-  } while(0)
-
-#define CHECK_SET_INTERFACE(interface)                                  \
-  do {                                                                  \
-    CHECK("get data interface ID ("STR(interface)")",                   \
-          (datasource_id =                                              \
-           bgpstream_get_data_interface_id_by_name(bs, STR(interface))) != 0); \
-    bgpstream_set_data_interface(bs, datasource_id);                    \
-  } while(0)
-
-
+#define CHECK_SET_INTERFACE(interface)                                         \
+  do {                                                                         \
+    CHECK("get data interface ID (" STR(interface) ")",                        \
+          (datasource_id = bgpstream_get_data_interface_id_by_name(            \
+             bs, STR(interface))) != 0);                                       \
+    bgpstream_set_data_interface(bs, datasource_id);                           \
+  } while (0)
 
 int test_bgpstream_filters()
 {
@@ -82,13 +88,15 @@ int test_bgpstream_filters()
 
   bgpstream_add_filter(bs, BGPSTREAM_FILTER_TYPE_RECORD_TYPE, "updates");
 
-  bgpstream_add_interval_filter(bs,1427846847,1427846874);
+  bgpstream_add_interval_filter(bs, 1427846847, 1427846874);
 
   bgpstream_add_filter(bs, BGPSTREAM_FILTER_TYPE_ELEM_PEER_ASN, "25152");
   bgpstream_add_filter(bs, BGPSTREAM_FILTER_TYPE_ELEM_PEER_ASN, "37105");
 
-  bgpstream_add_filter(bs, BGPSTREAM_FILTER_TYPE_ELEM_PREFIX, "2620:110:9004::/40");
-  bgpstream_add_filter(bs, BGPSTREAM_FILTER_TYPE_ELEM_PREFIX, "154.73.128.0/17");
+  bgpstream_add_filter(bs, BGPSTREAM_FILTER_TYPE_ELEM_PREFIX,
+                       "2620:110:9004::/40");
+  bgpstream_add_filter(bs, BGPSTREAM_FILTER_TYPE_ELEM_PREFIX,
+                       "154.73.128.0/17");
   bgpstream_add_filter(bs, BGPSTREAM_FILTER_TYPE_ELEM_PREFIX, "202.70.88.0/21");
 
   bgpstream_add_filter(bs, BGPSTREAM_FILTER_TYPE_ELEM_COMMUNITY, "2914:*");
@@ -96,29 +104,27 @@ int test_bgpstream_filters()
 
   int ret;
   int counter = 0;
-  int check_res = 0;  
-  CHECK("stream start ("STR(interface)")", bgpstream_start(bs) == 0);
+  int check_res = 0;
+  CHECK("stream start (" STR(interface) ")", bgpstream_start(bs) == 0);
 
-  while((ret = bgpstream_get_next_record(bs, rec)) > 0)
-    {
-      if(rec->status == BGPSTREAM_RECORD_STATUS_VALID_RECORD)
-        {
-          while((elem = bgpstream_record_get_next_elem(rec)) != NULL)
-            {
-              if(bgpstream_record_elem_snprintf(elem_buf, 65536, rec, elem) != NULL)
-                {
-                  /* more results than the expected ones*/
-                  CHECK("elem partial count", counter < 7); 
+  while ((ret = bgpstream_get_next_record(bs, rec)) > 0) {
+    if (rec->status == BGPSTREAM_RECORD_STATUS_VALID_RECORD) {
+      while ((elem = bgpstream_record_get_next_elem(rec)) != NULL) {
+        if (bgpstream_record_elem_snprintf(elem_buf, 65536, rec, elem) !=
+            NULL) {
+          /* more results than the expected ones*/
+          CHECK("elem partial count", counter < 7);
 
-                  /* check if the results are exactly the expected ones */
-                  CHECK("elem equality",
-                        (check_res = strncmp(elem_buf, expected_results[counter], 65536)) == 0);
+          /* check if the results are exactly the expected ones */
+          CHECK("elem equality",
+                (check_res =
+                   strncmp(elem_buf, expected_results[counter], 65536)) == 0);
 
-                  counter++;
-                }
-            }
+          counter++;
         }
+      }
     }
+  }
 
   CHECK("elem total count", counter == 7);
 
@@ -127,7 +133,6 @@ int test_bgpstream_filters()
   TEARDOWN;
   return 0;
 }
-
 
 int main()
 {
@@ -145,4 +150,3 @@ int main()
 
   return 0;
 }
-

--- a/test/bgpstream-test-utils-addr.c
+++ b/test/bgpstream-test-utils-addr.c
@@ -22,16 +22,16 @@
  */
 #include "bgpstream_test.h"
 
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
 #include <time.h>
 #include <unistd.h>
-#include <fcntl.h>
-#include <stdlib.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <arpa/inet.h>
-#include <stdbool.h>
-#include <string.h>
 
 #define BUFFER_LEN 1024
 char buffer[BUFFER_LEN];
@@ -58,8 +58,7 @@ int test_addresses_ipv4()
 
   /* check conversion from and to string */
   bgpstream_addr_ntop(buffer, BUFFER_LEN, &a);
-  CHECK("IPv4 address to string",
-        strcmp(buffer, IPV4_TEST_ADDR_A) == 0);
+  CHECK("IPv4 address to string", strcmp(buffer, IPV4_TEST_ADDR_A) == 0);
 
   /* STORAGE CHECKS */
 
@@ -68,51 +67,50 @@ int test_addresses_ipv4()
 
   /* check generic equal */
   CHECK("IPv4 address generic-equals (cast from storage)",
-        bgpstream_addr_equal((bgpstream_ip_addr_t*)&a,
-                             (bgpstream_ip_addr_t*)&b) == 0 &&
-        bgpstream_addr_equal((bgpstream_ip_addr_t*)&a,
-                             (bgpstream_ip_addr_t*)&a) != 0);
+        bgpstream_addr_equal((bgpstream_ip_addr_t *)&a,
+                             (bgpstream_ip_addr_t *)&b) == 0 &&
+          bgpstream_addr_equal((bgpstream_ip_addr_t *)&a,
+                               (bgpstream_ip_addr_t *)&a) != 0);
 
   /* check storage equal */
   CHECK("IPv4 address storage-equals (storage)",
         bgpstream_addr_storage_equal(&a, &b) == 0 &&
-        bgpstream_addr_storage_equal(&a, &a) != 0);
+          bgpstream_addr_storage_equal(&a, &a) != 0);
 
   /* IPV4-SPECIFIC CHECKS */
 
   /* populate ipv4 a */
-  bgpstream_str2addr(IPV4_TEST_ADDR_A, (bgpstream_addr_storage_t*)&a4);
+  bgpstream_str2addr(IPV4_TEST_ADDR_A, (bgpstream_addr_storage_t *)&a4);
   /* populate ipv4 b */
-  bgpstream_str2addr(IPV4_TEST_ADDR_B, (bgpstream_addr_storage_t*)&b4);
+  bgpstream_str2addr(IPV4_TEST_ADDR_B, (bgpstream_addr_storage_t *)&b4);
 
   /* check generic equal */
   CHECK("IPv4 address generic-equals (cast from ipv4)",
-        bgpstream_addr_equal((bgpstream_ip_addr_t*)&a4,
-                          (bgpstream_ip_addr_t*)&b4) == 0 &&
-        bgpstream_addr_equal((bgpstream_ip_addr_t*)&a4,
-                             (bgpstream_ip_addr_t*)&a4) != 0);
+        bgpstream_addr_equal((bgpstream_ip_addr_t *)&a4,
+                             (bgpstream_ip_addr_t *)&b4) == 0 &&
+          bgpstream_addr_equal((bgpstream_ip_addr_t *)&a4,
+                               (bgpstream_ip_addr_t *)&a4) != 0);
 
   /* check ipv4 equal */
   CHECK("IPv4 address ipv4-equals (ipv4)",
         bgpstream_ipv4_addr_equal(&a4, &b4) == 0 &&
-        bgpstream_ipv4_addr_equal(&a4, &a4) != 0);
-
+          bgpstream_ipv4_addr_equal(&a4, &a4) != 0);
 
   /* MASK CHECKS */
   /* generic mask */
   bgpstream_str2addr(IPV4_TEST_ADDR_A, &a);
   bgpstream_str2addr(IPV4_TEST_ADDR_A_MASKED, &a_masked);
 
-  bgpstream_addr_mask((bgpstream_ip_addr_t*)&a, IPV4_TEST_ADDR_A_MASKLEN);
+  bgpstream_addr_mask((bgpstream_ip_addr_t *)&a, IPV4_TEST_ADDR_A_MASKLEN);
 
   CHECK("IPv4 address generic-mask (cast from storage)",
-        bgpstream_addr_equal((bgpstream_ip_addr_t*)&a,
-                             (bgpstream_ip_addr_t*)&a_masked) != 0);
+        bgpstream_addr_equal((bgpstream_ip_addr_t *)&a,
+                             (bgpstream_ip_addr_t *)&a_masked) != 0);
 
   /* ipv4-specific */
-  bgpstream_str2addr(IPV4_TEST_ADDR_A, (bgpstream_addr_storage_t*)&a4);
+  bgpstream_str2addr(IPV4_TEST_ADDR_A, (bgpstream_addr_storage_t *)&a4);
   bgpstream_str2addr(IPV4_TEST_ADDR_A_MASKED,
-                     (bgpstream_addr_storage_t*)&a4_masked);
+                     (bgpstream_addr_storage_t *)&a4_masked);
 
   bgpstream_ipv4_addr_mask(&a4, IPV4_TEST_ADDR_A_MASKLEN);
 
@@ -120,11 +118,11 @@ int test_addresses_ipv4()
         bgpstream_ipv4_addr_equal(&a4, &a4_masked) != 0);
 
   /* copy checks */
-  bgpstream_addr_copy((bgpstream_ip_addr_t*)&b, (bgpstream_ip_addr_t*)&a);
+  bgpstream_addr_copy((bgpstream_ip_addr_t *)&b, (bgpstream_ip_addr_t *)&a);
 
   CHECK("IPv4 address copy",
-        bgpstream_addr_equal((bgpstream_ip_addr_t*)&a,
-                             (bgpstream_ip_addr_t*)&b) != 0);
+        bgpstream_addr_equal((bgpstream_ip_addr_t *)&a,
+                             (bgpstream_ip_addr_t *)&b) != 0);
 
   return 0;
 }
@@ -154,8 +152,7 @@ int test_addresses_ipv6()
 
   /* check conversion from and to string */
   bgpstream_addr_ntop(buffer, BUFFER_LEN, &a);
-  CHECK("IPv6 address to string",
-        strcmp(buffer, IPV6_TEST_ADDR_A) == 0);
+  CHECK("IPv6 address to string", strcmp(buffer, IPV6_TEST_ADDR_A) == 0);
 
   /* STORAGE CHECKS */
 
@@ -164,73 +161,72 @@ int test_addresses_ipv6()
 
   /* check generic equal */
   CHECK("IPv6 address generic-equals (cast from storage)",
-        bgpstream_addr_equal((bgpstream_ip_addr_t*)&a,
-                             (bgpstream_ip_addr_t*)&b) == 0 &&
-        bgpstream_addr_equal((bgpstream_ip_addr_t*)&a,
-                             (bgpstream_ip_addr_t*)&a) != 0);
+        bgpstream_addr_equal((bgpstream_ip_addr_t *)&a,
+                             (bgpstream_ip_addr_t *)&b) == 0 &&
+          bgpstream_addr_equal((bgpstream_ip_addr_t *)&a,
+                               (bgpstream_ip_addr_t *)&a) != 0);
 
   /* check storage equal */
   CHECK("IPv6 address storage-equals (storage)",
         bgpstream_addr_storage_equal(&a, &b) == 0 &&
-        bgpstream_addr_storage_equal(&a, &a) != 0);
+          bgpstream_addr_storage_equal(&a, &a) != 0);
 
   /* IPV6-SPECIFIC CHECKS */
 
   /* populate ipv6 a */
-  bgpstream_str2addr(IPV6_TEST_ADDR_A, (bgpstream_addr_storage_t*)&a6);
+  bgpstream_str2addr(IPV6_TEST_ADDR_A, (bgpstream_addr_storage_t *)&a6);
   /* populate ipv6 b */
-  bgpstream_str2addr(IPV6_TEST_ADDR_B, (bgpstream_addr_storage_t*)&b6);
+  bgpstream_str2addr(IPV6_TEST_ADDR_B, (bgpstream_addr_storage_t *)&b6);
 
   /* check generic equal */
   CHECK("IPv6 address generic-equals (cast from ipv6)",
-        bgpstream_addr_equal((bgpstream_ip_addr_t*)&a6,
-                          (bgpstream_ip_addr_t*)&b6) == 0 &&
-        bgpstream_addr_equal((bgpstream_ip_addr_t*)&a6,
-                             (bgpstream_ip_addr_t*)&a6) != 0);
+        bgpstream_addr_equal((bgpstream_ip_addr_t *)&a6,
+                             (bgpstream_ip_addr_t *)&b6) == 0 &&
+          bgpstream_addr_equal((bgpstream_ip_addr_t *)&a6,
+                               (bgpstream_ip_addr_t *)&a6) != 0);
 
   /* check ipv6 equal */
   CHECK("IPv6 address ipv6-equals (ipv6)",
         bgpstream_ipv6_addr_equal(&a6, &b6) == 0 &&
-        bgpstream_ipv6_addr_equal(&a6, &a6) != 0);
-
+          bgpstream_ipv6_addr_equal(&a6, &a6) != 0);
 
   /* MASK CHECKS (addr a checks len < 64, addr b checks len > 64) */
   /* generic mask */
   bgpstream_str2addr(IPV6_TEST_ADDR_A, &a);
   bgpstream_str2addr(IPV6_TEST_ADDR_A_MASKED, &a_masked);
-  bgpstream_addr_mask((bgpstream_ip_addr_t*)&a, IPV6_TEST_ADDR_A_MASKLEN);
+  bgpstream_addr_mask((bgpstream_ip_addr_t *)&a, IPV6_TEST_ADDR_A_MASKLEN);
 
   bgpstream_str2addr(IPV6_TEST_ADDR_B, &b);
   bgpstream_str2addr(IPV6_TEST_ADDR_B_MASKED, &b_masked);
-  bgpstream_addr_mask((bgpstream_ip_addr_t*)&b, IPV6_TEST_ADDR_B_MASKLEN);
+  bgpstream_addr_mask((bgpstream_ip_addr_t *)&b, IPV6_TEST_ADDR_B_MASKLEN);
 
   CHECK("IPv6 address generic-mask (cast from storage)",
-        bgpstream_addr_equal((bgpstream_ip_addr_t*)&a,
-                             (bgpstream_ip_addr_t*)&a_masked) != 0 &&
-        bgpstream_addr_equal((bgpstream_ip_addr_t*)&b,
-                             (bgpstream_ip_addr_t*)&b_masked) != 0);
+        bgpstream_addr_equal((bgpstream_ip_addr_t *)&a,
+                             (bgpstream_ip_addr_t *)&a_masked) != 0 &&
+          bgpstream_addr_equal((bgpstream_ip_addr_t *)&b,
+                               (bgpstream_ip_addr_t *)&b_masked) != 0);
 
   /* ipv6-specific */
-  bgpstream_str2addr(IPV6_TEST_ADDR_A, (bgpstream_addr_storage_t*)&a6);
+  bgpstream_str2addr(IPV6_TEST_ADDR_A, (bgpstream_addr_storage_t *)&a6);
   bgpstream_str2addr(IPV6_TEST_ADDR_A_MASKED,
-                     (bgpstream_addr_storage_t*)&a6_masked);
+                     (bgpstream_addr_storage_t *)&a6_masked);
   bgpstream_ipv6_addr_mask(&a6, IPV6_TEST_ADDR_A_MASKLEN);
 
-  bgpstream_str2addr(IPV6_TEST_ADDR_B, (bgpstream_addr_storage_t*)&b6);
+  bgpstream_str2addr(IPV6_TEST_ADDR_B, (bgpstream_addr_storage_t *)&b6);
   bgpstream_str2addr(IPV6_TEST_ADDR_B_MASKED,
-                     (bgpstream_addr_storage_t*)&b6_masked);
+                     (bgpstream_addr_storage_t *)&b6_masked);
   bgpstream_ipv6_addr_mask(&b6, IPV6_TEST_ADDR_B_MASKLEN);
 
   CHECK("IPv6 address ipv6-mask (ipv6)",
         bgpstream_ipv6_addr_equal(&a6, &a6_masked) != 0 &&
-        bgpstream_ipv6_addr_equal(&b6, &b6_masked) != 0);
+          bgpstream_ipv6_addr_equal(&b6, &b6_masked) != 0);
 
   /* copy checks */
-  bgpstream_addr_copy((bgpstream_ip_addr_t*)&b, (bgpstream_ip_addr_t*)&a);
+  bgpstream_addr_copy((bgpstream_ip_addr_t *)&b, (bgpstream_ip_addr_t *)&a);
 
   CHECK("IPv6 address copy",
-        bgpstream_addr_equal((bgpstream_ip_addr_t*)&a,
-                             (bgpstream_ip_addr_t*)&b) != 0);
+        bgpstream_addr_equal((bgpstream_ip_addr_t *)&a,
+                             (bgpstream_ip_addr_t *)&b) != 0);
 
   return 0;
 }

--- a/test/bgpstream-test-utils-patricia.c
+++ b/test/bgpstream-test-utils-patricia.c
@@ -22,16 +22,16 @@
  */
 #include "bgpstream_test.h"
 
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
 #include <time.h>
 #include <unistd.h>
-#include <fcntl.h>
-#include <stdlib.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <arpa/inet.h>
-#include <stdbool.h>
-#include <string.h>
 
 #define BUFFER_LEN 1024
 char buffer[BUFFER_LEN];
@@ -50,7 +50,6 @@ char buffer[BUFFER_LEN];
 #define IPV6_TEST_64_CNT 65537
 #define IPV6_TEST_PFX_CNT 4
 
-
 int test_patricia()
 {
   bgpstream_patricia_tree_t *pt;
@@ -66,62 +65,85 @@ int test_patricia()
         (res = bgpstream_patricia_tree_result_set_create()) != NULL);
 
   /* Insert into Patricia Tree */
-  
+
   CHECK("Insert into Patricia Tree v4",
-        bgpstream_patricia_tree_insert(pt, (bgpstream_pfx_t *) bgpstream_str2pfx(IPV4_TEST_PFX_A, &pfx)) != NULL);
+        bgpstream_patricia_tree_insert(pt, (bgpstream_pfx_t *)bgpstream_str2pfx(
+                                             IPV4_TEST_PFX_A, &pfx)) != NULL);
   CHECK("Insert into Patricia Tree v4",
-        bgpstream_patricia_tree_insert(pt, (bgpstream_pfx_t *) bgpstream_str2pfx(IPV4_TEST_PFX_B, &pfx)) != NULL);
+        bgpstream_patricia_tree_insert(pt, (bgpstream_pfx_t *)bgpstream_str2pfx(
+                                             IPV4_TEST_PFX_B, &pfx)) != NULL);
   CHECK("Insert into Patricia Tree v4",
-        bgpstream_patricia_tree_insert(pt, (bgpstream_pfx_t *) bgpstream_str2pfx(IPV4_TEST_PFX_B_CHILD, &pfx)) != NULL);
+        bgpstream_patricia_tree_insert(pt, (bgpstream_pfx_t *)bgpstream_str2pfx(
+                                             IPV4_TEST_PFX_B_CHILD, &pfx)) !=
+          NULL);
 
   CHECK("Insert into Patricia Tree v6",
-        bgpstream_patricia_tree_insert(pt, (bgpstream_pfx_t *) bgpstream_str2pfx(IPV6_TEST_PFX_A, &pfx)) != NULL);
+        bgpstream_patricia_tree_insert(pt, (bgpstream_pfx_t *)bgpstream_str2pfx(
+                                             IPV6_TEST_PFX_A, &pfx)) != NULL);
   CHECK("Insert into Patricia Tree v6",
-        bgpstream_patricia_tree_insert(pt, (bgpstream_pfx_t *) bgpstream_str2pfx(IPV6_TEST_PFX_A_CHILD, &pfx)) != NULL);
+        bgpstream_patricia_tree_insert(pt, (bgpstream_pfx_t *)bgpstream_str2pfx(
+                                             IPV6_TEST_PFX_A_CHILD, &pfx)) !=
+          NULL);
   CHECK("Insert into Patricia Tree v6",
-        bgpstream_patricia_tree_insert(pt, (bgpstream_pfx_t *) bgpstream_str2pfx(IPV6_TEST_PFX_B, &pfx)) != NULL);
+        bgpstream_patricia_tree_insert(pt, (bgpstream_pfx_t *)bgpstream_str2pfx(
+                                             IPV6_TEST_PFX_B, &pfx)) != NULL);
   CHECK("Insert into Patricia Tree v6",
-        bgpstream_patricia_tree_insert(pt, (bgpstream_pfx_t *) bgpstream_str2pfx(IPV6_TEST_PFX_B_CHILD, &pfx)) != NULL);
+        bgpstream_patricia_tree_insert(pt, (bgpstream_pfx_t *)bgpstream_str2pfx(
+                                             IPV6_TEST_PFX_B_CHILD, &pfx)) !=
+          NULL);
 
   /* Count prefixes */
   CHECK("Count Patricia Tree v4 prefixes",
-        bgpstream_patricia_prefix_count(pt, BGPSTREAM_ADDR_VERSION_IPV4) == IPV4_TEST_PFX_CNT);
+        bgpstream_patricia_prefix_count(pt, BGPSTREAM_ADDR_VERSION_IPV4) ==
+          IPV4_TEST_PFX_CNT);
   CHECK("Count Patricia Tree v6 prefixes",
-        bgpstream_patricia_prefix_count(pt, BGPSTREAM_ADDR_VERSION_IPV6) == IPV6_TEST_PFX_CNT);
-  
+        bgpstream_patricia_prefix_count(pt, BGPSTREAM_ADDR_VERSION_IPV6) ==
+          IPV6_TEST_PFX_CNT);
+
   /* Search prefixes */
   CHECK("Patricia Tree v4 search exact",
-        bgpstream_patricia_tree_search_exact(pt, (bgpstream_pfx_t *) bgpstream_str2pfx(IPV4_TEST_PFX_A, &pfx)) != NULL);
+        bgpstream_patricia_tree_search_exact(
+          pt, (bgpstream_pfx_t *)bgpstream_str2pfx(IPV4_TEST_PFX_A, &pfx)) !=
+          NULL);
   CHECK("Patricia Tree v6 search exact",
-        bgpstream_patricia_tree_search_exact(pt, (bgpstream_pfx_t *) bgpstream_str2pfx(IPV6_TEST_PFX_A, &pfx)) != NULL);
+        bgpstream_patricia_tree_search_exact(
+          pt, (bgpstream_pfx_t *)bgpstream_str2pfx(IPV6_TEST_PFX_A, &pfx)) !=
+          NULL);
 
   /* Overlap info */
-  CHECK("Patricia Tree v4 overlap info",
-        bgpstream_patricia_tree_get_pfx_overlap_info(pt, (bgpstream_pfx_t *) bgpstream_str2pfx(IPV4_TEST_PFX_OVERLAP, &pfx)) ==
-        BGPSTREAM_PATRICIA_LESS_SPECIFICS || BGPSTREAM_PATRICIA_MORE_SPECIFICS);
+  CHECK(
+    "Patricia Tree v4 overlap info",
+    bgpstream_patricia_tree_get_pfx_overlap_info(
+      pt, (bgpstream_pfx_t *)bgpstream_str2pfx(IPV4_TEST_PFX_OVERLAP, &pfx)) ==
+        BGPSTREAM_PATRICIA_LESS_SPECIFICS ||
+      BGPSTREAM_PATRICIA_MORE_SPECIFICS);
   CHECK("Patricia Tree v6 overlap info",
-        bgpstream_patricia_tree_get_pfx_overlap_info(pt, (bgpstream_pfx_t *) bgpstream_str2pfx(IPV6_TEST_PFX_B, &pfx)) ==
-        BGPSTREAM_PATRICIA_EXACT_MATCH || BGPSTREAM_PATRICIA_MORE_SPECIFICS);
-  
+        bgpstream_patricia_tree_get_pfx_overlap_info(
+          pt, (bgpstream_pfx_t *)bgpstream_str2pfx(IPV6_TEST_PFX_B, &pfx)) ==
+            BGPSTREAM_PATRICIA_EXACT_MATCH ||
+          BGPSTREAM_PATRICIA_MORE_SPECIFICS);
+
   /* Count minimum coverage prefixes */
   CHECK("Patricia Tree v4 minimum coverage",
-        bgpstream_patricia_tree_get_minimum_coverage(pt, BGPSTREAM_ADDR_VERSION_IPV4, res) == 0 &&
-        bgpstream_patricia_tree_result_set_count(res) == 2);
+        bgpstream_patricia_tree_get_minimum_coverage(
+          pt, BGPSTREAM_ADDR_VERSION_IPV4, res) == 0 &&
+          bgpstream_patricia_tree_result_set_count(res) == 2);
   CHECK("Patricia Tree v6 minimum coverage",
-        bgpstream_patricia_tree_get_minimum_coverage(pt, BGPSTREAM_ADDR_VERSION_IPV6, res) == 0 &&
-        bgpstream_patricia_tree_result_set_count(res) == 2);
+        bgpstream_patricia_tree_get_minimum_coverage(
+          pt, BGPSTREAM_ADDR_VERSION_IPV6, res) == 0 &&
+          bgpstream_patricia_tree_result_set_count(res) == 2);
 
   /* Count prefixes subnets */
-  CHECK("Patricia Tree v4 /24 subnets", bgpstream_patricia_tree_count_24subnets(pt) == IPV4_TEST_24_CNT);
-  CHECK("Patricia Tree v6 /64 subnets", bgpstream_patricia_tree_count_64subnets(pt) == IPV6_TEST_64_CNT);
+  CHECK("Patricia Tree v4 /24 subnets",
+        bgpstream_patricia_tree_count_24subnets(pt) == IPV4_TEST_24_CNT);
+  CHECK("Patricia Tree v6 /64 subnets",
+        bgpstream_patricia_tree_count_64subnets(pt) == IPV6_TEST_64_CNT);
 
   bgpstream_patricia_tree_destroy(pt);
   bgpstream_patricia_tree_result_set_destroy(&res);
 
   return 0;
 }
-
-
 
 int main()
 {

--- a/test/bgpstream-test-utils-pfx.c
+++ b/test/bgpstream-test-utils-pfx.c
@@ -22,16 +22,16 @@
  */
 #include "bgpstream_test.h"
 
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
 #include <time.h>
 #include <unistd.h>
-#include <fcntl.h>
-#include <stdlib.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <arpa/inet.h>
-#include <stdbool.h>
-#include <string.h>
 
 #define BUFFER_LEN 1024
 char buffer[BUFFER_LEN];
@@ -53,7 +53,7 @@ int test_prefixes_ipv4()
         bgpstream_str2pfx(IPV4_TEST_PFX_A, &a) != NULL);
 
   /* convert prefix to string */
-  bgpstream_pfx_snprintf(buffer, BUFFER_LEN, (bgpstream_pfx_t*)&a);
+  bgpstream_pfx_snprintf(buffer, BUFFER_LEN, (bgpstream_pfx_t *)&a);
   CHECK("IPv4 prefix to string",
         strncmp(IPV4_TEST_PFX_A, buffer, BUFFER_LEN) == 0);
 
@@ -63,46 +63,43 @@ int test_prefixes_ipv4()
   bgpstream_str2pfx(IPV4_TEST_PFX_B, &b);
 
   /* check generic equal */
-  CHECK("IPv4 prefix generic-equals (cast from storage)",
-        bgpstream_pfx_equal((bgpstream_pfx_t*)&a,
-                             (bgpstream_pfx_t*)&b) == 0 &&
-        bgpstream_pfx_equal((bgpstream_pfx_t*)&a,
-                             (bgpstream_pfx_t*)&a) != 0);
+  CHECK(
+    "IPv4 prefix generic-equals (cast from storage)",
+    bgpstream_pfx_equal((bgpstream_pfx_t *)&a, (bgpstream_pfx_t *)&b) == 0 &&
+      bgpstream_pfx_equal((bgpstream_pfx_t *)&a, (bgpstream_pfx_t *)&a) != 0);
 
   /* check storage equal */
   CHECK("IPv4 prefix storage-equals (storage)",
         bgpstream_pfx_storage_equal(&a, &b) == 0 &&
-        bgpstream_pfx_storage_equal(&a, &a) != 0);
+          bgpstream_pfx_storage_equal(&a, &a) != 0);
 
   /* IPV4-SPECIFIC CHECKS */
 
   /* populate ipv4 a */
-  bgpstream_str2pfx(IPV4_TEST_PFX_A, (bgpstream_pfx_storage_t*)&a4);
+  bgpstream_str2pfx(IPV4_TEST_PFX_A, (bgpstream_pfx_storage_t *)&a4);
   /* populate ipv4 b */
-  bgpstream_str2pfx(IPV4_TEST_PFX_B, (bgpstream_pfx_storage_t*)&b4);
+  bgpstream_str2pfx(IPV4_TEST_PFX_B, (bgpstream_pfx_storage_t *)&b4);
 
   /* check generic equal */
-  CHECK("IPv4 prefix generic-equals (cast from ipv4)",
-        bgpstream_pfx_equal((bgpstream_pfx_t*)&a4,
-                            (bgpstream_pfx_t*)&b4) == 0 &&
-        bgpstream_pfx_equal((bgpstream_pfx_t*)&a4,
-                            (bgpstream_pfx_t*)&a4) != 0);
+  CHECK(
+    "IPv4 prefix generic-equals (cast from ipv4)",
+    bgpstream_pfx_equal((bgpstream_pfx_t *)&a4, (bgpstream_pfx_t *)&b4) == 0 &&
+      bgpstream_pfx_equal((bgpstream_pfx_t *)&a4, (bgpstream_pfx_t *)&a4) != 0);
 
   /* check ipv4 equal */
   CHECK("IPv4 prefix ipv4-equals (ipv4)",
         bgpstream_ipv4_pfx_equal(&a4, &b4) == 0 &&
-        bgpstream_ipv4_pfx_equal(&a4, &a4) != 0);
-
+          bgpstream_ipv4_pfx_equal(&a4, &a4) != 0);
 
   /* prefix contains (i.e. more specifics) */
   bgpstream_str2pfx(IPV4_TEST_PFX_B, &a);
   bgpstream_str2pfx(IPV4_TEST_PFX_B_CHILD, &b);
   /* b is a child of a BUT a is NOT a child of b */
-  CHECK("IPv4 prefix contains",
-        bgpstream_pfx_contains((bgpstream_pfx_t*)&a,
-                               (bgpstream_pfx_t*)&b) != 0 &&
-        bgpstream_pfx_contains((bgpstream_pfx_t*)&b,
-                               (bgpstream_pfx_t*)&a) == 0);
+  CHECK(
+    "IPv4 prefix contains",
+    bgpstream_pfx_contains((bgpstream_pfx_t *)&a, (bgpstream_pfx_t *)&b) != 0 &&
+      bgpstream_pfx_contains((bgpstream_pfx_t *)&b, (bgpstream_pfx_t *)&a) ==
+        0);
 
   return 0;
 }
@@ -127,7 +124,7 @@ int test_prefixes_ipv6()
         bgpstream_str2pfx(IPV6_TEST_PFX_A, &a) != NULL);
 
   /* convert prefix to string */
-  bgpstream_pfx_snprintf(buffer, BUFFER_LEN, (bgpstream_pfx_t*)&a);
+  bgpstream_pfx_snprintf(buffer, BUFFER_LEN, (bgpstream_pfx_t *)&a);
   CHECK("IPv6 prefix to string",
         strncmp(IPV6_TEST_PFX_A, buffer, BUFFER_LEN) == 0);
 
@@ -137,36 +134,33 @@ int test_prefixes_ipv6()
   bgpstream_str2pfx(IPV6_TEST_PFX_B, &b);
 
   /* check generic equal */
-  CHECK("IPv6 prefix generic-equals (cast from storage)",
-        bgpstream_pfx_equal((bgpstream_pfx_t*)&a,
-                             (bgpstream_pfx_t*)&b) == 0 &&
-        bgpstream_pfx_equal((bgpstream_pfx_t*)&a,
-                             (bgpstream_pfx_t*)&a) != 0);
+  CHECK(
+    "IPv6 prefix generic-equals (cast from storage)",
+    bgpstream_pfx_equal((bgpstream_pfx_t *)&a, (bgpstream_pfx_t *)&b) == 0 &&
+      bgpstream_pfx_equal((bgpstream_pfx_t *)&a, (bgpstream_pfx_t *)&a) != 0);
 
   /* check storage equal */
   CHECK("IPv6 prefix storage-equals (storage)",
         bgpstream_pfx_storage_equal(&a, &b) == 0 &&
-        bgpstream_pfx_storage_equal(&a, &a) != 0);
+          bgpstream_pfx_storage_equal(&a, &a) != 0);
 
   /* IPV6-SPECIFIC CHECKS */
 
   /* populate ipv6 a */
-  bgpstream_str2pfx(IPV6_TEST_PFX_A, (bgpstream_pfx_storage_t*)&a6);
+  bgpstream_str2pfx(IPV6_TEST_PFX_A, (bgpstream_pfx_storage_t *)&a6);
   /* populate ipv6 b */
-  bgpstream_str2pfx(IPV6_TEST_PFX_B, (bgpstream_pfx_storage_t*)&b6);
+  bgpstream_str2pfx(IPV6_TEST_PFX_B, (bgpstream_pfx_storage_t *)&b6);
 
   /* check generic equal */
-  CHECK("IPv6 prefix generic-equals (cast from ipv6)",
-        bgpstream_pfx_equal((bgpstream_pfx_t*)&a6,
-                            (bgpstream_pfx_t*)&b6) == 0 &&
-        bgpstream_pfx_equal((bgpstream_pfx_t*)&a6,
-                            (bgpstream_pfx_t*)&a6) != 0);
+  CHECK(
+    "IPv6 prefix generic-equals (cast from ipv6)",
+    bgpstream_pfx_equal((bgpstream_pfx_t *)&a6, (bgpstream_pfx_t *)&b6) == 0 &&
+      bgpstream_pfx_equal((bgpstream_pfx_t *)&a6, (bgpstream_pfx_t *)&a6) != 0);
 
   /* check ipv6 equal */
   CHECK("IPv6 prefix ipv6-equals (ipv6)",
         bgpstream_ipv6_pfx_equal(&a6, &b6) == 0 &&
-        bgpstream_ipv6_pfx_equal(&a6, &a6) != 0);
-
+          bgpstream_ipv6_pfx_equal(&a6, &a6) != 0);
 
   /* prefix contains (i.e. more specifics) */
   bgpstream_str2pfx(IPV6_TEST_PFX_A, &a);
@@ -175,14 +169,14 @@ int test_prefixes_ipv6()
   bgpstream_str2pfx(IPV6_TEST_PFX_B_CHILD, &b_child);
   /* b is a child of a BUT a is NOT a child of b */
   CHECK("IPv6 prefix contains",
-        bgpstream_pfx_contains((bgpstream_pfx_t*)&a,
-                               (bgpstream_pfx_t*)&a_child) != 0 &&
-        bgpstream_pfx_contains((bgpstream_pfx_t*)&a_child,
-                               (bgpstream_pfx_t*)&a) == 0 &&
-        bgpstream_pfx_contains((bgpstream_pfx_t*)&b,
-                               (bgpstream_pfx_t*)&b_child) != 0 &&
-        bgpstream_pfx_contains((bgpstream_pfx_t*)&b_child,
-                               (bgpstream_pfx_t*)&b) == 0);
+        bgpstream_pfx_contains((bgpstream_pfx_t *)&a,
+                               (bgpstream_pfx_t *)&a_child) != 0 &&
+          bgpstream_pfx_contains((bgpstream_pfx_t *)&a_child,
+                                 (bgpstream_pfx_t *)&a) == 0 &&
+          bgpstream_pfx_contains((bgpstream_pfx_t *)&b,
+                                 (bgpstream_pfx_t *)&b_child) != 0 &&
+          bgpstream_pfx_contains((bgpstream_pfx_t *)&b_child,
+                                 (bgpstream_pfx_t *)&b) == 0);
 
   return 0;
 }

--- a/test/bgpstream-test.c
+++ b/test/bgpstream-test.c
@@ -29,60 +29,57 @@
 #include <wandio.h>
 
 #define singlefile_RECORDS 537347
-#define csvfile_RECORDS    559424
-#define sqlite_RECORDS     538308
-#define broker_RECORDS     2153
+#define csvfile_RECORDS 559424
+#define sqlite_RECORDS 538308
+#define broker_RECORDS 2153
 
 bgpstream_t *bs;
 bgpstream_record_t *rec;
 bgpstream_data_interface_id_t datasource_id = 0;
 bgpstream_data_interface_option_t *option;
 
-#define RUN(interface)                                          \
-  do {                                                          \
-  int ret;                                                      \
-  int counter = 0;                                              \
-  CHECK("stream start ("STR(interface)")",                      \
-        bgpstream_start(bs) == 0);                              \
-  while((ret = bgpstream_get_next_record(bs, rec)) > 0) {       \
-    if(rec->status == BGPSTREAM_RECORD_STATUS_VALID_RECORD) {   \
-      counter++;                                                \
-    }                                                           \
-  }                                                             \
-  bgpstream_stop(bs);                                           \
-  CHECK("read records ("STR(interface)")",                      \
-        ret == 0 && counter == interface##_RECORDS);            \
-  } while(0)
+#define RUN(interface)                                                         \
+  do {                                                                         \
+    int ret;                                                                   \
+    int counter = 0;                                                           \
+    CHECK("stream start (" STR(interface) ")", bgpstream_start(bs) == 0);      \
+    while ((ret = bgpstream_get_next_record(bs, rec)) > 0) {                   \
+      if (rec->status == BGPSTREAM_RECORD_STATUS_VALID_RECORD) {               \
+        counter++;                                                             \
+      }                                                                        \
+    }                                                                          \
+    bgpstream_stop(bs);                                                        \
+    CHECK("read records (" STR(interface) ")",                                 \
+          ret == 0 && counter == interface##_RECORDS);                         \
+  } while (0)
 
-#define SETUP                                   \
-  do {                                          \
-    bs = bgpstream_create();                    \
-    rec = bgpstream_record_create();            \
-  } while(0)
+#define SETUP                                                                  \
+  do {                                                                         \
+    bs = bgpstream_create();                                                   \
+    rec = bgpstream_record_create();                                           \
+  } while (0)
 
-#define TEARDOWN                                \
-  do {                                          \
-    bgpstream_record_destroy(rec);              \
-    rec = NULL;                                 \
-    bgpstream_destroy(bs);                      \
-    bs = NULL;                                  \
-  } while(0)
+#define TEARDOWN                                                               \
+  do {                                                                         \
+    bgpstream_record_destroy(rec);                                             \
+    rec = NULL;                                                                \
+    bgpstream_destroy(bs);                                                     \
+    bs = NULL;                                                                 \
+  } while (0)
 
-#define CHECK_SET_INTERFACE(interface)                                  \
-  do {                                                                  \
-    CHECK("get data interface ID ("STR(interface)")",                   \
-          (datasource_id =                                              \
-           bgpstream_get_data_interface_id_by_name(bs, STR(interface))) != 0); \
-    bgpstream_set_data_interface(bs, datasource_id);                    \
-  } while(0)
+#define CHECK_SET_INTERFACE(interface)                                         \
+  do {                                                                         \
+    CHECK("get data interface ID (" STR(interface) ")",                        \
+          (datasource_id = bgpstream_get_data_interface_id_by_name(            \
+             bs, STR(interface))) != 0);                                       \
+    bgpstream_set_data_interface(bs, datasource_id);                           \
+  } while (0)
 
 int test_bgpstream()
 {
-  CHECK("BGPStream create",
-        (bs = bgpstream_create()) != NULL);
+  CHECK("BGPStream create", (bs = bgpstream_create()) != NULL);
 
-  CHECK("BGPStream record create",
-        (rec = bgpstream_record_create()) != NULL);
+  CHECK("BGPStream record create", (rec = bgpstream_record_create()) != NULL);
 
   TEARDOWN;
   return 0;
@@ -95,16 +92,14 @@ int test_singlefile()
   CHECK_SET_INTERFACE(singlefile);
 
   CHECK("get option (rib-file)",
-        (option =
-         bgpstream_get_data_interface_option_by_name(bs, datasource_id,
-                                                     "rib-file")) != NULL);
-  bgpstream_set_data_interface_option(bs, option,
-                           "routeviews.route-views.jinx.ribs.1427846400.bz2");
+        (option = bgpstream_get_data_interface_option_by_name(
+           bs, datasource_id, "rib-file")) != NULL);
+  bgpstream_set_data_interface_option(
+    bs, option, "routeviews.route-views.jinx.ribs.1427846400.bz2");
 
   CHECK("get option (upd-file)",
-        (option =
-         bgpstream_get_data_interface_option_by_name(bs, datasource_id,
-                                                     "upd-file")) != NULL);
+        (option = bgpstream_get_data_interface_option_by_name(
+           bs, datasource_id, "upd-file")) != NULL);
   bgpstream_set_data_interface_option(bs, option,
                                       "ris.rrc06.updates.1427846400.gz");
 
@@ -121,9 +116,8 @@ int test_csvfile()
   CHECK_SET_INTERFACE(csvfile);
 
   CHECK("get option (csv-file)",
-        (option =
-         bgpstream_get_data_interface_option_by_name(bs, datasource_id,
-                                                     "csv-file")) != NULL);
+        (option = bgpstream_get_data_interface_option_by_name(
+           bs, datasource_id, "csv-file")) != NULL);
   bgpstream_set_data_interface_option(bs, option, "csv_test.csv");
 
   bgpstream_add_filter(bs, BGPSTREAM_FILTER_TYPE_COLLECTOR, "rrc06");
@@ -141,9 +135,8 @@ int test_sqlite()
   CHECK_SET_INTERFACE(sqlite);
 
   CHECK("get option (db-file)",
-        (option =
-         bgpstream_get_data_interface_option_by_name(bs, datasource_id,
-                                                     "db-file")) != NULL);
+        (option = bgpstream_get_data_interface_option_by_name(
+           bs, datasource_id, "db-file")) != NULL);
   bgpstream_set_data_interface_option(bs, option, "sqlite_test.db");
 
   bgpstream_add_filter(bs, BGPSTREAM_FILTER_TYPE_PROJECT, "routeviews");
@@ -170,7 +163,7 @@ int test_broker()
 
   bgpstream_add_filter(bs, BGPSTREAM_FILTER_TYPE_COLLECTOR, "route-views6");
   bgpstream_add_filter(bs, BGPSTREAM_FILTER_TYPE_RECORD_TYPE, "updates");
-  bgpstream_add_interval_filter(bs,1427846550,1427846700);
+  bgpstream_add_interval_filter(bs, 1427846550, 1427846700);
 
   RUN(broker);
 
@@ -180,37 +173,31 @@ int test_broker()
 
 int main()
 {
-  CHECK_SECTION("BGPStream",
-                test_bgpstream() == 0);
+  CHECK_SECTION("BGPStream", test_bgpstream() == 0);
 
 #ifdef WITH_DATA_INTERFACE_SINGLEFILE
-  CHECK_SECTION("singlefile data interface",
-                test_singlefile() == 0);
+  CHECK_SECTION("singlefile data interface", test_singlefile() == 0);
 #else
   SKIPPED_SECTION("singlefile data interface");
 #endif
 
 #ifdef WITH_DATA_INTERFACE_CSVFILE
-  CHECK_SECTION("csvfile data interface",
-                test_csvfile() == 0);
+  CHECK_SECTION("csvfile data interface", test_csvfile() == 0);
 #else
   SKIPPED_SECTION("csvfile data interface");
 #endif
 
 #ifdef WITH_DATA_INTERFACE_SQLITE
-  CHECK_SECTION("sqlite data interface",
-                test_sqlite() == 0);
+  CHECK_SECTION("sqlite data interface", test_sqlite() == 0);
 #else
   SKIPPED_SECTION("sqlite data interface");
 #endif
 
 #ifdef WITH_DATA_INTERFACE_BROKER
-  CHECK_SECTION("broker data interface",
-                test_broker() == 0);
+  CHECK_SECTION("broker data interface", test_broker() == 0);
 #else
   SKIPPED_SECTION("broker data interface");
 #endif
 
   return 0;
 }
-

--- a/test/bgpstream_test.h
+++ b/test/bgpstream_test.h
@@ -20,50 +20,49 @@
  * You should have received a copy of the GNU General Public License along with
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "config.h"
 #include "bgpstream.h"
+#include "config.h"
 
-#define CHECK_MSG(name, err_msg, check)                          \
-  do {                                                           \
-    if(!(check)) {                                               \
-      fprintf(stderr, " * "name": FAILED\n");                    \
-      fprintf(stderr, " ! Failed check was: '"#check"'\n");      \
-      fprintf(stderr, err_msg"\n\n");                            \
-      return -1;                                                 \
-    } else {                                                     \
-      fprintf(stderr, " * "name": OK\n");                        \
-    }                                                            \
-  } while(0)
+#define CHECK_MSG(name, err_msg, check)                                        \
+  do {                                                                         \
+    if (!(check)) {                                                            \
+      fprintf(stderr, " * " name ": FAILED\n");                                \
+      fprintf(stderr, " ! Failed check was: '" #check "'\n");                  \
+      fprintf(stderr, err_msg "\n\n");                                         \
+      return -1;                                                               \
+    } else {                                                                   \
+      fprintf(stderr, " * " name ": OK\n");                                    \
+    }                                                                          \
+  } while (0)
 
-#define CHECK(name, check)                      \
-  do {                                                           \
-    if(!(check)) {                                               \
-      fprintf(stderr, " * "name": FAILED\n");                    \
-      fprintf(stderr, " ! Failed check was: '"#check"'\n");      \
-      return -1;                                                 \
-    } else {                                                     \
-      fprintf(stderr, " * "name": OK\n");                        \
-    }                                                            \
-  } while(0)
+#define CHECK(name, check)                                                     \
+  do {                                                                         \
+    if (!(check)) {                                                            \
+      fprintf(stderr, " * " name ": FAILED\n");                                \
+      fprintf(stderr, " ! Failed check was: '" #check "'\n");                  \
+      return -1;                                                               \
+    } else {                                                                   \
+      fprintf(stderr, " * " name ": OK\n");                                    \
+    }                                                                          \
+  } while (0)
 
-#define CHECK_SECTION(name, check)                \
-  do {                                            \
-    fprintf(stderr, "Checking "name"...\n");      \
-    if(!(check)) {                                \
-      fprintf(stderr, name": FAILED\n\n");        \
-      return -1;                                  \
-    } else {                                      \
-      fprintf(stderr, name": OK\n\n");            \
-    }                                             \
-  } while(0)
+#define CHECK_SECTION(name, check)                                             \
+  do {                                                                         \
+    fprintf(stderr, "Checking " name "...\n");                                 \
+    if (!(check)) {                                                            \
+      fprintf(stderr, name ": FAILED\n\n");                                    \
+      return -1;                                                               \
+    } else {                                                                   \
+      fprintf(stderr, name ": OK\n\n");                                        \
+    }                                                                          \
+  } while (0)
 
-#define SKIPPED(name)                           \
-  do {                                          \
-    fprintf(stderr, " * "name": SKIPPED\n");    \
-  } while(0)
+#define SKIPPED(name)                                                          \
+  do {                                                                         \
+    fprintf(stderr, " * " name ": SKIPPED\n");                                 \
+  } while (0)
 
-
-#define SKIPPED_SECTION(name)                           \
-  do {                                                  \
-    fprintf(stderr, name": SKIPPED\n");                 \
-  } while(0)
+#define SKIPPED_SECTION(name)                                                  \
+  do {                                                                         \
+    fprintf(stderr, name ": SKIPPED\n");                                       \
+  } while (0)

--- a/test/tutorial.c
+++ b/test/tutorial.c
@@ -21,47 +21,43 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
 #include <time.h>
 #include <unistd.h>
-#include <fcntl.h>
-#include <stdlib.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <arpa/inet.h>
-#include <stdbool.h>
-#include <string.h>
 
 #include "bgpstream.h"
 
-int
-main()
+int main()
 {
   /* Allocate memory for a bgpstream instance */
   bgpstream_t *bs = bs = bgpstream_create();
-  if(!bs) {
+  if (!bs) {
     fprintf(stderr, "ERROR: Could not create BGPStream instance\n");
     return -1;
   }
 
   /* Allocate memory for a re-usable bgprecord instance */
   bgpstream_record_t *bs_record = bgpstream_record_create();
-  if(bs_record == NULL)
-    {
-      fprintf(stderr, "ERROR: Could not create BGPStream record\n");
-      return -1;
-    }
+  if (bs_record == NULL) {
+    fprintf(stderr, "ERROR: Could not create BGPStream record\n");
+    return -1;
+  }
 
-  
   /* Configure the sqlite interface */
-  bgpstream_data_interface_id_t datasource_id = bgpstream_get_data_interface_id_by_name(bs, "sqlite");
+  bgpstream_data_interface_id_t datasource_id =
+    bgpstream_get_data_interface_id_by_name(bs, "sqlite");
   bgpstream_set_data_interface(bs, datasource_id);
 
   /* Configure the sqlite interface options */
-  bgpstream_data_interface_option_t *option = 
-    bgpstream_get_data_interface_option_by_name(bs, datasource_id,
-                                                "db-file");
+  bgpstream_data_interface_option_t *option =
+    bgpstream_get_data_interface_option_by_name(bs, datasource_id, "db-file");
   bgpstream_set_data_interface_option(bs, option, "./sqlite_test.db");
 
   /* Select bgp data from RRC06 and route-views.jinx collectors only */
@@ -73,10 +69,10 @@ main()
 
   /* Select a time interval to process:
    * Wed, 01 Apr 2015 00:02:30 GMT -> Wed, 01 Apr 2015 00:05:00 UTC */
-  bgpstream_add_interval_filter(bs,1427846550,1427846700);
+  bgpstream_add_interval_filter(bs, 1427846550, 1427846700);
 
   /* Start bgpstream */
-  if(bgpstream_start(bs) < 0) {
+  if (bgpstream_start(bs) < 0) {
     fprintf(stderr, "ERROR: Could not init BGPStream\n");
     return -1;
   }
@@ -89,19 +85,16 @@ main()
   bgpstream_elem_t *bs_elem = NULL;
 
   /* Read the stream of records */
-  do
-    {
-      /* get next record */
-      get_next_ret = bgpstream_get_next_record(bs, bs_record);
-      if(get_next_ret && bs_record->status == BGPSTREAM_RECORD_STATUS_VALID_RECORD)
-        {
-          while((bs_elem = bgpstream_record_get_next_elem (bs_record)) != NULL)
-            {
-              elem_counter++;
-            }
-        }
+  do {
+    /* get next record */
+    get_next_ret = bgpstream_get_next_record(bs, bs_record);
+    if (get_next_ret &&
+        bs_record->status == BGPSTREAM_RECORD_STATUS_VALID_RECORD) {
+      while ((bs_elem = bgpstream_record_get_next_elem(bs_record)) != NULL) {
+        elem_counter++;
+      }
     }
-  while(get_next_ret > 0);
+  } while (get_next_ret > 0);
 
   printf("\tRead %d elems\n", elem_counter);
 
@@ -111,7 +104,5 @@ main()
   /* de-allocate memory for the bgpstream record */
   bgpstream_record_destroy(bs_record);
 
-  
   return 0;
 }
-

--- a/tools/bgpreader.c
+++ b/tools/bgpreader.c
@@ -23,45 +23,49 @@
 
 #include "config.h"
 
+#include <assert.h>
+#include <ctype.h>
+#include <inttypes.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <ctype.h>
-#include <stdlib.h>
 #include <unistd.h>
-#include <assert.h>
-#include <inttypes.h>
 #include <unistd.h>
 
 #include "bgpstream.h"
 
 #define PROJECT_CMD_CNT 10
-#define TYPE_CMD_CNT    10
+#define TYPE_CMD_CNT 10
 #define COLLECTOR_CMD_CNT 100
 #define PREFIX_CMD_CNT 1000
 #define COMMUNITY_CMD_CNT 1000
 #define PEERASN_CMD_CNT 1000
 #define WINDOW_CMD_CNT 1024
 #define OPTION_CMD_CNT 1024
-#define BGPSTREAM_RECORD_OUTPUT_FORMAT \
-  "# Record format:\n" \
-  "# <dump-type>|<dump-pos>|<project>|<collector>|<status>|<dump-time>\n" \
-  "#\n" \
-  "# <dump-type>: R RIB, U Update\n" \
-  "# <dump-pos>:  B begin, M middle, E end\n" \
-  "# <status>:    V valid, E empty, F filtered, R corrupted record, S corrupted source\n" \
+#define BGPSTREAM_RECORD_OUTPUT_FORMAT                                         \
+  "# Record format:\n"                                                         \
+  "# <dump-type>|<dump-pos>|<project>|<collector>|<status>|<dump-time>\n"      \
+  "#\n"                                                                        \
+  "# <dump-type>: R RIB, U Update\n"                                           \
+  "# <dump-pos>:  B begin, M middle, E end\n"                                  \
+  "# <status>:    V valid, E empty, F filtered, R corrupted record, S "        \
+  "corrupted source\n"                                                         \
   "#\n"
-#define BGPSTREAM_ELEM_OUTPUT_FORMAT \
-  "# Elem format:\n" \
-  "# <dump-type>|<elem-type>|<record-ts>|<project>|<collector>|<peer-ASN>|<peer-IP>|<prefix>|<next-hop-IP>|<AS-path>|<origin-AS>|<communities>|<old-state>|<new-state>\n" \
-  "#\n" \
-  "# <dump-type>: R RIB, U Update\n" \
-  "# <elem-type>: R RIB, A announcement, W withdrawal, S state message\n" \
-  "#\n" \
-  "# RIB control messages (signal Begin and End of RIB):\n" \
-  "# <dump-type>|<dump-pos>|<record-ts>|<project>|<collector>\n" \
-  "#\n" \
-  "# <dump-pos>:  B begin, E end\n" \
+#define BGPSTREAM_ELEM_OUTPUT_FORMAT                                           \
+  "# Elem format:\n"                                                           \
+  "# "                                                                         \
+  "<dump-type>|<elem-type>|<record-ts>|<project>|<collector>|<peer-ASN>|<"     \
+  "peer-IP>|<prefix>|<next-hop-IP>|<AS-path>|<origin-AS>|<communities>|<old-"  \
+  "state>|<new-state>\n"                                                       \
+  "#\n"                                                                        \
+  "# <dump-type>: R RIB, U Update\n"                                           \
+  "# <elem-type>: R RIB, A announcement, W withdrawal, S state message\n"      \
+  "#\n"                                                                        \
+  "# RIB control messages (signal Begin and End of RIB):\n"                    \
+  "# <dump-type>|<dump-pos>|<record-ts>|<project>|<collector>\n"               \
+  "#\n"                                                                        \
+  "# <dump-pos>:  B begin, E end\n"                                            \
   "#\n"
 
 struct window {
@@ -74,8 +78,8 @@ static bgpstream_data_interface_id_t datasource_id_default = 0;
 static bgpstream_data_interface_id_t datasource_id = 0;
 static bgpstream_data_interface_info_t *datasource_info = NULL;
 
-
-static void data_if_usage() {
+static void data_if_usage()
+{
   bgpstream_data_interface_id_t *ids = NULL;
   int id_cnt = 0;
   int i;
@@ -84,20 +88,18 @@ static void data_if_usage() {
 
   id_cnt = bgpstream_get_data_interfaces(bs, &ids);
 
-  for(i=0; i<id_cnt; i++)
-    {
-      info = bgpstream_get_data_interface_info(bs, ids[i]);
+  for (i = 0; i < id_cnt; i++) {
+    info = bgpstream_get_data_interface_info(bs, ids[i]);
 
-      if(info != NULL)
-        {
-          fprintf(stderr,
-                  "       %-15s%s%s\n", info->name, info->description,
-                  (ids[i] == datasource_id_default) ? " (default)" : "");
-        }
+    if (info != NULL) {
+      fprintf(stderr, "       %-15s%s%s\n", info->name, info->description,
+              (ids[i] == datasource_id_default) ? " (default)" : "");
     }
+  }
 }
 
-static void dump_if_options() {
+static void dump_if_options()
+{
   assert(datasource_id != 0);
 
   bgpstream_data_interface_option_t *options;
@@ -107,55 +109,62 @@ static void dump_if_options() {
   opt_cnt = bgpstream_get_data_interface_options(bs, datasource_id, &options);
 
   fprintf(stderr, "Data interface options for '%s':\n", datasource_info->name);
-  if(opt_cnt == 0)
-    {
-      fprintf(stderr, "   [NONE]\n");
+  if (opt_cnt == 0) {
+    fprintf(stderr, "   [NONE]\n");
+  } else {
+    for (i = 0; i < opt_cnt; i++) {
+      fprintf(stderr, "   %-15s%s\n", options[i].name, options[i].description);
     }
-  else
-    {
-      for(i=0; i<opt_cnt; i++)
-        {
-          fprintf(stderr, "   %-15s%s\n",
-                  options[i].name, options[i].description);
-        }
-    }
+  }
   fprintf(stderr, "\n");
 }
 
-static void usage() {
-  fprintf(stderr,
-	  "usage: bgpreader -w <start>[,<end>] [<options>]\n"
-          "Available options are:\n"
-          "   -d <interface> use the given data interface to find available data\n"
-          "                  available data interfaces are:\n");
+static void usage()
+{
+  fprintf(
+    stderr,
+    "usage: bgpreader -w <start>[,<end>] [<options>]\n"
+    "Available options are:\n"
+    "   -d <interface> use the given data interface to find available data\n"
+    "                  available data interfaces are:\n");
   data_if_usage();
-  fprintf(stderr,
-          "   -o <option-name,option-value>*\n"
-          "                  set an option for the current data interface.\n"
-          "                  use '-o ?' to get a list of available options for the current\n"
-          "                  data interface. (data interface can be selected using -d)\n"
-	  "   -p <project>   process records from only the given project (routeviews, ris)*\n"
-	  "   -c <collector> process records from only the given collector*\n"
-	  "   -t <type>      process records with only the given type (ribs, updates)*\n"
-          "   -w <start>[,<end>]\n"
-          "                  process records within the given time window\n"
-          "                    (omitting the end parameter enables live mode)*\n"
-          "   -P <period>    process a rib files every <period> seconds (bgp time)\n"
-          "   -j <peer ASN>  return valid elems originated by a specific peer ASN*\n"
-          "   -k <prefix>    return valid elems associated with a specific prefix*\n"
-          "   -y <community> return valid elems with the specified community* \n"
-          "                  (format: asn:value, the '*' metacharacter is recognized)\n"
-	  "   -l             enable live mode (make blocking requests for BGP records)\n"
-	  "                  allows bgpstream to be used to process data in real-time\n"
-          "\n"
-          "   -e             print info for each element of a valid BGP record (default)\n"
-          "   -m             print info for each BGP valid record in bgpdump -m format\n"
-          "   -r             print info for each BGP record (used mostly for debugging BGPStream)\n"
-          "   -i             print format information before output\n"
-          "\n"
-	  "   -h             print this help menu\n"
-	  "* denotes an option that can be given multiple times\n"
-	  );
+  fprintf(
+    stderr,
+    "   -o <option-name,option-value>*\n"
+    "                  set an option for the current data interface.\n"
+    "                  use '-o ?' to get a list of available options for the "
+    "current\n"
+    "                  data interface. (data interface can be selected using "
+    "-d)\n"
+    "   -p <project>   process records from only the given project "
+    "(routeviews, ris)*\n"
+    "   -c <collector> process records from only the given collector*\n"
+    "   -t <type>      process records with only the given type (ribs, "
+    "updates)*\n"
+    "   -w <start>[,<end>]\n"
+    "                  process records within the given time window\n"
+    "                    (omitting the end parameter enables live mode)*\n"
+    "   -P <period>    process a rib files every <period> seconds (bgp time)\n"
+    "   -j <peer ASN>  return valid elems originated by a specific peer ASN*\n"
+    "   -k <prefix>    return valid elems associated with a specific prefix*\n"
+    "   -y <community> return valid elems with the specified community* \n"
+    "                  (format: asn:value, the '*' metacharacter is "
+    "recognized)\n"
+    "   -l             enable live mode (make blocking requests for BGP "
+    "records)\n"
+    "                  allows bgpstream to be used to process data in "
+    "real-time\n"
+    "\n"
+    "   -e             print info for each element of a valid BGP record "
+    "(default)\n"
+    "   -m             print info for each BGP valid record in bgpdump -m "
+    "format\n"
+    "   -r             print info for each BGP record (used mostly for "
+    "debugging BGPStream)\n"
+    "   -i             print format information before output\n"
+    "\n"
+    "   -h             print this help menu\n"
+    "* denotes an option that can be given multiple times\n");
 }
 
 // print / utility functions
@@ -211,7 +220,7 @@ int main(int argc, char *argv[])
 
   /* required to be created before usage is called */
   bs = bgpstream_create();
-  if(!bs) {
+  if (!bs) {
     fprintf(stderr, "ERROR: Could not create BGPStream instance\n");
     return -1;
   }
@@ -221,231 +230,196 @@ int main(int argc, char *argv[])
 
   /* allocate memory for bs_record */
   bgpstream_record_t *bs_record = bgpstream_record_create();
-  if(bs_record == NULL)
-    {
-      fprintf(stderr, "ERROR: Could not create BGPStream record\n");
-      bgpstream_destroy(bs);
-      return -1;
-    }
+  if (bs_record == NULL) {
+    fprintf(stderr, "ERROR: Could not create BGPStream record\n");
+    bgpstream_destroy(bs);
+    return -1;
+  }
 
   while (prevoptind = optind,
-	 (opt = getopt (argc, argv, "d:o:p:c:t:w:j:k:y:P:lrmeivh?")) >= 0)
-    {
-      if (optind == prevoptind + 2 && (optarg == NULL || *optarg == '-') ) {
-        opt = ':';
-        -- optind;
+         (opt = getopt(argc, argv, "d:o:p:c:t:w:j:k:y:P:lrmeivh?")) >= 0) {
+    if (optind == prevoptind + 2 && (optarg == NULL || *optarg == '-')) {
+      opt = ':';
+      --optind;
+    }
+    switch (opt) {
+    case 'p':
+      if (projects_cnt == PROJECT_CMD_CNT) {
+        fprintf(stderr, "ERROR: A maximum of %d projects can be specified on "
+                        "the command line\n",
+                PROJECT_CMD_CNT);
+        usage();
+        exit(-1);
       }
-      switch (opt)
-	{
-	case 'p':
-	  if(projects_cnt == PROJECT_CMD_CNT)
-	    {
-	      fprintf(stderr,
-		      "ERROR: A maximum of %d projects can be specified on "
-		      "the command line\n",
-		      PROJECT_CMD_CNT);
-	      usage();
-	      exit(-1);
-	    }
-	  projects[projects_cnt++] = strdup(optarg);
-	  break;
-	case 'c':
-	  if(collectors_cnt == COLLECTOR_CMD_CNT)
-	    {
-	      fprintf(stderr,
-		      "ERROR: A maximum of %d collectors can be specified on "
-		      "the command line\n",
-		      COLLECTOR_CMD_CNT);
-	      usage();
-	      exit(-1);
-	    }
-	  collectors[collectors_cnt++] = strdup(optarg);
-	  break;
-	case 't':
-	  if(types_cnt == TYPE_CMD_CNT)
-	    {
-	      fprintf(stderr,
-		      "ERROR: A maximum of %d types can be specified on "
-		      "the command line\n",
-		      TYPE_CMD_CNT);
-	      usage();
-	      exit(-1);
-	    }
-	  types[types_cnt++] = strdup(optarg);
-	  break;
-	case 'w':
-	  if(windows_cnt == WINDOW_CMD_CNT)
-            {
-              fprintf(stderr,
-                      "ERROR: A maximum of %d windows can be specified on "
-                      "the command line\n",
-                      WINDOW_CMD_CNT);
-              usage();
-              exit(-1);
-            }
-	  /* split the window into a start and end */
-	  if((endp = strchr(optarg, ',')) == NULL)
-	    {
-              windows[windows_cnt].end = BGPSTREAM_FOREVER;
-	    }
-          else
-            {
-              *endp = '\0';
-              endp++;
-              windows[windows_cnt].end =  atoi(endp);
-            }
-	  windows[windows_cnt].start = atoi(optarg);
-	  windows_cnt++;
-	  break;
-        case 'j':
-	  if(peerasns_cnt == PEERASN_CMD_CNT)
-	    {
-	      fprintf(stderr,
-		      "ERROR: A maximum of %d peer asns can be specified on "
-		      "the command line\n",
-		      PEERASN_CMD_CNT);
-	      usage();
-	      exit(-1);
-	    }
-	  peerasns[peerasns_cnt++] = strdup(optarg);
-	  break;
-        case 'k':
-	  if(prefixes_cnt == PREFIX_CMD_CNT)
-	    {
-	      fprintf(stderr,
-		      "ERROR: A maximum of %d peer asns can be specified on "
-		      "the command line\n",
-		      PREFIX_CMD_CNT);
-	      usage();
-	      exit(-1);
-	    }
-	  prefixes[prefixes_cnt++] = strdup(optarg);
-	  break;
-        case 'y':
-	  if(communities_cnt == COMMUNITY_CMD_CNT)
-	    {
-	      fprintf(stderr,
-		      "ERROR: A maximum of %d communities can be specified on "
-		      "the command line\n",
-		      PREFIX_CMD_CNT);
-	      usage();
-	      exit(-1);
-	    }
-	  communities[communities_cnt++] = strdup(optarg);
-	  break;
-        case 'P':
-          rib_period = atoi(optarg);
-          break;
-	case 'd':
-          if((datasource_id =
-              bgpstream_get_data_interface_id_by_name(bs, optarg)) == 0)
-            {
-              fprintf(stderr, "ERROR: Invalid data interface name '%s'\n",
-                      optarg);
-              usage();
-              exit(-1);
-            }
-          datasource_info =
-            bgpstream_get_data_interface_info(bs, datasource_id);
-	  break;
-        case 'o':
-          if(interface_options_cnt == OPTION_CMD_CNT)
-	    {
-	      fprintf(stderr,
-		      "ERROR: A maximum of %d interface options can be specified\n",
-		      OPTION_CMD_CNT);
-	      usage();
-	      exit(-1);
-	    }
-	  interface_options[interface_options_cnt++] = strdup(optarg);
-          break;
+      projects[projects_cnt++] = strdup(optarg);
+      break;
+    case 'c':
+      if (collectors_cnt == COLLECTOR_CMD_CNT) {
+        fprintf(stderr, "ERROR: A maximum of %d collectors can be specified on "
+                        "the command line\n",
+                COLLECTOR_CMD_CNT);
+        usage();
+        exit(-1);
+      }
+      collectors[collectors_cnt++] = strdup(optarg);
+      break;
+    case 't':
+      if (types_cnt == TYPE_CMD_CNT) {
+        fprintf(stderr, "ERROR: A maximum of %d types can be specified on "
+                        "the command line\n",
+                TYPE_CMD_CNT);
+        usage();
+        exit(-1);
+      }
+      types[types_cnt++] = strdup(optarg);
+      break;
+    case 'w':
+      if (windows_cnt == WINDOW_CMD_CNT) {
+        fprintf(stderr, "ERROR: A maximum of %d windows can be specified on "
+                        "the command line\n",
+                WINDOW_CMD_CNT);
+        usage();
+        exit(-1);
+      }
+      /* split the window into a start and end */
+      if ((endp = strchr(optarg, ',')) == NULL) {
+        windows[windows_cnt].end = BGPSTREAM_FOREVER;
+      } else {
+        *endp = '\0';
+        endp++;
+        windows[windows_cnt].end = atoi(endp);
+      }
+      windows[windows_cnt].start = atoi(optarg);
+      windows_cnt++;
+      break;
+    case 'j':
+      if (peerasns_cnt == PEERASN_CMD_CNT) {
+        fprintf(stderr, "ERROR: A maximum of %d peer asns can be specified on "
+                        "the command line\n",
+                PEERASN_CMD_CNT);
+        usage();
+        exit(-1);
+      }
+      peerasns[peerasns_cnt++] = strdup(optarg);
+      break;
+    case 'k':
+      if (prefixes_cnt == PREFIX_CMD_CNT) {
+        fprintf(stderr, "ERROR: A maximum of %d peer asns can be specified on "
+                        "the command line\n",
+                PREFIX_CMD_CNT);
+        usage();
+        exit(-1);
+      }
+      prefixes[prefixes_cnt++] = strdup(optarg);
+      break;
+    case 'y':
+      if (communities_cnt == COMMUNITY_CMD_CNT) {
+        fprintf(stderr,
+                "ERROR: A maximum of %d communities can be specified on "
+                "the command line\n",
+                PREFIX_CMD_CNT);
+        usage();
+        exit(-1);
+      }
+      communities[communities_cnt++] = strdup(optarg);
+      break;
+    case 'P':
+      rib_period = atoi(optarg);
+      break;
+    case 'd':
+      if ((datasource_id =
+             bgpstream_get_data_interface_id_by_name(bs, optarg)) == 0) {
+        fprintf(stderr, "ERROR: Invalid data interface name '%s'\n", optarg);
+        usage();
+        exit(-1);
+      }
+      datasource_info = bgpstream_get_data_interface_info(bs, datasource_id);
+      break;
+    case 'o':
+      if (interface_options_cnt == OPTION_CMD_CNT) {
+        fprintf(stderr,
+                "ERROR: A maximum of %d interface options can be specified\n",
+                OPTION_CMD_CNT);
+        usage();
+        exit(-1);
+      }
+      interface_options[interface_options_cnt++] = strdup(optarg);
+      break;
 
-	case 'l':
-	  live = 1;
-	  break;
-	case 'r':
-	  record_output_on = 1;
-	  break;
-	case 'm':
-	  record_bgpdump_output_on = 1;
-	  break;
-	case 'e':
-	  elem_output_on = 1;
-	  break;
-        case 'i':
-	  output_info = 1;
-	  break;
-	case ':':
-	  fprintf(stderr, "ERROR: Missing option argument for -%c\n", optopt);
-	  usage();
-	  exit(-1);
-	  break;
-	case '?':
-	case 'v':
-	  fprintf(stderr, "bgpreader version %d.%d.%d\n",
-		  BGPSTREAM_MAJOR_VERSION,
-		  BGPSTREAM_MID_VERSION,
-		  BGPSTREAM_MINOR_VERSION);
-	  usage();
-	  exit(0);
-	  break;
-	default:
-	  usage();
-	  exit(-1);
-	}
-    }
-
-  for(i=0; i<interface_options_cnt; i++)
-    {
-      if(*interface_options[i] == '?')
-        {
-          dump_if_options();
-          usage();
-          exit(0);
-        }
-      else
-        {
-          /* actually set this option */
-          if((endp = strchr(interface_options[i], ',')) == NULL)
-            {
-              fprintf(stderr,
-                      "ERROR: Malformed data interface option (%s)\n",
-                      interface_options[i]);
-              fprintf(stderr,
-                      "ERROR: Expecting <option-name>,<option-value>\n");
-              usage();
-              exit(-1);
-            }
-          *endp = '\0';
-          endp++;
-          if((option =
-              bgpstream_get_data_interface_option_by_name(bs, datasource_id,
-                                                          interface_options[i])) == NULL)
-            {
-              fprintf(stderr,
-                      "ERROR: Invalid option '%s' for data interface '%s'\n",
-                      interface_options[i], datasource_info->name);
-              usage();
-              exit(-1);
-            }
-          bgpstream_set_data_interface_option(bs, option, endp);
-        }
-      free(interface_options[i]);
-      interface_options[i] = NULL;
-    }
-  interface_options_cnt = 0;
-
-  if(windows_cnt == 0)
-    {
-      fprintf(stderr,
-              "ERROR: At least one time window must be specified using -w\n");
+    case 'l':
+      live = 1;
+      break;
+    case 'r':
+      record_output_on = 1;
+      break;
+    case 'm':
+      record_bgpdump_output_on = 1;
+      break;
+    case 'e':
+      elem_output_on = 1;
+      break;
+    case 'i':
+      output_info = 1;
+      break;
+    case ':':
+      fprintf(stderr, "ERROR: Missing option argument for -%c\n", optopt);
+      usage();
+      exit(-1);
+      break;
+    case '?':
+    case 'v':
+      fprintf(stderr, "bgpreader version %d.%d.%d\n", BGPSTREAM_MAJOR_VERSION,
+              BGPSTREAM_MID_VERSION, BGPSTREAM_MINOR_VERSION);
+      usage();
+      exit(0);
+      break;
+    default:
       usage();
       exit(-1);
     }
+  }
+
+  for (i = 0; i < interface_options_cnt; i++) {
+    if (*interface_options[i] == '?') {
+      dump_if_options();
+      usage();
+      exit(0);
+    } else {
+      /* actually set this option */
+      if ((endp = strchr(interface_options[i], ',')) == NULL) {
+        fprintf(stderr, "ERROR: Malformed data interface option (%s)\n",
+                interface_options[i]);
+        fprintf(stderr, "ERROR: Expecting <option-name>,<option-value>\n");
+        usage();
+        exit(-1);
+      }
+      *endp = '\0';
+      endp++;
+      if ((option = bgpstream_get_data_interface_option_by_name(
+             bs, datasource_id, interface_options[i])) == NULL) {
+        fprintf(stderr, "ERROR: Invalid option '%s' for data interface '%s'\n",
+                interface_options[i], datasource_info->name);
+        usage();
+        exit(-1);
+      }
+      bgpstream_set_data_interface_option(bs, option, endp);
+    }
+    free(interface_options[i]);
+    interface_options[i] = NULL;
+  }
+  interface_options_cnt = 0;
+
+  if (windows_cnt == 0) {
+    fprintf(stderr,
+            "ERROR: At least one time window must be specified using -w\n");
+    usage();
+    exit(-1);
+  }
 
   /* if the user did not specify any output format
    * then the default one is per elem */
-  if(record_output_on == 0 && elem_output_on == 0 && record_bgpdump_output_on == 0) {
+  if (record_output_on == 0 && elem_output_on == 0 &&
+      record_bgpdump_output_on == 0) {
     elem_output_on = 1;
   }
 
@@ -454,133 +428,111 @@ int main(int argc, char *argv[])
   /* allocate memory for interface */
 
   /* projects */
-  for(i=0; i<projects_cnt; i++)
-    {
-      bgpstream_add_filter(bs, BGPSTREAM_FILTER_TYPE_PROJECT, projects[i]);
-      free(projects[i]);
-    }
+  for (i = 0; i < projects_cnt; i++) {
+    bgpstream_add_filter(bs, BGPSTREAM_FILTER_TYPE_PROJECT, projects[i]);
+    free(projects[i]);
+  }
 
   /* collectors */
-  for(i=0; i<collectors_cnt; i++)
-    {
-      bgpstream_add_filter(bs, BGPSTREAM_FILTER_TYPE_COLLECTOR, collectors[i]);
-      free(collectors[i]);
-    }
+  for (i = 0; i < collectors_cnt; i++) {
+    bgpstream_add_filter(bs, BGPSTREAM_FILTER_TYPE_COLLECTOR, collectors[i]);
+    free(collectors[i]);
+  }
 
   /* types */
-  for(i=0; i<types_cnt; i++)
-    {
-      bgpstream_add_filter(bs, BGPSTREAM_FILTER_TYPE_RECORD_TYPE, types[i]);
-      free(types[i]);
-    }
+  for (i = 0; i < types_cnt; i++) {
+    bgpstream_add_filter(bs, BGPSTREAM_FILTER_TYPE_RECORD_TYPE, types[i]);
+    free(types[i]);
+  }
 
   /* windows */
-  for(i=0; i<windows_cnt; i++)
-    {
-      bgpstream_add_interval_filter(bs, windows[i].start, windows[i].end);
-    }
+  for (i = 0; i < windows_cnt; i++) {
+    bgpstream_add_interval_filter(bs, windows[i].start, windows[i].end);
+  }
 
   /* peer asns */
-  for(i=0; i<peerasns_cnt; i++)
-    {
-      bgpstream_add_filter(bs, BGPSTREAM_FILTER_TYPE_ELEM_PEER_ASN, peerasns[i]);
-      free(peerasns[i]);
-    }
+  for (i = 0; i < peerasns_cnt; i++) {
+    bgpstream_add_filter(bs, BGPSTREAM_FILTER_TYPE_ELEM_PEER_ASN, peerasns[i]);
+    free(peerasns[i]);
+  }
 
   /* prefixes */
-  for(i=0; i<prefixes_cnt; i++)
-    {
-      bgpstream_add_filter(bs, BGPSTREAM_FILTER_TYPE_ELEM_PREFIX, prefixes[i]);
-      free(prefixes[i]);
-    }
+  for (i = 0; i < prefixes_cnt; i++) {
+    bgpstream_add_filter(bs, BGPSTREAM_FILTER_TYPE_ELEM_PREFIX, prefixes[i]);
+    free(prefixes[i]);
+  }
 
   /* communities */
-  for(i=0; i<communities_cnt; i++)
-    {
-      bgpstream_add_filter(bs, BGPSTREAM_FILTER_TYPE_ELEM_COMMUNITY, communities[i]);
-      free(communities[i]);
-    }
+  for (i = 0; i < communities_cnt; i++) {
+    bgpstream_add_filter(bs, BGPSTREAM_FILTER_TYPE_ELEM_COMMUNITY,
+                         communities[i]);
+    free(communities[i]);
+  }
 
   /* frequencies */
-  if(rib_period > 0)
-    {
-      bgpstream_add_rib_period_filter(bs, rib_period);
-    }
+  if (rib_period > 0) {
+    bgpstream_add_rib_period_filter(bs, rib_period);
+  }
 
   /* datasource */
   bgpstream_set_data_interface(bs, datasource_id);
 
   /* live */
-  if(live != 0)
-    {
-      bgpstream_set_live_mode(bs);
-    }
+  if (live != 0) {
+    bgpstream_set_live_mode(bs);
+  }
 
   /* turn on interface */
-  if(bgpstream_start(bs) < 0) {
+  if (bgpstream_start(bs) < 0) {
     fprintf(stderr, "ERROR: Could not init BGPStream\n");
     return -1;
   }
 
-  if(output_info)
-    {
-      if(record_output_on)
-        {
-          printf(BGPSTREAM_RECORD_OUTPUT_FORMAT);
-        }
-      if(elem_output_on)
-        {
-          printf(BGPSTREAM_ELEM_OUTPUT_FORMAT);
-        }
+  if (output_info) {
+    if (record_output_on) {
+      printf(BGPSTREAM_RECORD_OUTPUT_FORMAT);
     }
+    if (elem_output_on) {
+      printf(BGPSTREAM_ELEM_OUTPUT_FORMAT);
+    }
+  }
 
   /* use the interface */
   int get_next_ret = 0;
-  bgpstream_elem_t * bs_elem;
-  do
-    {
-      get_next_ret = bgpstream_get_next_record(bs, bs_record);
-      if(get_next_ret && record_output_on)
-	{
-	  print_bs_record(bs_record);
-	}
-      if(get_next_ret && bs_record->status == BGPSTREAM_RECORD_STATUS_VALID_RECORD)
-	{
-	  if(record_bgpdump_output_on)
-	    {
-	      bgpstream_record_print_mrt_data(bs_record);
-	    }
-	  if(elem_output_on)
-	    {
-              /* check if the record is of type RIB, in case extract the ID */
-              if(bs_record->attributes.dump_type == BGPSTREAM_RIB)
-                {
+  bgpstream_elem_t *bs_elem;
+  do {
+    get_next_ret = bgpstream_get_next_record(bs, bs_record);
+    if (get_next_ret && record_output_on) {
+      print_bs_record(bs_record);
+    }
+    if (get_next_ret &&
+        bs_record->status == BGPSTREAM_RECORD_STATUS_VALID_RECORD) {
+      if (record_bgpdump_output_on) {
+        bgpstream_record_print_mrt_data(bs_record);
+      }
+      if (elem_output_on) {
+        /* check if the record is of type RIB, in case extract the ID */
+        if (bs_record->attributes.dump_type == BGPSTREAM_RIB) {
 
-                  /* print the RIB start line */
-                  if(bs_record->dump_pos == BGPSTREAM_DUMP_START)
-                    {
-                      print_rib_control_message(bs_record);
-                    }
-                }
+          /* print the RIB start line */
+          if (bs_record->dump_pos == BGPSTREAM_DUMP_START) {
+            print_rib_control_message(bs_record);
+          }
+        }
 
-	      while((bs_elem =
-                     bgpstream_record_get_next_elem(bs_record)) != NULL)
-		{
-		  if(print_elem(bs_record, bs_elem) != 0)
-                    {
-                      goto err;
-                    }
-		}
-              /* check if end of RIB has been reached */
-              if(bs_record->attributes.dump_type == BGPSTREAM_RIB &&
-                 bs_record->dump_pos == BGPSTREAM_DUMP_END)
-                {
-                  print_rib_control_message(bs_record);
-                }
-	    }
-	}
-  }
-  while(get_next_ret > 0);
+        while ((bs_elem = bgpstream_record_get_next_elem(bs_record)) != NULL) {
+          if (print_elem(bs_record, bs_elem) != 0) {
+            goto err;
+          }
+        }
+        /* check if end of RIB has been reached */
+        if (bs_record->attributes.dump_type == BGPSTREAM_RIB &&
+            bs_record->dump_pos == BGPSTREAM_DUMP_END) {
+          print_rib_control_message(bs_record);
+        }
+      }
+    }
+  } while (get_next_ret > 0);
 
   /* de-allocate memory for bs_record */
   bgpstream_record_destroy(bs_record);
@@ -593,14 +545,12 @@ int main(int argc, char *argv[])
 
   return 0;
 
- err:
+err:
   bgpstream_record_destroy(bs_record);
   bgpstream_stop(bs);
   bgpstream_destroy(bs);
   return -1;
 }
-
-
 
 /* print utility functions */
 
@@ -611,112 +561,99 @@ static void print_bs_record(bgpstream_record_t *bs_record)
   assert(bs_record);
 
   size_t written = 0; /* < how many bytes we wanted to write */
-  ssize_t c = 0; /* < how many chars were written */
+  ssize_t c = 0;      /* < how many chars were written */
   char *buf_p = record_buf;
   int len = 65536;
 
   /* record type */
-  if((c =
-      bgpstream_record_dump_type_snprintf(buf_p, len-written,
-                                          bs_record->attributes.dump_type)) < 0)
-    {
-      return;
-    }
+  if ((c = bgpstream_record_dump_type_snprintf(
+         buf_p, len - written, bs_record->attributes.dump_type)) < 0) {
+    return;
+  }
   written += c;
   buf_p += c;
 
-  c = snprintf(buf_p, len-written, "|");
+  c = snprintf(buf_p, len - written, "|");
   written += c;
   buf_p += c;
 
   /* record position */
-  if((c = bgpstream_record_dump_pos_snprintf(buf_p, len-written,
-                                             bs_record->dump_pos)) < 0)
-    {
-      return;
-    }
+  if ((c = bgpstream_record_dump_pos_snprintf(buf_p, len - written,
+                                              bs_record->dump_pos)) < 0) {
+    return;
+  }
   written += c;
   buf_p += c;
 
   /* Record timestamp, project, collector */
-  c = snprintf(buf_p, len-written, "|%ld|%s|%s|",
-               bs_record->attributes.record_time,
-               bs_record->attributes.dump_project,
-               bs_record->attributes.dump_collector);
+  c = snprintf(
+    buf_p, len - written, "|%ld|%s|%s|", bs_record->attributes.record_time,
+    bs_record->attributes.dump_project, bs_record->attributes.dump_collector);
   written += c;
   buf_p += c;
 
   /* record status */
-  if((c = bgpstream_record_status_snprintf(buf_p, len-written, bs_record->status)) < 0)
-    {
-      return;
-    }
+  if ((c = bgpstream_record_status_snprintf(buf_p, len - written,
+                                            bs_record->status)) < 0) {
+    return;
+  }
   written += c;
   buf_p += c;
 
   /* dump time */
-  c = snprintf(buf_p, len-written, "|%ld",
-               bs_record->attributes.dump_time);
+  c = snprintf(buf_p, len - written, "|%ld", bs_record->attributes.dump_time);
   written += c;
   buf_p += c;
 
-  if(written >= len)
-    {
-      return;
-    }
+  if (written >= len) {
+    return;
+  }
 
   printf("%s\n", record_buf);
 }
-
 
 static void print_rib_control_message(bgpstream_record_t *bs_record)
 {
   assert(bs_record);
 
   size_t written = 0; /* < how many bytes we wanted to write */
-  ssize_t c = 0; /* < how many chars were written */
+  ssize_t c = 0;      /* < how many chars were written */
   char *buf_p = record_buf;
   int len = 65536;
 
   /* record type */
-  if((c =
-      bgpstream_record_dump_type_snprintf(buf_p, len-written,
-                                              bs_record->attributes.dump_type)) < 0)
-    {
-      return;
-    }
+  if ((c = bgpstream_record_dump_type_snprintf(
+         buf_p, len - written, bs_record->attributes.dump_type)) < 0) {
+    return;
+  }
   written += c;
   buf_p += c;
 
-  c = snprintf(buf_p, len-written, "|");
+  c = snprintf(buf_p, len - written, "|");
   written += c;
   buf_p += c;
 
   /* record position */
-  if((c = bgpstream_record_dump_pos_snprintf(buf_p, len-written,
-                                             bs_record->dump_pos)) < 0)
-    {
-      return;
-    }
+  if ((c = bgpstream_record_dump_pos_snprintf(buf_p, len - written,
+                                              bs_record->dump_pos)) < 0) {
+    return;
+  }
   written += c;
   buf_p += c;
 
   /* Record timestamp, project, collector */
-  c = snprintf(buf_p, len-written, "|%ld|%s|%s",
-               bs_record->attributes.record_time,
-               bs_record->attributes.dump_project,
-               bs_record->attributes.dump_collector);
+  c = snprintf(
+    buf_p, len - written, "|%ld|%s|%s", bs_record->attributes.record_time,
+    bs_record->attributes.dump_project, bs_record->attributes.dump_collector);
   written += c;
   buf_p += c;
 
-  if(written >= len)
-    {
-      return;
-    }
+  if (written >= len) {
+    return;
+  }
 
   printf("%s\n", record_buf);
 }
-
 
 static char elem_buf[65536];
 static int print_elem(bgpstream_record_t *bs_record, bgpstream_elem_t *elem)
@@ -725,12 +662,10 @@ static int print_elem(bgpstream_record_t *bs_record, bgpstream_elem_t *elem)
   assert(elem);
   int len = 65536;
 
-  if(bgpstream_record_elem_snprintf(elem_buf, len, bs_record, elem) != NULL)
-    {
-      printf("%s\n", elem_buf);
-      return 0;
-    }
+  if (bgpstream_record_elem_snprintf(elem_buf, len, bs_record, elem) != NULL) {
+    printf("%s\n", elem_buf);
+    return 0;
+  }
 
   return -1;
 }
-


### PR DESCRIPTION
As noted in Issue #24, we were in need of a consistent code style throughout the project.

This adds a [clang-format](http://clang.llvm.org/docs/ClangFormat.html) configuration file (`.clang-format`) and a `format` make target to automatically reformat all code. It also re-formats all existing code to match this style.

The style that I have adopted is very similar to the [LLVM style](http://llvm.org/docs/CodingStandards.html), but see the `.clang-format` file added by this PR for definitive information.

I'm also happy to hear arguments for changing a specific aspect of the style.