### PR TITLE
No longer require time interval to be set

### DIFF
--- a/lib/bgpstream.h
+++ b/lib/bgpstream.h
@@ -179,8 +179,10 @@ void bgpstream_add_rib_period_filter(bgpstream_t *bs, uint32_t period);
  * @param begin_time    the first time that will match the filter (inclusive)
  * @param end_time      the last time that will match the filter (inclusive)
  *
- * If end_time is set to BGPSTREAM_FOREVER, the stream will be set to live mode,
- * and will process data forever.
+ * If end_time is set to BGPSTREAM_FOREVER (0), the stream will be set to live
+ * mode, and will process data forever. If no intervals are added, then
+ * BGPStream will default to processing every available record, however, this
+ * will trigger a run-time error if using the Broker data interface.
  */
 void bgpstream_add_interval_filter(bgpstream_t *bs, uint32_t begin_time,
                                    uint32_t end_time);

--- a/tools/bgpreader.c
+++ b/tools/bgpreader.c
@@ -410,10 +410,17 @@ int main(int argc, char *argv[])
   interface_options_cnt = 0;
 
   if (windows_cnt == 0) {
-    fprintf(stderr,
-            "ERROR: At least one time window must be specified using -w\n");
-    usage();
-    exit(-1);
+    if (datasource_id == BGPSTREAM_DATA_INTERFACE_BROKER) {
+      fprintf(stderr,
+              "ERROR: At least one time window must be set when using the "
+              "broker data interface\n");
+      usage();
+      exit(-1);
+    } else {
+      fprintf(stderr,
+              "WARN: No time windows specified, defaulting to all "
+              "available data\n");
+    }
   }
 
   /* if the user did not specify any output format


### PR DESCRIPTION
Now, if a time interval is not set, BGPStream will default to processing all available data. Note however, that the Broker data interface still requires a time interval to be set to prevent users from accidentally requesting tens of TB of data (e.g., by running bgpreader with no arguments).

This fixes Issue #22 