### PR TITLE
Add documentation for the AS Path Segment string format

### DIFF
--- a/lib/utils/bgpstream_utils_as_path.c
+++ b/lib/utils/bgpstream_utils_as_path.c
@@ -109,6 +109,12 @@ seg_set_dup(bgpstream_as_path_seg_set_t *src)
       *bufp = '\0';                                                            \
   } while (0)
 
+/*
+ * WARNING: The output format of this function is documented in both
+ * bgpstream_utils_as_path.h and _pybgpstream_bgpelem.c. Ensure both places are
+ * updated if changing this format (and be very sure that you need to change it
+ * at all since this is a well-known format also used by bgpdump).
+ */
 int bgpstream_as_path_seg_snprintf(char *buf, size_t len,
                                    bgpstream_as_path_seg_t *seg)
 {

--- a/lib/utils/bgpstream_utils_as_path.h
+++ b/lib/utils/bgpstream_utils_as_path.h
@@ -154,6 +154,20 @@ typedef struct bgpstream_as_path_iter {
  * @return the number of characters written given an infinite len (not including
  * the trailing nul). If this value is greater than or equal to len, then the
  * output was truncated.
+ *
+ * String representation format:
+ * - If the segment is a simple ASN (BGPSTREAM_AS_PATH_SEG_ASN), then the string
+ *   will be the decimal representation of the ASN (not dotted-decimal).
+ * - If the segment is an AS Set (BGPSTREAM_AS_PATH_SEG_SET), then the string
+ *   will be a comma-separated list of ASNs, enclosed in braces. E.g.,
+ *   "{12345,6789}".
+ * - If the segment is an AS Confederation Set
+ *   (BGPSTREAM_AS_PATH_SEG_CONFED_SET), then the string will be a
+ *   comma-separated list of ASNs, enclosed in brackets. E.g., "[12345,6789]".
+ * - If the segment is an AS Sequence Set (BGPSTREAM_AS_PATH_SEG_CONFED_SEQ),
+ *   then the string will be a space-separated list of ASNs, enclosed in
+ *   parentheses. E.g., "(12345 6789)".
+ * Note that it is possible to have a set/sequence with only a single element.
  */
 int bgpstream_as_path_seg_snprintf(char *buf, size_t len,
                                    bgpstream_as_path_seg_t *seg);

--- a/pybgpstream/docs/api__pybgpstream.rst
+++ b/pybgpstream/docs/api__pybgpstream.rst
@@ -273,3 +273,24 @@ BGPElem
 	      (basestring)
             - 'new-state': The new state of the peer, shares the same possible
 	      values as old-state. (basestring)
+
+      The 'as-path' field is a string representation of the AS Path, constructed
+      using bgpstream_as_path_snprintf and is a space-separated sequence of AS
+      Path Segments, each constructed using bgpstream_as_path_seg_snprintf. As
+      noted in the libBGPStream API documention, AS Path Segments are converted
+      to strings using the following convention:
+      - If the segment is a simple ASN (BGPSTREAM_AS_PATH_SEG_ASN), then the
+        string will be the decimal representation of the ASN (not
+        dotted-decimal).
+      - If the segment is an AS Set (BGPSTREAM_AS_PATH_SEG_SET), then the string
+        will be a comma-separated list of ASNs, enclosed in braces. E.g.,
+        "{12345,6789}".
+      - If the segment is an AS Confederation Set
+        (BGPSTREAM_AS_PATH_SEG_CONFED_SET), then the string will be a
+        comma-separated list of ASNs, enclosed in brackets. E.g.,
+        "[12345,6789]".
+      - If the segment is an AS Sequence Set (BGPSTREAM_AS_PATH_SEG_CONFED_SEQ),
+        then the string will be a space-separated list of ASNs, enclosed in
+        parentheses. E.g., "(12345 6789)".
+      Note that it is possible to have a set/sequence with only a single
+      element.


### PR DESCRIPTION
Also document the format of the `as-path` field of PyBGPStream's BGPElem.