### PR TITLE
Fixes for bgpdump parser

### DIFF
--- a/lib/bgpdump/bgpdump_lib.c
+++ b/lib/bgpdump/bgpdump_lib.c
@@ -431,7 +431,7 @@ int process_mrtd_table_dump(struct mstream *s, BGPDUMP_ENTRY *entry)
   read_asn(s, &entry->body.mrtd_table_dump.peer_as, asn_len);
 
   if ((entry->attr = process_attributes(s, asn_len, NULL)) == NULL) {
-    return 0;
+    return -1;
   }
 
   return 1;


### PR DESCRIPTION
This improves the ability of the bgpdump parsing sub-library to (more) gracefully recover from invalid data and return an error code rather than simply aborting.

This closes Issue #62 