### PR TITLE
Fix broken PyBGPStream includes

### DIFF
--- a/pybgpstream/src/_pybgpstream_bgpelem.c
+++ b/pybgpstream/src/_pybgpstream_bgpelem.c
@@ -23,9 +23,7 @@
 
 #include "pyutils.h"
 #include <Python.h>
-
 #include <bgpstream.h>
-
 #include "_pybgpstream_bgpelem.h"
 
 #define BGPElemDocstring "BGPElem object"

--- a/pybgpstream/src/_pybgpstream_bgpelem.h
+++ b/pybgpstream/src/_pybgpstream_bgpelem.h
@@ -24,9 +24,8 @@
 #ifndef ___PYBGPSTREAM_BGPELEM_H
 #define ___PYBGPSTREAM_BGPELEM_H
 
+#include "bgpstream_elem.h"
 #include <Python.h>
-
-#include <bgpstream_utils.h>
 
 typedef struct {
   PyObject_HEAD

--- a/pybgpstream/src/_pybgpstream_bgprecord.c
+++ b/pybgpstream/src/_pybgpstream_bgprecord.c
@@ -23,9 +23,7 @@
 
 #include "pyutils.h"
 #include <Python.h>
-
 #include <bgpstream.h>
-
 #include "_pybgpstream_bgpelem.h"
 #include "_pybgpstream_bgprecord.h"
 

--- a/pybgpstream/src/_pybgpstream_bgprecord.h
+++ b/pybgpstream/src/_pybgpstream_bgprecord.h
@@ -24,9 +24,8 @@
 #ifndef ___PYBGPSTREAM_BGPRECORD_H
 #define ___PYBGPSTREAM_BGPRECORD_H
 
+#include "bgpstream.h"
 #include <Python.h>
-
-#include <bgpstream.h>
 
 typedef struct {
   PyObject_HEAD

--- a/pybgpstream/src/_pybgpstream_bgpstream.c
+++ b/pybgpstream/src/_pybgpstream_bgpstream.c
@@ -22,9 +22,7 @@
  */
 #include "pyutils.h"
 #include <Python.h>
-
 #include <bgpstream.h>
-
 #include "_pybgpstream_bgprecord.h"
 
 typedef struct {

--- a/pybgpstream/src/_pybgpstream_bgpstream.h
+++ b/pybgpstream/src/_pybgpstream_bgpstream.h
@@ -21,10 +21,10 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Python.h>
-
 #ifndef ___PYBGPSTREAM_BGPSTREAM_H
 #define ___PYBGPSTREAM_BGPSTREAM_H
+
+#include <Python.h>
 
 /** Expose the BGPStreamType structure */
 PyTypeObject *_pybgpstream_bgpstream_get_BGPStreamType(void);

--- a/pybgpstream/src/_pybgpstream_module.c
+++ b/pybgpstream/src/_pybgpstream_module.c
@@ -22,7 +22,6 @@
  */
 
 #include <Python.h>
-
 #include "_pybgpstream_bgpelem.h"
 #include "_pybgpstream_bgprecord.h"
 #include "_pybgpstream_bgpstream.h"

--- a/pybgpstream/src/pyutils.h
+++ b/pybgpstream/src/pyutils.h
@@ -1,5 +1,30 @@
+/*
+ * This file is part of bgpstream
+ *
+ * CAIDA, UC San Diego
+ * bgpstream-info@caida.org
+ *
+ * Copyright (C) 2012 The Regents of the University of California.
+ * Authors: Alistair King, Chiara Orsini
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef ___PYUTILS_H
 #define ___PYUTILS_H
+
+#include <Python.h>
 
 #ifndef PyVarObject_HEAD_INIT
 #define PyVarObject_HEAD_INIT(type, size) PyObject_HEAD_INIT(type) size,


### PR DESCRIPTION
Forgot to ensure pybgpstream still compiled after reformatting code.

Also adds missing copyright header to `pyutils.h`